### PR TITLE
Fix JIRAError to correctly include full details

### DIFF
--- a/jira/utils.py
+++ b/jira/utils.py
@@ -148,17 +148,17 @@ class JIRAError(Exception):
         if self.url:
             t += "\n\turl: %s" % self.url
 
-        if self.request and hasattr(self.request, 'headers'):
-            t += "\n\trequest headers = " % self.request.headers
+        if self.request is not None and hasattr(self.request, 'headers'):
+            t += "\n\trequest headers = %s" % self.request.headers
 
-        if self.request and hasattr(self.request, 'text'):
-            t += "\n\trequest text = " % self.request.text
+        if self.request is not None and hasattr(self.request, 'text'):
+            t += "\n\trequest text = %s" % self.request.text
 
-        if self.response and hasattr(self.response, 'headers'):
-            t += "\n\tresponse headers = " % self.response.headers
+        if self.response is not None and hasattr(self.response, 'headers'):
+            t += "\n\tresponse headers = %s" % self.response.headers
 
-        if self.response and hasattr(self.response, 'text'):
-            t += "\n\tresponse text = " % self.response.headers
+        if self.response is not None and hasattr(self.response, 'text'):
+            t += "\n\tresponse text = %s" % self.response.text
 
         t += '\n'
         return t


### PR DESCRIPTION
This fixes #85 

str(JIRAError) now includes full details of any server-side errors.

The problems in the __str__ implementation are threefold:
1. The response.text block checks for the text attribute but then uses
   the headers attribute (cut-and-paste error from the lines above)
2. The response object is "Truthy" based upon the HTTP response, so in
   the case of an HTTP error it is actually "False" so the conditional
   check fails and response details are not included.
3. Finally, the format string is invalid and causes an exception
   because it is missing a %s at the end.

These problems have all been addressed in this commit.