### PR TITLE
Do not try to recover if we're not going to do the retry.

### DIFF
--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -112,15 +112,18 @@ class ResilientSession(Session):
                     "%s while doing %s %s [%s]" % (e, verb.upper(), url, kwargs))
                 exception = e
             retry_number += 1
-            response_or_exception = response if response is not None else exception
-            if self.__recoverable(response_or_exception, url, verb.upper(), retry_number):
-                if retry_data:
-                    # if data is a stream, we cannot just read again from it,
-                    # retry_data() will give us a new stream with the data
-                    kwargs['data'] = retry_data()
-                continue
-            else:
-                break
+
+            if retry_number <= self.max_retries:
+                response_or_exception = response if response is not None else exception
+                if self.__recoverable(response_or_exception, url, verb.upper(), retry_number):
+                    if retry_data:
+                        # if data is a stream, we cannot just read again from it,
+                        # retry_data() will give us a new stream with the data
+                        kwargs['data'] = retry_data()
+                    continue
+                else:
+                    break
+
         if exception is not None:
             raise exception
         raise_on_error(response, verb=verb, **kwargs)


### PR DESCRIPTION
Right now the sleep is always executed, even if we're going to throw the exception as the re-try limit was reached. Which is especially annoying when you set max_retries to 0 ;).

I was unable to get the tests running so I'm not sure if it is 100% safe from tests perspective, sorry.