### PR TITLE
fix non-ascii resource name error for python 2 by skipping if the res…

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -829,6 +829,11 @@ def dict2resource(raw, top=None, options=None, session=None):
 
     seqs = tuple, list, set, frozenset
     for i, j in iteritems(raw):
+        try:
+            str(i)
+        except UnicodeEncodeError:
+            continue
+
         if isinstance(j, dict):
             if 'self' in j:
                 resource = cls_for_resource(j['self'])(options, session, j)


### PR DESCRIPTION
…ource name is non-ascii