### PR TITLE
Fix handling of Jira's invalid 200 responses (JRA-41559)

### DIFF
--- a/jira/package_meta.py
+++ b/jira/package_meta.py
@@ -100,6 +100,6 @@ def get_git_changeset():
         return None
     return timestamp.strftime('%Y%m%d%H%M%S')
 
-__version__ = get_version()
+__version__ = BASE_VERSION
 setup_metadata['version'] = __version__
 setup_metadata['download_url'] = 'https://github.com/pycontribs/jira/archive/%s.tar.gz' % __version__

--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -66,6 +66,10 @@ def raise_on_error(r, verb='???', **kwargs):
     # for debugging weird errors on CI
     if r.status_code not in [200, 201, 202, 204]:
         raise JIRAError(r.status_code, request=request, response=r, **kwargs)
+    if _is_invalid_jra41559_response(r):
+        raise JIRAError(
+            200, "Atlassian's bug https://jira.atlassian.com/browse/JRA-41559",
+            r.url, request=request, response=r, **kwargs)
 
 
 class ResilientSession(Session):


### PR DESCRIPTION
Handling of https://jira.atlassian.com/browse/JRA-41559 does not seem to be working properly, leading to using empty response bodies when the error occurs rather than retrying (and raising if the issue gets triggered too many times).

This pull request slightly refactors handling of JRA-41559 so that:
- requests leading to such an invalid 200 response get retried rather than accepting the invalid empty body
- successive failures with such an error ultimately raise a `JIRAError` rather than failing silently

I believe it fixes #253 and #246.
