### PR TITLE
Don't limit search_issues() results by default

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1550,7 +1550,7 @@ class JIRA(object):
 
     # Search
 
-    def search_issues(self, jql_str, startAt=0, maxResults=50, validate_query=True, fields=None, expand=None,
+    def search_issues(self, jql_str, startAt=0, maxResults=None, validate_query=True, fields=None, expand=None,
                       json_result=None):
         """
         Get a ResultList of issue Resources matching a JQL search string.


### PR DESCRIPTION
The default maxResults=50 is a hazard that we ran in to
because if you're not explicitly specifying maxResults
you don't expect to have to handle paging.

Since the implementation neatly handles batch retrieval
of all results, it seems appropriate to use this logic
to get all search results by default unless you explicitly
limit this by setting maxResults.