### PR TITLE
Fix ResourceLeak warning with CPython3

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -203,6 +203,11 @@ class JIRA(object):
             globals()['logging'].error("invalid server_info: %s", si)
             raise e
 
+    def __del__(self):
+        session = getattr(self, "_session", None)
+        if session is not None:
+            session.close()
+
     def _check_for_html_error(self, content):
         # TODO: Make it return errors when content is a webpage with errors
         # JIRA has the bad habbit of returning errors in pages with 200 and


### PR DESCRIPTION
See https://bitbucket.org/bspeakmon/jira-python/issue/140/fix-resourceleak-warning-under-python-3

The fact that you closed that issue does not deny the fact that you do not know that requests.Session-s should be explicitly closed.