### PR TITLE
Raise an AttributeError if a requested attribute doesn't exist within se...

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -89,6 +89,8 @@ class Resource(object):
         except Exception as e:
             if item in self.raw:
                 return self.raw[item]
+            else:
+                raise AttributeError("%r object has no attribute %r" % (self.__class__, item))
 
     def find(self, id, params=None):
 


### PR DESCRIPTION
...lf or self.raw. This is a bug fix to ensure calls to hasattr return false when the attribute doesn't exist.