### PR TITLE
Use context processor for opening files

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2233,7 +2233,8 @@ class JIRA(object):
 
         r = self._session.post(
             url, headers=self._options['headers'], data=payload)
-        open("/tmp/jira_email_user_%s.html" % user, "w").write(r.text)
+        with open("/tmp/jira_email_user_%s.html" % user, "w") as f :
+            f.write(r.text)
 
     def rename_user(self, old_user, new_user):
         """
@@ -2292,8 +2293,8 @@ class JIRA(object):
                     "Reconfigure JIRA and disable XSRF in order to be able call this. See https://developer.atlassian.com/display/JIRADEV/Form+Token+Handling")
                 return False
 
-            open("/tmp/jira_rename_user_%s_to%s.html" %
-                 (old_user, new_user), "w").write(r.content)
+            with open("/tmp/jira_rename_user_%s_to%s.html" % (old_user, new_user), "w") as f:
+                f.write(r.content)
 
             msg = r.status_code
             m = re.search("<span class=\"errMsg\">(.*)<\/span>", r.content)

--- a/jira/exceptions.py
+++ b/jira/exceptions.py
@@ -48,9 +48,9 @@ class JIRAError(Exception):
         # Only log to tempfile if the option is set.
         elif self.log_to_tempfile:
             fd, file_name = tempfile.mkstemp(suffix='.tmp', prefix='jiraerror-')
-            f = open(file_name, "w")
-            t += " details: %s" % file_name
-            f.write(details)
+            with open(file_name, "w") as f
+                t += " details: %s" % file_name
+                f.write(details)
         # Otherwise, just return the error as usual
         else:
             if self.text:

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ def get_metadata(*path):
 
 
 def read(fname):
-    return open(os.path.join(base_path, fname)).read()
+    with open(os.path.join(base_path, fname)) as f:
+        return f.read()
 
 
 def get_requirements(*path):
@@ -160,6 +161,8 @@ def get_requirements(*path):
 #                 "already published ones (PyPi). Increse version to be able to pass prerelease stage.")
 
 if __name__ == '__main__':
+    with open("README.rst") as f:
+        readme = f.read()
 
     setup(
         name=NAME,
@@ -178,7 +181,7 @@ if __name__ == '__main__':
             'console_scripts':
             ['jirashell = jira.jirashell:main']},
 
-        long_description=open("README.rst").read(),
+        long_description=readme,
         provides=[NAME],
         bugtrack_url='https://github.com/pycontribs/jira/issues',
         home_page='https://github.com/pycontribs/jira',


### PR DESCRIPTION
Without it, jira is causing "too many open files" error when there JIRA instance doesn't work/
