### PR TITLE
Partially fix falsy maxResults handling in search_issues

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1717,8 +1717,6 @@ class JIRA(object):
 
         search_params = {
             "jql": jql_str,
-            "startAt": startAt,
-            "maxResults": maxResults,
             "validateQuery": validate_query,
             "fields": fields,
             "expand": expand}


### PR DESCRIPTION
This is the same fix as #248, but that PR (a) will no longer merge cleanly, and (b) missed the removal of the `startAt` parameter, which also should not be passed according to the comment in `_fetch_pages()`.

~~However, I don't think there's any bug here since the values passed to `_fetch_pages()` are the same as the ones provided in the `params`. So this is really just a bit of cleanup.~~
