### PR TITLE
Issue add_field_value should use Resource update function

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -332,7 +332,7 @@ class Issue(Resource):
 
         This should work with: labels, multiple checkbox lists, multiple select
         """
-        self.update({"update": {field: [{"add": value}]}})
+        super(Issue, self).update(fields={"update": {field: [{"add": value}]}})
 
     def delete(self, deleteSubtasks=False):
         """


### PR DESCRIPTION
If add_field_value uses self.update, json data like {'field': {'update': ...}} is generated, which is not accepted by the JIRA REST api.