### PR TITLE
README.rst: Make valid on PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,6 @@ JIRA Python Library
 .. image:: https://pypip.in/wheel/jira/badge.svg?style=flat
         :target: https://pypi.python.org/pypi/jira/
 
-.. |br| raw:: html
 ------------
 
 .. image:: https://api.travis-ci.org/pycontribs/jira.svg?branch=master


### PR DESCRIPTION
PyPI page is rendering description as text rather than reST.

This is because the raw directive is disabled.

I can tell this by doing:

    pip install restview
    restview --pypi-strict README.rst

which outputs: `README.rst:23: (WARNING/2) "raw" directive disabled.`