### PR TITLE
Move optional filemagic line to requirements-opt

### DIFF
--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -3,3 +3,4 @@ unittest2
 ordereddict
 PyJWT
 requests_jwt
+filemagic>=1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 requests>=2.6.0
 tlslite>=0.4.4
 six>=1.9.0
-filemagic>=1.6
 setuptools>=0.8.0
 requests_toolbelt
 ordereddict


### PR DESCRIPTION
This patch moves the `filemagic>=1.6` line from `requirements.txt` to
`requirements-opt.txt` since it is an optional requirement, and `setup.py`
also lists it as such.