### PR TITLE
params object for _fetch_pages should not contain maxResults

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1718,7 +1718,6 @@ class JIRA(object):
         search_params = {
             "jql": jql_str,
             "startAt": startAt,
-            "maxResults": maxResults,
             "validateQuery": validate_query,
             "fields": fields,
             "expand": expand}


### PR DESCRIPTION
This fixes issues if you pass False into jira.search_issues(maxResults=False).
