### PR TITLE
Fix issue ranking

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -227,6 +227,8 @@ class JIRA(object):
 
         self._options.update(options)
 
+        self._rank = None
+
         # Rip off trailing slash since all urls depend on that
         if self._options['server'].endswith('/'):
             self._options['server'] = self._options['server'][:-1]
@@ -2805,6 +2807,5 @@ class GreenHopper(JIRA):
     def __init__(self, options=None, basic_auth=None, oauth=None, async=None):
         warnings.warn(
             "GreenHopper() class is deprecated, just use JIRA() instead.", DeprecationWarning)
-        self._rank = None
         JIRA.__init__(
             self, options=options, basic_auth=basic_auth, oauth=oauth, async=async)

--- a/jira/client.py
+++ b/jira/client.py
@@ -2793,8 +2793,13 @@ class JIRA(object):
         # {"issueKeys":["ANERDS-102"],"rankBeforeKey":"ANERDS-94","rankAfterKey":"ANERDS-7","customFieldId":11431}
         if not self._rank:
             for field in self.fields():
-                if field['name'] == 'Rank' and field['schema']['custom'] == "com.pyxis.greenhopper.jira:gh-global-rank":
-                    self._rank = field['schema']['customId']
+                if field['name'] == 'Rank':
+                    if field['schema']['custom'] == "com.pyxis.greenhopper.jira:gh-lexo-rank":
+                        self._rank = field['schema']['customId']
+                        break
+                    elif field['schema']['custom'] == "com.pyxis.greenhopper.jira:gh-global-rank":
+                        # Obsolete since JIRA v6.3.13.1
+                        self._rank = field['schema']['customId']
         data = {
             "issueKeys": [issue], "rankBeforeKey": next_issue, "customFieldId": self._rank}
         url = self._get_url('rank', base=self.AGILE_BASE_URL)


### PR DESCRIPTION
Current version throws an `AttributeError` when calling `rank()` because the `_rank` property does not exist for the `JIRA` class unless you monkey-patch it in. `GreenHopper` defines it correctly, but that class is deprecated.

Also, the `gh-global-rank` field is now obsolete, which caused errors for me when I tried to rank issues with that field. Using the newer `gh-lexo-rank` fixed this for me.