### PR TITLE
Fix #170 : use default 'hidden' email address when Jira server settin…

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -785,7 +785,7 @@ class JIRA(object):
 
         result = {}
         for user in r['users']['items']:
-            result[user['name']] = {'fullname': user['displayName'], 'email': user['emailAddress'],
+            result[user['name']] = {'fullname': user['displayName'], 'email': user.get('emailAddress', 'hidden') ,
                                     'active': user['active']}
         return result
 


### PR DESCRIPTION
When Jira server is set to hide email addresses, they aren't send using API, so use a default 'hidden' in this case.