### PR TITLE
Adds support for Kerberos auth.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,6 +63,10 @@ requests-oauthlib
 -----------------
 Used to implement OAuth. The latest version as of this writing is 0.3.3.
 
+requests-kerberos
+-----------------
+Used to implement Kerberos.
+
 IPython
 -------
 The `IPython enhanced Python interpreter <http://ipython.org>`_ provides the fancy chrome used by
@@ -169,6 +173,13 @@ Pass a dict of OAuth properties to the ``oauth`` constructor argument::
 
 See https://confluence.atlassian.com/display/JIRA/Configuring+OAuth+Authentication+for+an+Application+Link for details
 on configuring an OAuth provider for JIRA.
+
+Kerberos
+^^^^^^^^
+
+To enable Kerberos auth, set ``kerberos=True``::
+
+    authed_jira = JIRA(kerberos=True)
 
 .. _jirashell-label:
 
@@ -444,7 +455,7 @@ Discussion and support
 
 We encourage all who wish to discuss by using https://answers.atlassian.com/questions/topics/754366/jira-python
 
-Keep in mind to use the jira-python tag when you add a new question. This will assure that the project mantainers 
+Keep in mind to use the jira-python tag when you add a new question. This will assure that the project mantainers
 will get notified about your question.
 
 API Documentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 requests>=2.6.0
 requests-oauthlib>=0.3.3
+requests-kerberos
 tlslite>=0.4.4
 six>=1.9.0
 setuptools>=0.8.0


### PR DESCRIPTION
Couple of questions:

1. requests_kerberos package is marked compatible with python 2.6+ and 3.4+ which is a subset of the support of jira project. It might work on older versions... or not. Should I remove the package from requirements and make it optional (I see `requests-oauthlib` import happens within `_create_oauth_session()` but it's still declared in requirements file so that confuses me a little)?

2. Not directly possible to add tests for this, as there's no Kerberos server to authenticate against. Then again, it's simply `auth=HTTPKerberosAuth()` that this change introduces and `requests_kerberos` package is supposed to test that functionality anyway. Are we fine without tests?