### PR TITLE
Fix fetching all issues when maxResults is Falsy

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -390,7 +390,7 @@ class JIRA(object):
             if isinstance(resource, dict):
                 total = resource.get('total', 1)
                 # 'isLast' is the optional key added to responses in JIRA Agile 6.7.6. So far not used in basic JIRA API.
-                is_last = resource.get('isLast', True)
+                is_last = resource.get('isLast', False)
                 start_at_from_response = resource.get('startAt', 0)
                 max_results_from_response = resource.get('maxResults', 1)
             else:
@@ -1719,7 +1719,6 @@ class JIRA(object):
         search_params = {
             "jql": jql_str,
             "startAt": startAt,
-            "maxResults": maxResults,
             "validateQuery": validate_query,
             "fields": fields,
             "expand": expand}


### PR DESCRIPTION
There are two problems that are currently affecting the ability to
fetch all results.

1. In older versions of this code when maxResults was falsy, it would
then change it to be 50, and then iterate over the code. This was
changed to a much more ideal method, however the old code blindly put
the value of maxResults into the dict of search params. It didn't matter
as it get reassigned pretty fast. The new code still put's it blindly
 into the map, but then never reassigns it, and continues to do a search
with it to determin how many results there are. Which creates an invalid
search query. Solution: Remove it from being added to the map. It
actually never intentionally used in that map without having it
reassigned first.

2. There is this isLast code, which likely could be removed entirely.
It, according to the comment only works with the Jira agile module. If
jira doesn't know what isLast is, the code would return that is_last is
True. Obviously this is a bad failure case, as if we don't have the
agile module we can only ever return one page. Solution: Change the
default to False.