### PR TITLE
Use '.content' rather than '.text' when attempting to check for non-e…

### DIFF
--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -29,7 +29,7 @@ class ResilientSession(Session):
             if response.status_code in [502, 503, 504]:
                 return True
             elif not (response.status_code == 200 and
-                      len(response.text) == 0 and
+                      len(response.content) == 0 and
                       'X-Seraph-LoginReason' in response.headers and
                       'AUTHENTICATED_FAILED' in response.headers['X-Seraph-LoginReason']):
                 return False

--- a/jira/utils.py
+++ b/jira/utils.py
@@ -123,7 +123,7 @@ def raise_on_error(r, verb='???', **kwargs):
         raise JIRAError(r.status_code, request=request, response=r, **kwargs)
     # testing for the WTH bug exposed on
     # https://answers.atlassian.com/questions/11457054/answers/11975162
-    if r.status_code == 200 and len(r.text) == 0 \
+    if r.status_code == 200 and len(r.content) == 0 \
             and 'X-Seraph-LoginReason' in r.headers \
             and 'AUTHENTICATED_FAILED' in r.headers['X-Seraph-LoginReason']:
         pass


### PR DESCRIPTION
…mpty response to avoid character encoding detection on binary files.