### PR TITLE
Fixed mimetype issue with Jira attachment. MultipartEncoder sent attachm...

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -405,7 +405,7 @@ class JIRA(object):
             def file_stream():
                 return MultipartEncoder(
                     fields={
-                        'file': (fname, attachment, 'text/plain')}
+                        'file': (fname, attachment, 'application/octet-stream')}
                 )
             m = file_stream()
             r = self._session.post(


### PR DESCRIPTION
MultipartEncoder did not properly identify file-mimetype, it caused issues with for example pdf-files. After changing 'text/plain' to 'application/octet-stream' fixed the issue. 

Wrong mimetype:
![wrong_mime](https://cloud.githubusercontent.com/assets/6129901/6992981/7fd1b1ac-daee-11e4-8b2f-552af6ad576a.png)

Browser view after clicking pdf-attachment.
![wrong_mime_pdf](https://cloud.githubusercontent.com/assets/6129901/6992985/856b4b5a-daee-11e4-9c09-af3c9b855261.png)

Fixed mimetype:
![fixed_mimetype](https://cloud.githubusercontent.com/assets/6129901/6992987/87b41c66-daee-11e4-80d3-44aa0f4f970b.png)


