### PR TITLE
Adding functionality to allow deletion of issue links

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1397,6 +1397,17 @@ class JIRA(object):
         r = self._session.post(
             url, data=json.dumps(data))
 
+	@translate_resource_args
+	def delete_issue_link(self, linkId):
+		"""
+		Delete a link between two issues.
+
+		:param linkId: the ID of the link to delete
+		"""
+
+		url = self._get_url('issueLink') + "/" + linkId
+		r = self.jira._session.delete(url)
+		
     def issue_link(self, id):
         """
         Get an issue link Resource from the server.

--- a/jira/client.py
+++ b/jira/client.py
@@ -1397,16 +1397,16 @@ class JIRA(object):
         r = self._session.post(
             url, data=json.dumps(data))
 
-	@translate_resource_args
-	def delete_issue_link(self, linkId):
-		"""
-		Delete a link between two issues.
+    @translate_resource_args
+    def delete_issue_link(self, linkId):
+        """
+        Delete a link between two issues.
 
-		:param linkId: the ID of the link to delete
-		"""
+        :param linkId: the ID of the link to delete
+        """
 
-		url = self._get_url('issueLink') + "/" + linkId
-		r = self.jira._session.delete(url)
+        url = self._get_url('issueLink') + "/" + linkId
+        r = self.jira._session.delete(url)
 		
     def issue_link(self, id):
         """

--- a/jira/client.py
+++ b/jira/client.py
@@ -1397,15 +1397,14 @@ class JIRA(object):
         r = self._session.post(
             url, data=json.dumps(data))
 
-    @translate_resource_args
-    def delete_issue_link(self, linkId):
+    def delete_issue_link(self, id):
         """
         Delete a link between two issues.
 
-        :param linkId: the ID of the link to delete
+        :param id: ID of the issue link to delete
         """
 
-        url = self._get_url('issueLink') + "/" + linkId
+        url = self._get_url('issueLink') + "/" + id
         r = self.jira._session.delete(url)
 		
     def issue_link(self, id):


### PR DESCRIPTION
Adding the delete_issue_link(id) functionality to allow deletion of issue links via the JIRA python API.

E.g.
```python
for link in issue.fields.issuelinks:
    jira.delete_issue_link(link.id)
```