### PR TITLE
Error responses should not be automatically logged to a tempfile

### DIFF
--- a/jira/exceptions.py
+++ b/jira/exceptions.py
@@ -16,6 +16,11 @@ class JIRAError(Exception):
         self.request = request
         self.response = response
         self.headers = kwargs.get('headers', None)
+        self.log_to_tempfile = False
+        if 'PYJIRA_LOG_TO_TEMPFILE' in os.environ:
+            self.log_to_tempfile = True
+        if 'TRAVIS' in os.environ:
+            self.travis = True
 
     def __str__(self):
         t = "JiraError HTTP %s" % self.status_code
@@ -35,14 +40,21 @@ class JIRAError(Exception):
         if self.response is not None and hasattr(self.response, 'text'):
             details += "\n\tresponse text = %s" % self.response.text
 
-        if JIRAError.log_to_tempfile:
+        # separate logging for Travis makes sense.
+        if self.travis:
+            if self.text:
+                t += "\n\ttext: %s" % self.text
+            t += details
+        # Only log to tempfile if the option is set.
+        elif self.log_to_tempfile:
             fd, file_name = tempfile.mkstemp(suffix='.tmp', prefix='jiraerror-')
             f = open(file_name, "w")
             t += " details: %s" % file_name
             f.write(details)
+        # Otherwise, just return the error as usual
         else:
             if self.text:
                 t += "\n\ttext: %s" % self.text
-            t += details
+            t += "\n\t" + details
 
         return t


### PR DESCRIPTION
# Why this PR?

I thought about this for a while. I looked at the code to see various ways we could do this, but honestly I just think this is best, because we shouldn't create random files unless we're told to do so.

The environment variable is really the only option. The only other option would be to thread this option through every single function that's related. However, because this one error is raised through so many different paths in the library, it would require mutating half the objects in the library and a number of methods that aren't attached to objects (e.g. json_loads and raise_on_error.)

So, I don't really see any other option than an environment variable. If there is any other option or if you think there's a better way of doing it, please tell me what you'd like to do.

For now, I'm going to use the forked version of the library.