### PR TITLE
README.rst: Double back quotes, fix links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,9 +54,11 @@ Feeling impatient? I like your style.
 Installation
 ~~~~~~~~~~~~
 
-Download and install using `pip install jira` or `easy_install jira`
+Download and install using ``pip install jira`` or ``easy_install jira``
 
-You can also try `pip install --user --upgrade jira` which will install or upgrade jira to user directory. Or maybe you ARE using a [virtualenv][2], right?
+You can also try ``pip install --user --upgrade jira`` which will install or
+upgrade jira to your user directory. Or maybe you ARE using a virtualenv_
+right?
 
 Usage
 ~~~~~
@@ -73,8 +75,7 @@ In additions to all the contributors we would like to thank to these companies:
 * Travis_ for hosting our continous integration
 * Navicat_ for providing us free licenses of their powerful database client GUI tools.
 
-[1]: http://docs.python-requests.org/
-[2]: http://www.virtualenv.org/en/latest/index.html
+.. _virtualenv: http://www.virtualenv.org/en/latest/index.html
 
 .. image:: https://www.atlassian.com/dms/wac/images/press/Atlassian-logos/logoAtlassianPNG.png
    :width: 100px


### PR DESCRIPTION
- Use double back quotes for monospace font for commands.
- Remove link for `requests`; Use reST syntx for `virtualenv` link.