### PR TITLE
Jira Agile public API used

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -316,7 +316,7 @@ class JIRA(object):
             return False
         return True
 
-    def _fetch_pages(self, item_type, items_key, request_path, startAt, maxResults, params, base=JIRA_BASE_URL):
+    def _fetch_pages(self, item_type, items_key, request_path, startAt, maxResults, params = None, base=JIRA_BASE_URL):
         """
         Fetches
         :param item_type: Type of single item. ResultList of such items will be returned.
@@ -326,13 +326,13 @@ class JIRA(object):
         :param startAt: index of the first record to be fetched
         :param maxResults: Maximum number of items to return.
                 If maxResults evaluates as False, it will try to get all items in batches.
-        :param params: Params to be set in all requests.
-            startAt and maxResults params will be added to this dictionary.
+        :param params: Params to be used in all requests. Should not contain startAt and maxResults,
+                        as they will be added for each request created from this function.
         :param base: base URL
         :return: ResultList
         """
 
-        page_params = params.copy()
+        page_params = params.copy() if params else {}
         if startAt:
             page_params['startAt'] = startAt
         if maxResults:
@@ -2069,7 +2069,7 @@ class JIRA(object):
         r = self._session.put(url, params=params, data=json.dumps(data))
 
     def _get_url(self, path, base=JIRA_BASE_URL):
-        options = self._options
+        options = self._options.copy()
         options.update({'path': path})
         return base.format(**options)
 

--- a/jira/client.py
+++ b/jira/client.py
@@ -59,7 +59,7 @@ from .resources import Resource, Issue, Comment, Project, Attachment, Component,
     Worklog, IssueLink, IssueLinkType, IssueType, Priority, Version, Role, Resolution, SecurityLevel, Status, User, \
     CustomFieldOption, RemoteLink
 # GreenHopper specific resources
-from .resources import Board, Sprint
+from .resources import GreenHopperResource, Board, Sprint
 from .resilientsession import ResilientSession
 from .version import __version__
 from .utils import threaded_requests, json_loads, CaseInsensitiveDict
@@ -144,6 +144,8 @@ class JIRA(object):
         "context_path": "/",
         "rest_path": "api",
         "rest_api_version": "2",
+        "agile_rest_path" : GreenHopperResource.GREENHOPPER_REST_PATH,
+        "agile_rest_api_version" : "1.0",
         "verify": True,
         "resilient": True,
         "async": False,
@@ -163,8 +165,9 @@ class JIRA(object):
 
     checked_version = False
 
-    JIRA_BASE_URL = '{server}/rest/api/{rest_api_version}/{path}'
-    AGILE_BASE_URL = '{server}/rest/greenhopper/1.0/{path}'
+    # TODO: remove these two variables and use the ones defined in resources
+    JIRA_BASE_URL = Resource.JIRA_BASE_URL
+    AGILE_BASE_URL = GreenHopperResource.AGILE_BASE_URL
 
     def __init__(self, server=None, options=None, basic_auth=None, oauth=None, jwt=None,
                  validate=False, get_server_info=True, async=False, logging=True, max_retries=3):
@@ -188,6 +191,8 @@ class JIRA(object):
             * server -- the server address and context path to use. Defaults to ``http://localhost:2990/jira``.
             * rest_path -- the root REST path to use. Defaults to ``api``, where the JIRA REST resources live.
             * rest_api_version -- the version of the REST resources under rest_path to use. Defaults to ``2``.
+            * agile_rest_path - the REST path to use for JIRA Agile requests. Defaults to ``greenhopper`` (old, private
+               API). Check `GreenHopperResource` for other supported values.
             * verify -- Verify SSL certs. Defaults to ``True``.
             * client_cert -- a tuple of (cert,key) for the requests library for client side SSL
             * check_update -- Check whether using the newest python-jira library version.
@@ -2548,51 +2553,82 @@ class JIRA(object):
     """
 
     @translate_resource_args
-    def boards(self):
+    def boards(self, startAt=0, maxResults=50, type=None, name=None):
         """
-        Get a list of board GreenHopperResources.
-        """
-        r_json = self._get_json(
-            'rapidviews/list', base=self.AGILE_BASE_URL)
+        Get a list of board resources.
 
-        boards = [Board(self._options, self._session, raw_boards_json)
-                  for raw_boards_json in r_json['views']]
-        return boards
+        :param startAt: The starting index of the returned boards. Base index: 0.
+        :param maxResults: The maximum number of boards to return per page. Default: 50
+        :param type: Filters results to boards of the specified type. Valid values: scrum, kanban.
+        :param name: Filters results to boards that match or partially match the specified name.
+        :rtype ResultList[Board]
+
+        When old GreenHopper private API is used, paging is not enabled and all parameters are ignored.
+        """
+
+        params = {}
+        if type:
+            params['type'] = type
+        if name:
+            params['name'] = name
+
+        if self._options['agile_rest_path'] == GreenHopperResource.GREENHOPPER_REST_PATH:
+            # Old, private API did not support pagination, all records were present in response,
+            #   and no parameters were supported.
+            if startAt or maxResults or params:
+                warnings.warn('Old private GreenHopper API is used, all parameters will be ignored.', Warning)
+
+            r_json = self._get_json('rapidviews/list', base=self.AGILE_BASE_URL)
+            boards = [Board(self._options, self._session, raw_boards_json) for raw_boards_json in r_json['views']]
+            return ResultList(boards, 0, len(boards), len(boards), True)
+        else:
+            return self._fetch_pages(Board, 'values', 'board', startAt, maxResults, params, base=self.AGILE_BASE_URL)
 
     @translate_resource_args
-    def sprints(self, id, extended=False):
+    def sprints(self, board_id=None, extended=False, startAt=0, maxResults=50, state=None):
         """
         Get a list of sprint GreenHopperResources.
 
-        :param id: the board to get sprints from
-        :param extended: fetch additional information like startDate, endDate, completeDate,
-            much slower because it requires an additional requests for each sprint
-        :rtype: dict
-             >>> { "id": 893,
-             >>> "name": "iteration.5",
-             >>> "state": "FUTURE",
-             >>> "linkedPagesCount": 0,
-             >>> "startDate": "None",
-             >>> "endDate": "None",
-             >>> "completeDate": "None",
-             >>> "remoteLinks": []
-             >>> }
+        :param board_id: the board to get sprints from
+        :param extended: Used only by old GreenHopper API to fetch additional information like
+            startDate, endDate, completeDate, much slower because it requires an additional requests for each sprint.
+            New JIRA Agile API always returns this information without a need for additional requests.
+        :param startAt: the index of the first sprint to return (0 based)
+        :param maxResults: the maximum number of sprints to return
+        :param state: Filters results to sprints in specified states. Valid values: future, active, closed.
+            You can define multiple states separated by commas
+        :rtype dict
+        :return (content depends on API version, but always contains id, name, state, startDate and endDate)
+
+        When old GreenHopper private API is used, paging is not enabled,
+            and `startAt`, `maxResults` and `state` parameters are ignored.
         """
-        r_json = self._get_json('sprintquery/%s?includeHistoricSprints=true&includeFutureSprints=true' % id,
-                                base=self.AGILE_BASE_URL)
 
-        if extended:
-            sprints = []
-            for raw_sprints_json in r_json['sprints']:
-                r_json = self._get_json(
-                    'sprint/%s/edit/model' % raw_sprints_json['id'], base=self.AGILE_BASE_URL)
-                sprints.append(
-                    Sprint(self._options, self._session, r_json['sprint']))
+        params = {}
+        if state:
+            if isinstance(state, string_types):
+                state = state.split(",")
+            params['state'] = state
+
+        if self._options['agile_rest_path'] == GreenHopperResource.GREENHOPPER_REST_PATH:
+            r_json = self._get_json('sprintquery/%s?includeHistoricSprints=true&includeFutureSprints=true' % board_id,
+                                    base=self.AGILE_BASE_URL)
+
+            if params:
+                warnings.warn('Old private GreenHopper API is used, parameters %s will be ignored.' % params.keys(),
+                              Warning)
+
+            if extended:
+                sprints = [Sprint(self._options, self._session, self.sprint_info(None, raw_sprints_json['id']))
+                           for raw_sprints_json in r_json['sprints']]
+            else:
+                sprints = [Sprint(self._options, self._session, raw_sprints_json)
+                           for raw_sprints_json in r_json['sprints']]
+
+            return ResultList(sprints, 0, len(sprints), len(sprints), True)
         else:
-            sprints = [Sprint(self._options, self._session, raw_sprints_json)
-                       for raw_sprints_json in r_json['sprints']]
-
-        return sprints
+            return self._fetch_pages(Sprint, 'values', 'board/%s/sprint' % board_id, startAt, maxResults, params,
+                                     self.AGILE_BASE_URL)
 
     def sprints_by_name(self, id, extended=False):
         sprints = {}
@@ -2611,8 +2647,10 @@ class JIRA(object):
         if startDate:
             payload['startDate'] = startDate
         if endDate:
-            payload['startDate'] = endDate
+            payload['endDate'] = endDate
         if state:
+            if self._options['agile_rest_path'] != GreenHopperResource.GREENHOPPER_REST_PATH:
+                raise NotImplementedError('Public JIRA API does not support state update')
             payload['state'] = state
 
         url = self._get_url('sprint/%s' % id, base=self.AGILE_BASE_URL)
@@ -2633,6 +2671,10 @@ class JIRA(object):
         # issueKeysAddedDuringSprint used to mark some with a * ?
         # puntedIssues are for scope change?
 
+        if self._options['agile_rest_path'] != GreenHopperResource.GREENHOPPER_REST_PATH:
+            raise NotImplementedError('JIRA Agile Public API does not support this request')
+        warnings.warn('JIRA.completed_issues uses deprecated API, that is going to be removed on the 1st February 2016',
+                      DeprecationWarning)
         r_json = self._get_json('rapid/charts/sprintreport?rapidViewId=%s&sprintId=%s' % (board_id, sprint_id),
                                 base=self.AGILE_BASE_URL)
         issues = [Issue(self._options, self._session, raw_issues_json) for raw_issues_json in
@@ -2643,6 +2685,11 @@ class JIRA(object):
         """
         Return the total completed points this sprint.
         """
+        if self._options['agile_rest_path'] != GreenHopperResource.GREENHOPPER_REST_PATH:
+            raise NotImplementedError('JIRA Agile Public API does not support this request')
+        warnings.warn('JIRA.completedIssuesEstimateSum uses deprecated API, that is going to be removed'
+                      ' on the 1st February 2016',
+                      DeprecationWarning)
         return self._get_json('rapid/charts/sprintreport?rapidViewId=%s&sprintId=%s' % (board_id, sprint_id),
                               base=self.AGILE_BASE_URL)['contents']['completedIssuesEstimateSum']['value']
 
@@ -2650,35 +2697,39 @@ class JIRA(object):
         """
         Return the completed issues for the sprint
         """
+        if self._options['agile_rest_path'] != GreenHopperResource.GREENHOPPER_REST_PATH:
+            raise NotImplementedError('JIRA Agile Public API does not support this request')
+        warnings.warn('JIRA.incompleted_issues uses deprecated API, that is going to be removed'
+                      'on the 1st February 2016',
+                      DeprecationWarning)
         r_json = self._get_json('rapid/charts/sprintreport?rapidViewId=%s&sprintId=%s' % (board_id, sprint_id),
                                 base=self.AGILE_BASE_URL)
         issues = [Issue(self._options, self._session, raw_issues_json) for raw_issues_json in
                   r_json['contents']['incompletedIssues']]
         return issues
 
+    # TODO: remove sprint_info() method, sprint() method suit the convention more
     def sprint_info(self, board_id, sprint_id):
         """
         Return the information about a sprint.
 
-        :param board_id: the board retrieving issues from
-        :param sprint_id: the sprint retieving issues from
+        :param board_id: the board retrieving issues from. Deprecated and ignored.
+        :param sprint_id: the sprint retrieving issues from
         """
-        return self._get_json('rapid/charts/sprintreport?rapidViewId=%s&sprintId=%s' % (board_id, sprint_id),
-                              base=self.AGILE_BASE_URL)['sprint']
+        sprint = Sprint(self._options, self._session)
+        sprint.find(id)
+        return sprint.raw
+
+    def sprint(self, id):
+        sprint = Sprint(self._options, self._session)
+        sprint.find(id)
+        return sprint
 
     # TODO: remove this as we do have Board.delete()
     def delete_board(self, id):
-        """
-        Deletes an agile board.
-
-        :param id:
-        :return:
-        """
-        payload = {}
-        url = self._get_url(
-            'rapidview/%s' % id, base=self.AGILE_BASE_URL)
-        r = self._session.delete(
-            url, data=json.dumps(payload))
+        """ Deletes an agile board. """
+        board = Board(self._options, self._session, raw = {'id':id})
+        board.delete()
 
     def create_board(self, name, project_ids, preset="scrum"):
         """
@@ -2689,6 +2740,9 @@ class JIRA(object):
         :param preset: what preset to use for this board
         :type preset: 'kanban', 'scrum', 'diy'
         """
+        if self._options['agile_rest_path'] != GreenHopperResource.GREENHOPPER_REST_PATH:
+            raise NotImplementedError('JIRA Agile Public API does not support this request')
+
         payload = {}
         if isinstance(project_ids, string_types):
             ids = []
@@ -2716,39 +2770,42 @@ class JIRA(object):
         :param name: name of the sprint
         :param board_id: the board to add the sprint to
         """
-        url = self._get_url(
-            'sprint/%s' % board_id, base=self.AGILE_BASE_URL)
-        r = self._session.post(
-            url)
-        raw_issue_json = json_loads(r)
-        """ now r contains something like:
-        {
-              "id": 742,
-              "name": "Sprint 89",
-              "state": "FUTURE",
-              "linkedPagesCount": 0,
-              "startDate": "None",
-              "endDate": "None",
-              "completeDate": "None",
-              "remoteLinks": []
-        }"""
 
         payload = {'name': name}
         if startDate:
             payload["startDate"] = startDate
         if endDate:
             payload["endDate"] = endDate
-        url = self._get_url(
-            'sprint/%s' % raw_issue_json['id'], base=self.AGILE_BASE_URL)
-        r = self._session.put(
-            url, data=json.dumps(payload))
-        raw_issue_json = json_loads(r)
+
+        if self._options['agile_rest_path'] == GreenHopperResource.GREENHOPPER_REST_PATH:
+            url = self._get_url('sprint/%s' % board_id, base=self.AGILE_BASE_URL)
+            r = self._session.post(url)
+            raw_issue_json = json_loads(r)
+            """ now r contains something like:
+            {
+                  "id": 742,
+                  "name": "Sprint 89",
+                  "state": "FUTURE",
+                  "linkedPagesCount": 0,
+                  "startDate": "None",
+                  "endDate": "None",
+                  "completeDate": "None",
+                  "remoteLinks": []
+            }"""
+
+            url = self._get_url(
+                'sprint/%s' % raw_issue_json['id'], base=self.AGILE_BASE_URL)
+            r = self._session.put(
+                url, data=json.dumps(payload))
+            raw_issue_json = json_loads(r)
+        else:
+            url = self._get_url('sprint', base=self.AGILE_BASE_URL)
+            payload['originBoardId'] = board_id
+            r = self._session.post(url, data=json.dumps(payload))
+            raw_issue_json = json_loads(r)
 
         return Sprint(self._options, self._session, raw=raw_issue_json)
 
-    # TODO: broken, this API does not exist anymore and we need to use
-    # issue.update() to perform this operaiton
-    # Workaround based on https://answers.atlassian.com/questions/277651/jira-agile-rest-api-example
     def add_issues_to_sprint(self, sprint_id, issue_keys):
         """
         Add the issues in ``issue_keys`` to the ``sprint_id``. The sprint must
@@ -2766,18 +2823,33 @@ class JIRA(object):
         :param issue_keys: the issues to add to the sprint
         """
 
-        # Get the customFieldId for "Sprint"
-        sprint_field_name = "Sprint"
-        sprint_field_id = [f['schema']['customId'] for f in self.fields()
-                           if f['name'] == sprint_field_name][0]
+        if self._options['agile_rest_path'] == GreenHopperResource.AGILE_BASE_REST_PATH:
+            url = self._get_url('sprint/%s/issue' % sprint_id, base=self.AGILE_BASE_URL)
+            payload = {'issues': issue_keys}
+            try:
+                self._session.post(url, data=json.dumps(payload))
+            except JIRAError as e:
+                if e.status_code == 404:
+                    warnings.warn('Status code 404 may mean, that too old JIRA Agile version is installed.'
+                                  ' At least version 6.7.10 is required.')
+                raise
+        elif self._options['agile_rest_path'] == GreenHopperResource.GREENHOPPER_REST_PATH:
+            # In old, private API the function does not exist anymore and we need to use
+            # issue.update() to perform this operation
+            # Workaround based on https://answers.atlassian.com/questions/277651/jira-agile-rest-api-example
 
-        data = {}
-        data['idOrKeys'] = issue_keys
-        data['customFieldId'] = sprint_field_id
-        data['sprintId'] = sprint_id
-        data['addToBacklog'] = False
-        url = self._get_url('sprint/rank', base=self.AGILE_BASE_URL)
-        r = self._session.put(url, data=json.dumps(data))
+            # Get the customFieldId for "Sprint"
+            sprint_field_name = "Sprint"
+            sprint_field_id = [f['schema']['customId'] for f in self.fields()
+                               if f['name'] == sprint_field_name][0]
+
+            data = {'idOrKeys': issue_keys, 'customFieldId': sprint_field_id,
+                    'sprintId': sprint_id, 'addToBacklog': False}
+            url = self._get_url('sprint/rank', base=self.AGILE_BASE_URL)
+            r = self._session.put(url, data=json.dumps(data))
+        else:
+            raise NotImplementedError('No API for adding issues to sprint for agile_rest_path="%s"' %
+                                      self._options['agile_rest_path'])
 
     def add_issues_to_epic(self, epic_id, issue_keys, ignore_epics=True):
         """
@@ -2787,6 +2859,10 @@ class JIRA(object):
         :param issue_keys: the issues to add to the epic
         :param ignore_epics: ignore any issues listed in ``issue_keys`` that are epics
         """
+        if self._options['agile_rest_path'] != GreenHopperResource.GREENHOPPER_REST_PATH:
+            # TODO: simulate functionality using issue.update()?
+            raise NotImplementedError('JIRA Agile Public API does not support this request')
+
         data = {}
         data['issueKeys'] = issue_keys
         data['ignoreEpics'] = ignore_epics
@@ -2795,6 +2871,7 @@ class JIRA(object):
         r = self._session.put(
             url, data=json.dumps(data))
 
+    # TODO: Both GreenHopper and new JIRA Agile API support moving more than one issue.
     def rank(self, issue, next_issue):
         """
         Rank an issue before another using the default Ranking field, the one named 'Rank'.
@@ -2802,7 +2879,6 @@ class JIRA(object):
         :param issue: issue key of the issue to be ranked before the second one.
         :param next_issue: issue key of the second issue.
         """
-        # {"issueKeys":["ANERDS-102"],"rankBeforeKey":"ANERDS-94","rankAfterKey":"ANERDS-7","customFieldId":11431}
         if not self._rank:
             for field in self.fields():
                 if field['name'] == 'Rank':
@@ -2812,11 +2888,26 @@ class JIRA(object):
                     elif field['schema']['custom'] == "com.pyxis.greenhopper.jira:gh-global-rank":
                         # Obsolete since JIRA v6.3.13.1
                         self._rank = field['schema']['customId']
-        data = {
-            "issueKeys": [issue], "rankBeforeKey": next_issue, "customFieldId": self._rank}
-        url = self._get_url('rank', base=self.AGILE_BASE_URL)
-        r = self._session.put(
-            url, data=json.dumps(data))
+
+        if self._options['agile_rest_path'] == GreenHopperResource.AGILE_BASE_REST_PATH:
+            url = self._get_url('issue/rank', base=self.AGILE_BASE_URL)
+            payload = { 'issues': [issue], 'rankBeforeIssue': next_issue, 'rankCustomFieldId': self._rank }
+            try:
+                r = self._session.put(url, data=json.dumps(payload))
+            except JIRAError as e:
+                if e.status_code == 404:
+                    warnings.warn('Status code 404 may mean, that too old JIRA Agile version is installed.'
+                                  ' At least version 6.7.10 is required.')
+                raise
+        elif self._options['agile_rest_path'] == GreenHopperResource.GREENHOPPER_REST_PATH:
+            # {"issueKeys":["ANERDS-102"],"rankBeforeKey":"ANERDS-94","rankAfterKey":"ANERDS-7","customFieldId":11431}
+            data = {
+                "issueKeys": [issue], "rankBeforeKey": next_issue, "customFieldId": self._rank}
+            url = self._get_url('rank', base=self.AGILE_BASE_URL)
+            r = self._session.put(url, data=json.dumps(data))
+        else:
+            raise NotImplementedError('No API for ranking issues for agile_rest_path="%s"' %
+                                      self._options['agile_rest_path'])
 
 
 class GreenHopper(JIRA):

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -69,15 +69,18 @@ class Resource(object):
     ``ids`` parameter to ``find()``.
     """
 
+    JIRA_BASE_URL = '{server}/rest/{rest_path}/{rest_api_version}/{path}'
+
     # A prioritized list of the keys in self.raw most likely to contain a human
     # readable name or identifier, or that offer other key information.
     _READABLE_IDS = ('displayName', 'key', 'name', 'filename', 'value',
                      'scope', 'votes', 'id', 'mimeType', 'closed')
 
-    def __init__(self, resource, options, session):
+    def __init__(self, resource, options, session, base_url=JIRA_BASE_URL):
         self._resource = resource
         self._options = options
         self._session = session
+        self._base_url = base_url
 
         # Explicitly define as None so we know when a resource has actually
         # been loaded
@@ -147,14 +150,17 @@ class Resource(object):
         if params is None:
             params = {}
 
-        url = '{server}/rest/{rest_path}/{rest_api_version}/'.format(
-            **self._options)
         if isinstance(id, tuple):
-            url += self._resource.format(*id)
+            path = self._resource.format(*id)
         else:
-            url += self._resource.format(id)
-
+            path = self._resource.format(id)
+        url = self._get_url(self, path)
         self._load(url, params=params)
+
+    def _get_url(self, path):
+        options = self._options.copy()
+        options.update({'path': path})
+        return self._base_url.format(**options)
 
     def update(self, fields=None, async=None, jira=None, **kwargs):
         """
@@ -255,13 +261,15 @@ class Resource(object):
         else:
             r = self._session.delete(url=self.self, params=params)
 
-    def _load(self, url, headers=CaseInsensitiveDict(), params=None):
+    def _load(self, url, headers=CaseInsensitiveDict(), params=None, path=None):
         r = self._session.get(url, headers=headers, params=params)
         try:
             j = json_loads(r)
         except ValueError as e:
             logging.error("%s:\n%s" % (e, r.text))
             raise e
+        if path:
+            j = j[path]
         self._parse_raw(j)
 
     def _parse_raw(self, raw):
@@ -751,35 +759,57 @@ class GreenHopperResource(Resource):
 
     """A generic GreenHopper resource."""
 
+    AGILE_BASE_URL = '{server}/rest/{agile_rest_path}/{agile_rest_api_version}/{path}'
+
+    GREENHOPPER_REST_PATH = "greenhopper"
+    """ Old, private API. Deprecated and will be removed from JIRA on the 1st February 2016. """
+    AGILE_EXPERIMENTAL_REST_PATH = "greenhopper/experimental-api"
+    """ Experimental API available in JIRA Agile 6.7.3 - 6.7.6, basically the same as Public API """
+    AGILE_BASE_REST_PATH = "agile"
+    """ Public API introduced in JIRA Agile 6.7.7. """
+
     def __init__(self, path, options, session, raw):
-        Resource.__init__(self, path, options, session)
+        self.self = None
+
+        Resource.__init__(self, path, options, session, self.AGILE_BASE_URL)
         if raw:
             self._parse_raw(raw)
-        url = '{server}/rest/greenhopper/1.0/'.format(**self._options)
-        url += path.format(**raw)
-        self.self = url
+            # Old GreenHopper API did not contain self - create it for backward compatibility.
+            if not self.self:
+                self.self = self._get_url(path.format(raw['id']))
 
 
 class Sprint(GreenHopperResource):
 
     """A GreenHopper sprint."""
 
-    def __init__(self, options, session, raw):
-        GreenHopperResource.__init__(
-            self, 'sprint/{id}', options, session, raw)
-        if raw:
-            self._parse_raw(raw)
+    def __init__(self, options, session, raw=None):
+        GreenHopperResource.__init__(self, 'sprint/{0}', options, session, raw)
+
+    def find(self, id, params=None):
+        if self._options['agile_rest_path'] != GreenHopperResource.GREENHOPPER_REST_PATH:
+            Resource.find(self, id, params)
+        else:
+            # Old, private GreenHopper API had non-standard way of loading Sprint
+            url = self._get_url(self, 'sprint/%s/edit/model' % id)
+            j = self._load(url, params=params, path='sprint')
+            self._parse_raw(j)
 
 
 class Board(GreenHopperResource):
 
     """A GreenHopper board."""
 
-    def __init__(self, options, session, raw):
-        GreenHopperResource.__init__(
-            self, 'rapidview/{id}', options, session, raw)
-        if raw:
-            self._parse_raw(raw)
+    def __init__(self, options, session, raw=None):
+        path = 'rapidview/{0}' if options['agile_rest_path'] == self.GREENHOPPER_REST_PATH else 'board/{id}'
+        GreenHopperResource.__init__(self, path, options, session, raw)
+
+    def delete(self, params=None):
+        if self._options['agile_rest_path'] != GreenHopperResource.GREENHOPPER_REST_PATH:
+            raise NotImplementedError('JIRA Agile Public API does not support Board removal')
+
+        Resource.delete(self, params)
+
 
 # Utilities
 


### PR DESCRIPTION
First two commits are the same as in "Added JIRA._fetch_pages function..." pull request, I just added them for completeness. I will remove these 2 commits when original PR will be pulled.

I added it, because of implementation of sprints fetching. Private API has two drawbacks:
- Fetching sprints in extended mode is very slow
- No 'originBoardId' in sprint data. In JIRA Agile public API it is present since version 6.7.10

Code is not fully tested, and I did not create any unit test for it. I decided to share it with you because I am Python newbie, and wanted to let someone more experienced take a look.

Is it a good direction? What is missing?