### PR TITLE
Added type hints to Issue class.

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -349,15 +349,35 @@ class Filter(Resource):
         if raw:
             self._parse_raw(raw)
 
-
 class Issue(Resource):
-
     """A JIRA issue."""
+
+    class _IssueFields:
+        def __init__(self):
+            self.attachment = None
+            """ :type : list[Attachment] """
+            self.description = None
+            """ :type : str """
+            self.project = None
+            """ :type : Project """
+            self.comment = None
+            """ :type : list[Comment] """
+            self.issuelinks = None
+            """ :type : list[IssueLink] """
+            self.worklog= None
+            """ :type : list[Worklog] """
 
     def __init__(self, options, session, raw=None):
         Resource.__init__(self, 'issue/{0}', options, session)
         if raw:
             self._parse_raw(raw)
+
+        self.fields = None
+        """ :type : Issue._IssueFields """
+        self.id = None
+        """ :type : int """
+        self.key = None
+        """ :type : str """
 
     def update(self, fields=None, update=None, async=None, jira=None, **fieldargs):
         """
@@ -437,7 +457,6 @@ class Issue(Resource):
 
     def __eq__(self, other):
         return self.id == other.id
-
 
 class Comment(Resource):
 


### PR DESCRIPTION
When learning jira library, I really missed some hints to learn the available fields. I came up with an idea, how to enable type hints functionality from PyCharm and other IDEs.

This is just an example implementation for Issue class to raise a discussion. I would be very thankful for comments and improvements proposals.

Note: private class _IssueFields is not used anywhere, it is only there to enable hints for issue.fields variable.