### PR TITLE
When search_issues() should return json - maxResults is ignored.

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1665,6 +1665,7 @@ class JIRA(object):
             "fields": fields,
             "expand": expand}
         if json_result:
+            search_params["maxResults"] = maxResults
             if not maxResults:
                 warnings.warn('All issues cannot be fetched at once, when json_result parameter is set', Warning)
             return self._get_json('search', params=search_params)


### PR DESCRIPTION
Fix after PR #248 `seach_issues()` ignored `maxResults`, when `json_result=True`.
Add maxResults to params dict. 

```python
#!/usr/bin/python
# -*- coding: utf-8 -*-

from optparse import OptionParser
import sys, json
from jira.exceptions import JIRAError

def main():
    try:
        from jira import JIRA
    except ImportError:
        print("python-jira not found, please install it")
        raise SystemExit

    parser = OptionParser(usage="%prog -s http://localhost/jira -u admin -p admin", version="%prog 0.1")
    parser.add_option("-s", "--server", type="string", dest="jira_server", help="JIRA instance")
    parser.add_option("-u", "--username", type="string", dest="jira_user", help="Username of JIRA account for auth basic")
    parser.add_option("-p", "--password", type="string", dest="jira_password", help="Password of JIRA account for auth basic")
    (opts, args) = parser.parse_args()

    if not (opts.jira_server or opts.jira_user or opts.jira_password):
        parser.print_help()
        sys.exit(1)

    try:
        jira = JIRA(server=opts.jira_server, logging=False, basic_auth=(opts.jira_user, opts.jira_password))
    except JIRAError:
        raise JIRAError("Can\'t connect to JIRA: '{0}'".format(opts.jira_server))

    query = jira.search_issues(jql_str="project = SUPPORT AND attachments is not EMPTY", json_result=True, maxResults=2, fields="key, attachment")

    if query:
        json_full = json.dumps(query)
        json_root = json.loads(json_full)
    else:
        print("Issues not found.")
        sys.exit(2)
    if json_root["total"] >=1:
        print("Found {0} issues.".format(json_root["total"]))
    else:
        print("Issues not found.")
        sys.exit(2)

    for i in query['issues']:
        for a in i['fields']['attachment']:
            print("For issue {0}, found attach: '{1}' [{2}].".format(i['key'], a['filename'], a['id']))

if __name__ == "__main__":
  main()

```

Before patch:

```
[k0ste@WorkStation jira]$ python check_issue_fields.py -s http://jira/ -u test -p test | wc -l
96
```

After patch:

```
[k0ste@WorkStation jira]$ python check_issue_fields.py -s http://jira/ -u test -p test | wc -l
3
```
```
Found 226 issues.
For issue SUPPORT-2616, found attach: 'hub.jpg' [35425].
For issue SUPPORT-2569, found attach: 'screen.png' [73413].
```