### PR TITLE
Do not fail when a searched issue has no fields

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1675,7 +1675,7 @@ class JIRA(object):
         if untranslate:
             for i in issues:
                 for k, v in iteritems(untranslate):
-                    if k in i.raw['fields']:
+                    if k in i.raw.get('fields', {}):
                         i.raw['fields'][v] = i.raw['fields'][k]
 
         return issues


### PR DESCRIPTION
When we do a search filtering on returned fields, such as:

```python
  client.search_issues(jql, fields='id')
```

The raw return is something like:

```
  {u'expand': u'operations,versionedRepresentations,editmeta,changelog,renderedFields',
   u'id': u'10005',
   u'key': u'TEST-6',
   u'self': u'http://jira:8080/rest/api/2/issue/10005'}
```

As the requested 'id' is not part of the 'fields', there is no 'fields'
dict returned by the REST API.