### PR TITLE
Comment: fix typo in comment 'visibility' name

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -391,7 +391,7 @@ class Comment(Resource):
         if body:
             data['body'] = body
         if visibility:
-            data['vissibility'] = visibility
+            data['visibility'] = visibility
         super(Comment, self).update(data)
 
 


### PR DESCRIPTION
Fix a trivial typo in comment unit: 'vissibility' --> 'visibility'.

Signed-off-by: Vladimir Zapolskiy <vz@mleia.com>