### PR TITLE
Fix jirashell.py for non-oauth authentication

### DIFF
--- a/jira/jirashell.py
+++ b/jira/jirashell.py
@@ -244,6 +244,8 @@ def main():
     if oauth['oauth_dance']:
         oauth = oauth_dance(
             options['server'], oauth['consumer_key'], oauth['key_cert'], oauth['print_tokens'], options['verify'])
+    else:
+        oauth = None
 
     jira = JIRA(options=options, basic_auth=basic_auth, oauth=oauth)
 


### PR DESCRIPTION
This is a minor fix for commit 292597c

Fixes #91 