### PR TITLE
Incorrect argument order in Resource.find function

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -102,7 +102,7 @@ class Resource(object):
             params = {}
 
         url = self._url(ids)
-        self._load(url, params)
+        self._load(url, params=params)
 
     def update(self, fields=None, async=None, jira=None, **kwargs):
         """


### PR DESCRIPTION
Checkout Resource.find function. At the end it calls load method:
```self._load(url, params)```
But load's second parameter is ```headers```, not ```params```:
```def _load(self, url, headers=CaseInsensitiveDict(), params=None):```