### PR TITLE
Fix for issue #294 - Can't fetch all sprints

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -385,7 +385,7 @@ class JIRA(object):
         if True:  # isinstance(resource, dict):
 
             if isinstance(resource, dict):
-                total = resource.get('total', 1)
+                total = resource.get('total')
                 # 'isLast' is the optional key added to responses in JIRA Agile 6.7.6. So far not used in basic JIRA API.
                 is_last = resource.get('isLast', True)
                 start_at_from_response = resource.get('startAt', 0)


### PR DESCRIPTION
Total was incorrectly defaulting to 1 instead of None, causing the while loop when maxResults is falsey to not be entered.

This fixes issue #294