### PR TITLE
Make subprocess error compatible with python < 3.3

### DIFF
--- a/jira/exceptions.py
+++ b/jira/exceptions.py
@@ -48,7 +48,7 @@ class JIRAError(Exception):
         # Only log to tempfile if the option is set.
         elif self.log_to_tempfile:
             fd, file_name = tempfile.mkstemp(suffix='.tmp', prefix='jiraerror-')
-            with open(file_name, "w") as f
+            with open(file_name, "w") as f:
                 t += " details: %s" % file_name
                 f.write(details)
         # Otherwise, just return the error as usual

--- a/jira/package_meta.py
+++ b/jira/package_meta.py
@@ -5,6 +5,13 @@ import logging
 import os
 import re
 import subprocess
+import sys
+
+if sys.version_info >= (3, 3):
+    SUBPROCESS_ERROR = subprocess.SubprocessError
+else:
+    SUBPROCESS_ERROR = subprocess.CalledProcessError
+
 
 from pkg_resources import parse_version
 
@@ -60,8 +67,7 @@ def run_but_ignore_errors(*args, **kwargs):
         try:
             return subprocess.check_output(*args, shell=True, stderr=devnull,
                                            **kwargs)
-        except (subprocess.SubprocessError,
-                OSError):
+        except (SUBPROCESS_ERROR, OSError):
             return None
         except Exception:
             logger = logging.getLogger(__name__)


### PR DESCRIPTION
`subprocess.SubprocessError` was added in python 3.3 as is not compatible with earlier versions.