### PR TITLE
Python >= 3.1 do not need `ordereddict` package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,15 @@ fp.close()
 # this should help getting annoying warnings from inside distutils
 warnings.simplefilter('ignore', UserWarning)
 
+def _is_ordereddict_needed():
+    ''' Check if `ordereddict` package really needed '''
+    try:
+        from collections import OrderedDict
+        return False
+    except ImportError:
+        pass
+    return True
+
 
 class PyTest(TestCommand):
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
@@ -147,8 +156,7 @@ setup(
                       'requests_oauthlib>=0.3.3',
                       'tlslite>=0.4.4',
                       'six>=1.9.0',
-                      'requests_toolbelt',
-                      'ordereddict'],
+                      'requests_toolbelt'] + (['ordereddict'] if _is_ordereddict_needed() else []),
     setup_requires=['pytest', ],
     tests_require=['pytest', 'tlslite>=0.4.4', 'requests>=2.6.0',
                    'setuptools', 'pep8', 'autopep8', 'sphinx', 'six>=1.9.0',


### PR DESCRIPTION
W/o this patch I've got the following error on my gentoo system:

    zaufi@gentop〉~〉jirashell
    Traceback (most recent call last):
    File "/usr/lib/python-exec/python3.4/jirashell", line 5, in <module>
        from pkg_resources import load_entry_point
    File "/usr/lib64/python3.4/site-packages/pkg_resources/__init__.py", line 3084, in <module>
        @_call_aside
    File "/usr/lib64/python3.4/site-packages/pkg_resources/__init__.py", line 3070, in _call_aside
        f(*args, **kwargs)
    File "/usr/lib64/python3.4/site-packages/pkg_resources/__init__.py", line 3097, in _initialize_master_working_set
        working_set = WorkingSet._build_master()
    File "/usr/lib64/python3.4/site-packages/pkg_resources/__init__.py", line 651, in _build_master
        ws.require(__requires__)
    File "/usr/lib64/python3.4/site-packages/pkg_resources/__init__.py", line 952, in require
        needed = self.resolve(parse_requirements(requirements))
    File "/usr/lib64/python3.4/site-packages/pkg_resources/__init__.py", line 839, in resolve
        raise DistributionNotFound(req, requirers)
    pkg_resources.DistributionNotFound: The 'ordereddict' distribution was not found and is required by jira
