### PR TITLE
Give users ability to disable update check

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -107,6 +107,7 @@ class JIRA(object):
         "resilient": True,
         "async": False,
         "client_cert": None,
+        "check_update": True,
         "headers": {
             'X-Atlassian-Token': 'no-check',
             'Cache-Control': 'no-cache',
@@ -211,7 +212,7 @@ class JIRA(object):
             globals()['logging'].error("invalid server_info: %s", si)
             raise e
 
-        if not JIRA.checked_version:
+        if options['check_update'] and not JIRA.checked_version:
             self._check_update_()
             JIRA.checked_version = True
 


### PR DESCRIPTION
Some of our applications which create JIRA issues are allowed to connect to our JIRA server but not to the internet at large. The recent update check added to this library makes those applications unable to connect to JIRA, because they time out on the update check. Specifically, you get a Urllib2 error like so:

```
  File "/home/app/virtualenv/lib/python2.7/site-packages/jira/client.py", line 224, in _check_update_
    "http://pypi.python.org/pypi/jira/json")
  File "/opt/local/lib/python2.7/urllib2.py", line 127, in urlopen
    return _opener.open(url, data, timeout)
  File "/opt/local/lib/python2.7/urllib2.py", line 404, in open
    response = self._open(req, data)
  File "/opt/local/lib/python2.7/urllib2.py", line 422, in _open
    '_open', req)
  File "/opt/local/lib/python2.7/urllib2.py", line 382, in _call_chain
    result = func(*args)
  File "/opt/local/lib/python2.7/urllib2.py", line 1214, in http_open
    return self.do_open(httplib.HTTPConnection, req)
  File "/opt/local/lib/python2.7/urllib2.py", line 1184, in do_open
    raise URLError(err)
urllib2.URLError: <urlopen error [Errno 145] Connection timed out>
```

This is a simple patch which just disables the update check.