### PR TITLE
Skip character encoding detection when attempting to check for non-empty response.

### DIFF
--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -29,7 +29,7 @@ class ResilientSession(Session):
             if response.status_code in [502, 503, 504]:
                 return True
             elif not (response.status_code == 200 and
-                      len(response.text) == 0 and
+                      len(response.content) == 0 and
                       'X-Seraph-LoginReason' in response.headers and
                       'AUTHENTICATED_FAILED' in response.headers['X-Seraph-LoginReason']):
                 return False

--- a/jira/utils.py
+++ b/jira/utils.py
@@ -123,7 +123,7 @@ def raise_on_error(r, verb='???', **kwargs):
         raise JIRAError(r.status_code, request=request, response=r, **kwargs)
     # testing for the WTH bug exposed on
     # https://answers.atlassian.com/questions/11457054/answers/11975162
-    if r.status_code == 200 and len(r.text) == 0 \
+    if r.status_code == 200 and len(r.content) == 0 \
             and 'X-Seraph-LoginReason' in r.headers \
             and 'AUTHENTICATED_FAILED' in r.headers['X-Seraph-LoginReason']:
         pass


### PR DESCRIPTION
This PR changes response handling to use the response's `.content` attribute rather than `.text` when attempting to check for non-empty responses.  Using `.text` will cause the requests library to attempt to infer the character encoding of the returned document, and not only is that unnecessary when checking for non-empty responses, the character encoding detection process may take non-trivial amounts of time to return (sometimes as long as minutes) on certain kinds of binary files.