### PR TITLE
Fix setup.py's setup_requires and requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests>=2.6.0
+requests-oauthlib>=0.3.3
 tlslite>=0.4.4
 six>=1.9.0
 filemagic>=1.6

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,6 @@ setup(
                       'tlslite>=0.4.4',
                       'six>=1.9.0',
                       'requests_toolbelt'] + (['ordereddict'] if _is_ordereddict_needed() else []),
-    setup_requires=['pytest', ],
     tests_require=['pytest', 'tlslite>=0.4.4', 'requests>=2.6.0',
                    'setuptools', 'pep8', 'autopep8', 'sphinx', 'sphinx_rtd_theme', 'six>=1.9.0',
                    'pytest-cov', 'pytest-pep8', 'pytest-instafail',


### PR DESCRIPTION
This patch fixes an issue where installing `jira` using `pip`, or really
any use of the `setup.py` file, causes `pip` or `python` to hang, unless
you are able to contact PyPI.

Listed among `setup.py`'s clauses was `setup_requires`, which pointed to
`pytest`, leading `pytest` to be a setup requirement unnecessarily. This
patch removes that.

One workaround was  _manually_ `pip` installing `pytest` _before_
installing the packages listed in `requirements.txt`, but
`requirements.txt` is the canonical point of reference for
`pip`-installed packages.

Furthermore, `pytest` is not and should never be a build or production
requirement.  It is strictly a test requirement, and is thus listed in
`requirements-dev.txt`.

Required for installation, but absent from `requirements.txt`, was
`requests-oauthlib>=0.3.3`, so I've added that in this patch, too.

These fixes are particularly useful for those running out of clean
virtualenvs, or where you have your own PyPI set up, or on a network
without access to PyPI.