### PR TITLE
#32 applying updating malformed label does not produce exception

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -730,12 +730,28 @@ class IssueTests(unittest.TestCase):
          issue = self.jira.create_issue(project=self.project_b,
                                        summary='Test issue for updating labels', description='Label testing',
                                        issuetype={'name': 'Bug'})
+
+         labelarray = ['testLabel']
          fields = {
-            'labels' : 'testLabel'
+            'labels' : labelarray
          }
 
          issue.update(fields=fields)
-         self.assertEqual(issue.fields.labels,'testLabel')
+         self.assertEqual(issue.fields.labels, ['testLabel'])
+
+    def test_update_with_bad_label(self):
+        issue = self.jira.create_issue(project=self.project_b,
+                                       summary='Test issue for updating labels', description='Label testing',
+                                       issuetype={'name': 'Bug'})
+
+        issue.fields.labels.append('this should not work')
+
+        fields = {
+            'labels': issue.fields.labels
+        }
+
+        self.assertRaises(JIRAError, issue.update, fields=fields)
+
 
     def test_delete(self):
         issue = self.jira.create_issue(project=self.project_b,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -726,6 +726,17 @@ class IssueTests(unittest.TestCase):
         self.assertEqual(issue.fields.priority.name, 'Major')
         issue.delete()
 
+    def test_update_with_label(self):
+         issue = self.jira.create_issue(project=self.project_b,
+                                       summary='Test issue for updating labels', description='Label testing',
+                                       issuetype={'name': 'Bug'})
+         fields = {
+            'labels' : 'testLabel'
+         }
+
+         issue.update(fields=fields)
+         self.assertEqual(issue.fields.labels,'testLabel')
+
     def test_delete(self):
         issue = self.jira.create_issue(project=self.project_b,
                                        summary='Test issue created',


### PR DESCRIPTION
Addressing concerns in #32 , wrote two tests to cover a good label addition and a bad label addition.  