### PR TITLE
Add support for pickling Resource instances

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -83,14 +83,21 @@ class Resource(object):
         return '<JIRA %s: %s>' % (self.__class__.__name__, ', '.join(names))
 
     def __getattr__(self, item):
-        # make sure pickling doesn't break
-        if item in ('__getnewargs__',):
-            raise KeyError(item)
-
         # this should make Project.key and similar to work
         try:
             return self[item]
         except Exception as e:
+            # Make sure pickling doesn't break
+            #   *MORE INFO*: This conditional wouldn't be necessary if __getattr__ wasn't used. But
+            #                since it is in use (no worries), we need to give the pickle.dump*
+            #                methods what they expect back. They expect to either get a KeyError
+            #                exception or a tuple of args to be passed to the __new__ method upon
+            #                unpickling (i.e. pickle.load* methods).
+            #   *NOTE*: if the __new__ method were to be implemented in this class, this may have
+            #           to be removed or changed.
+            if item in ('__getnewargs__',):
+                raise KeyError(item)
+
             if item in self.raw:
                 return self.raw[item]
 

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -95,7 +95,7 @@ class Resource(object):
             #                unpickling (i.e. pickle.load* methods).
             #   *NOTE*: if the __new__ method were to be implemented in this class, this may have
             #           to be removed or changed.
-            if item in ('__getnewargs__',):
+            if item == '__getnewargs__':
                 raise KeyError(item)
 
             if item in self.raw:

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -83,12 +83,28 @@ class Resource(object):
         return '<JIRA %s: %s>' % (self.__class__.__name__, ', '.join(names))
 
     def __getattr__(self, item):
+        # make sure pickling doesn't break
+        if item in ('__getnewargs__',):
+            raise KeyError(item)
+
         # this should make Project.key and similar to work
         try:
             return self[item]
         except Exception as e:
             if item in self.raw:
                 return self.raw[item]
+
+    def __getstate__(self):
+        """
+        Pickling the resource; using the raw dict
+        """
+        return self.raw
+
+    def __setstate__(self, raw_pickled):
+        """
+        Unpickling of the resource
+        """
+        self._parse_raw(raw_pickled)
 
     def find(self, id, params=None):
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -11,6 +11,7 @@ import requests
 import string
 import traceback
 import inspect
+import pickle
 from time import sleep
 import py
 
@@ -342,6 +343,14 @@ class UniversalResourceTests(unittest.TestCase):
         self.assertIsNotNone(ex.text)
         self.assertEqual(ex.url,
                          'https://pycontribs.atlassian.net/rest/api/2/woopsydoodle/666')
+
+    def test_pickling_resource(self):
+        resource = self.jira.find('issue/{0}',
+                                  self.test_manager.project_b_issue1)
+
+        pickled = pickle.dumps(resource)
+        unpickled = pickle.loads(pickled)
+        self.assertEqual(resource.key, unpickled.key)
 
 
 class ResourceTests(unittest.TestCase):


### PR DESCRIPTION
This adds support for pickling the resource instances. Handy if, like me, you're interested in caching the results of some queries.