### PR TITLE
Fixes to get 'python setup.py develop' working

### DIFF
--- a/jira/__init__.py
+++ b/jira/__init__.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from jira.utils.version import get_version
+from pkg_resources import get_distribution
 
 
-VERSION = (1, 0, 7, 'alpha', 0)
-
-__version__ = get_version(VERSION)
+__version__ = get_distribution('jira').version
 __author__ = 'bspeakmon@atlassian.com'
 
 from .config import get_jira  # noqa

--- a/jira/client.py
+++ b/jira/client.py
@@ -53,6 +53,7 @@ from .resilientsession import ResilientSession, raise_on_error
 from . import __version__
 from .utils import threaded_requests, json_loads, CaseInsensitiveDict
 from .exceptions import JIRAError
+from pkg_resources import parse_version
 
 try:
     from collections import OrderedDict
@@ -322,7 +323,7 @@ class JIRA(object):
             data = requests.get("http://pypi.python.org/pypi/jira/json", timeout=2.001).json()
 
             released_version = data['info']['version']
-            if released_version > __version__:
+            if parse_version(released_version) > parse_version(__version__):
                 warnings.warn(
                     "You are running an outdated version of JIRA Python %s. Current version is %s. Do not file any bugs against older versions." % (
                         __version__, released_version))

--- a/release.sh
+++ b/release.sh
@@ -49,7 +49,7 @@ git tag -fa -a RELEASE -m "Current RELEASE"
 
 NEW_VERSION="${VERSION%.*}.$((${VERSION##*.}+1))"
 set -ex
-sed -i.bak "s/${VERSION}/${NEW_VERSION}/" jira/version.py
+sed -i.bak "s/${VERSION}/${NEW_VERSION}/" setup.py
 
 git commit -m "Auto-increasing the version number after a release."
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ here = os.path.dirname(__file__)
 if here not in sys.path:
     sys.path.insert(0, here)
 
-__version__ = __import__(NAME).get_version()
+__version__ = '1.0.7'
 
 # this should help getting annoying warnings from inside distutils
 warnings.simplefilter('ignore', UserWarning)


### PR DESCRIPTION
* Removed setup.py dependency on library itself
* Moved version number to setup.py
* Changed package version check to use pkg_resources
* Updated release script to increment version in setup.py