### PR TITLE
Use own logger and remove JIRA.logging

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -460,8 +460,8 @@ class JIRA(object):
         :param size: number of threads to run on.
         """
         if hasattr(self._session, '_async_jobs'):
-            logger.info("Executing async %s jobs found in queue by using %s threads..." % (
-                len(self._session._async_jobs), size))
+            logger.info("Executing async %s jobs found in queue by using %s threads...",
+                        len(self._session._async_jobs), size)
             threaded_requests.map(self._session._async_jobs, size=size)
 
             # Application properties
@@ -540,8 +540,8 @@ class JIRA(object):
         if isinstance(attachment, string_types):
             attachment = open(attachment, "rb")
         if hasattr(attachment, 'read') and hasattr(attachment, 'mode') and attachment.mode != 'rb':
-            logger.warning(
-                "%s was not opened in 'rb' mode, attaching file may fail." % attachment.name)
+            logger.warning("%s was not opened in 'rb' mode, attaching file may fail.",
+                           attachment.name)
 
         url = self._get_url('issue/' + str(issue) + '/attachments')
 
@@ -1194,7 +1194,7 @@ class JIRA(object):
         try:
             r_json = json_loads(r)
         except ValueError as e:
-            logger.error("%s\n%s" % (e, r.text))
+            logger.error("%s\n%s", e, r.text)
             raise e
         return r_json
 
@@ -2107,7 +2107,7 @@ class JIRA(object):
         try:
             r_json = json_loads(r)
         except ValueError as e:
-            logger.error("%s\n%s" % (e, r.text))
+            logger.error("%s\n%s", e, r.text)
             raise e
         return r_json
 
@@ -2148,7 +2148,7 @@ class JIRA(object):
                 return mimetypes.guess_type("f." + imghdr.what(0, buff))[0]
             except (IOError, TypeError):
                 logger.warning("Couldn't detect content type of avatar image"
-                                ". Specify the 'contentType' parameter explicitly.")
+                               ". Specify the 'contentType' parameter explicitly.")
                 return None
 
     def email_user(self, user, body, title="JIRA Notification"):
@@ -2190,7 +2190,7 @@ class JIRA(object):
                 'username': old_user}
 
             # raw displayName
-            logger.debug("renaming %s" % self.user(old_user).emailAddress)
+            logger.debug("renaming %s", self.user(old_user).emailAddress)
 
             r = self._session.put(url, params=params,
                                   data=json.dumps(payload))
@@ -2213,7 +2213,7 @@ class JIRA(object):
                 "RunCanned": "Run"}
 
             # raw displayName
-            logger.debug("renaming %s" % self.user(old_user).emailAddress)
+            logger.debug("renaming %s", self.user(old_user).emailAddress)
 
             r = self._session.post(
                 url, headers=self._options['headers'], data=payload)
@@ -2227,7 +2227,8 @@ class JIRA(object):
 
             if re.compile("XSRF Security Token Missing").search(r.content):
                 logger.fatal(
-                    "Reconfigure JIRA and disable XSRF in order to be able call this. See https://developer.atlassian.com/display/JIRADEV/Form+Token+Handling")
+                    "Reconfigure JIRA and disable XSRF in order to be able call this. "
+                    "See https://developer.atlassian.com/display/JIRADEV/Form+Token+Handling")
                 return False
 
             with open("/tmp/jira_rename_user_%s_to%s.html" % (old_user, new_user), "w") as f:
@@ -2255,7 +2256,8 @@ class JIRA(object):
                 logger.error("User %s does not exists. %s", old_user, e)
                 return msg
 
-            logger.error(msg + '\n' + "User %s does still exists after rename, that's clearly a problem." % old_user)
+            logger.error(msg + "\nUser %s does still exists after rename, that's clearly a problem.",
+                         old_user)
             return False
 
     def delete_user(self, username):
@@ -2293,7 +2295,7 @@ class JIRA(object):
                 return True
             else:
                 logger.warning(
-                    'Got response from deactivating %s: %s' % (username, r.status_code))
+                    'Got response from deactivating %s: %s', username, r.status_code)
                 return r.status_code
         except Exception as e:
             print("Error Deactivating %s: %s" % (username, e))
@@ -2350,8 +2352,7 @@ class JIRA(object):
             if r.status_code == 200:
                 return True
             else:
-                logger.warning(
-                    'Got %s response from calling backup.' % r.status_code)
+                logger.warning('Got %s response from calling backup.', r.status_code)
                 return r.status_code
         except Exception as e:
             logger.error("I see %s", e)
@@ -2365,8 +2366,7 @@ class JIRA(object):
         if self.server_info().get('deploymentType') == 'Cloud':
             url = self._options['server'] + '/rest/obm/1.0/getprogress?_=%i' % epoch_time
         else:
-            logger.warning(
-                'This functionality is not available in Server version')
+            logger.warning('This functionality is not available in Server version')
             return None
         r = self._session.get(
             url, headers=self._options['headers'])
@@ -2380,7 +2380,8 @@ class JIRA(object):
             try:
                 root = etree.fromstring(r.text)
             except etree.ParseError as pe:
-                logger.warning('Unable to find backup info.  You probably need to initiate a new backup. %s' % pe)
+                logger.warning('Unable to find backup info.  '
+                               'You probably need to initiate a new backup. %s', pe)
                 return None
             for k in root.keys():
                 progress[k] = root.get(k)
@@ -2389,8 +2390,7 @@ class JIRA(object):
     def backup_complete(self):
         """Return boolean based on 'alternativePercentage' and 'size' returned from backup_progress (cloud only)."""
         if self.server_info().get('deploymentType') != 'Cloud':
-            logger.warning(
-                'This functionality is not available in Server version')
+            logger.warning('This functionality is not available in Server version')
             return None
         status = self.backup_progress()
         perc_complete = int(re.search(r"\s([0-9]*)\s",
@@ -2401,26 +2401,25 @@ class JIRA(object):
     def backup_download(self, filename=None):
         """Download backup file from WebDAV (cloud only)."""
         if self.server_info().get('deploymentType') != 'Cloud':
-            logger.warning(
-                'This functionality is not available in Server version')
+            logger.warning('This functionality is not available in Server version')
             return None
         remote_file = self.backup_progress()['fileName']
         local_file = filename or remote_file
         url = self._options['server'] + '/webdav/backupmanager/' + remote_file
         try:
-            logger.debug('Writing file to %s' % local_file)
+            logger.debug('Writing file to %s', local_file)
             with open(local_file, 'wb') as file:
                 try:
                     resp = self._session.get(url, headers=self._options['headers'], stream=True)
                 except Exception:
                     raise JIRAError()
                 if not resp.ok:
-                    logger.error("Something went wrong with download: %s" % resp.text)
+                    logger.error("Something went wrong with download: %s", resp.text)
                     raise JIRAError(resp.text)
                 for block in resp.iter_content(1024):
                     file.write(block)
         except JIRAError as je:
-            logger.error('Unable to access remote backup file: %s' % je)
+            logger.error('Unable to access remote backup file: %s', je)
         except IOError as ioe:
             logger.error(ioe)
         return None

--- a/jira/client.py
+++ b/jira/client.py
@@ -191,7 +191,7 @@ class JIRA(object):
     AGILE_BASE_URL = GreenHopperResource.AGILE_BASE_URL
 
     def __init__(self, server=None, options=None, basic_auth=None, oauth=None, jwt=None, kerberos=False,
-                 validate=False, get_server_info=True, async=False, logging=True, max_retries=3, proxies=None):
+                 validate=False, get_server_info=True, async=False, logging=False, max_retries=3, proxies=None):
         """Construct a JIRA client instance.
 
         Without any arguments, this client will connect anonymously to the JIRA instance
@@ -256,7 +256,10 @@ class JIRA(object):
         if async:
             options['async'] = async
 
-        self.logging = logging
+        if logging:
+            warnings.warn("JIRA.logging is no longer used; Please attach handlers to 'jira' logger",
+                          DeprecationWarning)
+        self.logging = False
 
         self._options = copy.copy(JIRA.DEFAULT_OPTIONS)
 
@@ -2553,11 +2556,9 @@ class JIRA(object):
         f = tempfile.NamedTemporaryFile(
             suffix='.html', prefix='python-jira-error-create-project-', delete=False)
         f.write(r.text)
-
-        if self.logging:
-            logger.error(
-                "Unexpected result while running create project. Server response saved in %s for further investigation [HTTP response=%s]." % (
-                    f.name, r.status_code))
+        logger.error("Unexpected result while running create project. "
+                     "Server response saved in %s for further investigation [HTTP response=%s].",
+                     f.name, r.status_code)
         return False
 
     def add_user(self, username, email, directoryId=1, password=None,

--- a/jira/client.py
+++ b/jira/client.py
@@ -191,7 +191,7 @@ class JIRA(object):
     AGILE_BASE_URL = GreenHopperResource.AGILE_BASE_URL
 
     def __init__(self, server=None, options=None, basic_auth=None, oauth=None, jwt=None, kerberos=False,
-                 validate=False, get_server_info=True, async=False, logging=False, max_retries=3, proxies=None):
+                 validate=False, get_server_info=True, async=False, max_retries=3, proxies=None):
         """Construct a JIRA client instance.
 
         Without any arguments, this client will connect anonymously to the JIRA instance
@@ -255,11 +255,6 @@ class JIRA(object):
             options['server'] = server
         if async:
             options['async'] = async
-
-        if logging:
-            warnings.warn("JIRA.logging is no longer used; Please attach handlers to 'jira' logger",
-                          DeprecationWarning)
-        self.logging = False
 
         self._options = copy.copy(JIRA.DEFAULT_OPTIONS)
 

--- a/jira/config.py
+++ b/jira/config.py
@@ -17,6 +17,9 @@ except ImportError:
 from jira.client import JIRA
 
 
+logger = logging.getLogger('jira')
+
+
 def get_jira(profile=None, url="http://localhost:2990", username="admin", password="admin", appid=None, autofix=False, verify=True):
     """Return a JIRA object by loading the connection details from the `config.ini` file.
 
@@ -64,7 +67,7 @@ def get_jira(profile=None, url="http://localhost:2990", username="admin", passwo
 
     config_file = findfile('config.ini')
     if config_file:
-        logging.debug("Found %s config file" % config_file)
+        logger.debug("Found %s config file" % config_file)
 
     if not profile:
         if config_file:

--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -81,8 +81,9 @@ class ResilientSession(Session):
     def __recoverable(self, response, url, request, counter=1):
         msg = response
         if isinstance(response, ConnectionError):
-            logger.warning("Got ConnectionError [%s] errno:%s on %s %s\n%s\%s" % (
-                response, response.errno, request, url, vars(response), response.__dict__))
+            logger.warning(
+                "Got ConnectionError [%s] errno:%s on %s %s\n%s\%s",
+                response, response.errno, request, url, vars(response), response.__dict__)
         if hasattr(response, 'status_code'):
             if response.status_code in [502, 503, 504]:
                 msg = "%s %s" % (response.status_code, response.reason)
@@ -96,8 +97,9 @@ class ResilientSession(Session):
 
         # Exponential backoff with full jitter.
         delay = min(60, 10 * 2 ** counter) * random.random()
-        logger.warning("Got recoverable error from %s %s, will retry [%s/%s] in %ss. Err: %s" % (
-            request, url, counter, self.max_retries, delay, msg))
+        logger.warning(
+            "Got recoverable error from %s %s, will retry [%s/%s] in %ss. Err: %s",
+            request, url, counter, self.max_retries, delay, msg)
         time.sleep(delay)
         return True
 
@@ -123,8 +125,7 @@ class ResilientSession(Session):
                 if response.status_code == 200:
                     return response
             except ConnectionError as e:
-                logger.warning(
-                    "%s while doing %s %s [%s]" % (e, verb.upper(), url, kwargs))
+                logger.warning("%s while doing %s %s [%s]", e, verb.upper(), url, kwargs)
                 exception = e
             retry_number += 1
 

--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -16,7 +16,7 @@ import time
 
 from jira.exceptions import JIRAError
 
-logging.getLogger('jira').addHandler(NullHandler())
+logger = logging.getLogger('jira')
 
 
 def raise_on_error(r, verb='???', **kwargs):
@@ -81,7 +81,7 @@ class ResilientSession(Session):
     def __recoverable(self, response, url, request, counter=1):
         msg = response
         if isinstance(response, ConnectionError):
-            logging.warning("Got ConnectionError [%s] errno:%s on %s %s\n%s\%s" % (
+            logger.warning("Got ConnectionError [%s] errno:%s on %s %s\n%s\%s" % (
                 response, response.errno, request, url, vars(response), response.__dict__))
         if hasattr(response, 'status_code'):
             if response.status_code in [502, 503, 504]:
@@ -96,7 +96,7 @@ class ResilientSession(Session):
 
         # Exponential backoff with full jitter.
         delay = min(60, 10 * 2 ** counter) * random.random()
-        logging.warning("Got recoverable error from %s %s, will retry [%s/%s] in %ss. Err: %s" % (
+        logger.warning("Got recoverable error from %s %s, will retry [%s/%s] in %ss. Err: %s" % (
             request, url, counter, self.max_retries, delay, msg))
         time.sleep(delay)
         return True
@@ -123,7 +123,7 @@ class ResilientSession(Session):
                 if response.status_code == 200:
                     return response
             except ConnectionError as e:
-                logging.warning(
+                logger.warning(
                     "%s while doing %s %s [%s]" % (e, verb.upper(), url, kwargs))
                 exception = e
             retry_number += 1

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -51,7 +51,7 @@ __all__ = (
     'RemoteLink'
 )
 
-logging.getLogger('jira').addHandler(NullHandler())
+logger = logging.getLogger('jira')
 
 
 def get_error_list(r):
@@ -230,17 +230,17 @@ class Resource(object):
                 r.status_code == 400:
             user = None
             error_list = get_error_list(r)
-            logging.error(error_list)
+            logger.error(error_list)
             if "The reporter specified is not a user." in error_list:
                 if 'reporter' not in data['fields']:
-                    logging.warning(
+                    logger.warning(
                         "autofix: setting reporter to '%s' and retrying the update." % self._options['autofix'])
                     data['fields']['reporter'] = {
                         'name': self._options['autofix']}
 
             if "Issues must be assigned." in error_list:
                 if 'assignee' not in data['fields']:
-                    logging.warning("autofix: setting assignee to '%s' for %s and retrying the update." % (
+                    logger.warning("autofix: setting assignee to '%s' for %s and retrying the update." % (
                         self._options['autofix'], self.key))
                     data['fields']['assignee'] = {
                         'name': self._options['autofix']}
@@ -248,11 +248,11 @@ class Resource(object):
                     # so we need to change the assignee before
 
             if "Issue type is a sub-task but parent issue key or id not specified." in error_list:
-                logging.warning(
+                logger.warning(
                     "autofix: trying to fix sub-task without parent by converting to it to bug")
                 data['fields']['issuetype'] = {"name": "Bug"}
             if "The summary is invalid because it contains newline characters." in error_list:
-                logging.warning("autofix: trying to fix newline in summary")
+                logger.warning("autofix: trying to fix newline in summary")
                 data['fields'][
                     'summary'] = self.fields.summary.replace("/n", "")
             for error in error_list:
@@ -271,11 +271,11 @@ class Resource(object):
                         raise NotImplemented()
 
             if user:
-                logging.warning(
+                logger.warning(
                     "Trying to add missing orphan user '%s' in order to complete the previous failed operation." % user)
                 jira.add_user(user, 'noreply@example.com', 10100, active=False)
                 # if 'assignee' not in data['fields']:
-                #    logging.warning("autofix: setting assignee to '%s' and retrying the update." % self._options['autofix'])
+                #    logger.warning("autofix: setting assignee to '%s' and retrying the update." % self._options['autofix'])
                 #    data['fields']['assignee'] = {'name': self._options['autofix']}
             # EXPERIMENTAL --->
             # import grequests
@@ -310,7 +310,7 @@ class Resource(object):
         try:
             j = json_loads(r)
         except ValueError as e:
-            logging.error("%s:\n%s" % (e, r.text))
+            logger.error("%s:\n%s" % (e, r.text))
             raise e
         if path:
             j = j[path]

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -164,10 +164,10 @@ class JiraTestManager(object):
                     if self.CI_JIRA_ADMIN:
                         self.jira_admin = JIRA(self.CI_JIRA_URL, basic_auth=(self.CI_JIRA_ADMIN,
                                                                              self.CI_JIRA_ADMIN_PASSWORD),
-                                               logging=False, validate=True, max_retries=self.max_retries)
+                                               validate=True, max_retries=self.max_retries)
                     else:
                         self.jira_admin = JIRA(self.CI_JIRA_URL, validate=True,
-                                               logging=False, max_retries=self.max_retries)
+                                               max_retries=self.max_retries)
                 if self.jira_admin.current_user() != self.CI_JIRA_ADMIN:
                     # self.jira_admin.
                     self.initialized = 1
@@ -179,16 +179,16 @@ class JiraTestManager(object):
                         'access_token_secret':
                             'K83jBZnjnuVRcfjBflrKyThJa0KSjSs2',
                         'consumer_key': CONSUMER_KEY,
-                        'key_cert': KEY_CERT_DATA}, logging=False, max_retries=self.max_retries)
+                        'key_cert': KEY_CERT_DATA}, max_retries=self.max_retries)
                 else:
                     if self.CI_JIRA_ADMIN:
                         self.jira_sysadmin = JIRA(self.CI_JIRA_URL,
                                                   basic_auth=(self.CI_JIRA_ADMIN,
                                                               self.CI_JIRA_ADMIN_PASSWORD),
-                                                  logging=False, validate=True, max_retries=self.max_retries)
+                                                  validate=True, max_retries=self.max_retries)
                     else:
                         self.jira_sysadmin = JIRA(self.CI_JIRA_URL,
-                                                  logging=False, max_retries=self.max_retries)
+                                                  max_retries=self.max_retries)
 
                 if OAUTH:
                     self.jira_normal = JIRA(oauth={
@@ -202,10 +202,10 @@ class JiraTestManager(object):
                         self.jira_normal = JIRA(self.CI_JIRA_URL,
                                                 basic_auth=(self.CI_JIRA_USER,
                                                             self.CI_JIRA_USER_PASSWORD),
-                                                validate=True, logging=False, max_retries=self.max_retries)
+                                                validate=True, max_retries=self.max_retries)
                     else:
                         self.jira_normal = JIRA(self.CI_JIRA_URL,
-                                                validate=True, logging=False, max_retries=self.max_retries)
+                                                validate=True, max_retries=self.max_retries)
 
                 # now we need some data to start with for the tests
 
@@ -1727,8 +1727,7 @@ class OtherTests(unittest.TestCase):
         try:
             JIRA('https://support.atlassian.com',
                  basic_auth=("xxx", "xxx"),
-                 validate=True,
-                 logging=False)
+                 validate=True)
         except Exception as e:
             self.assertIsInstance(e, JIRAError)
             # 20161010: jira cloud returns 500
@@ -1748,14 +1747,14 @@ class SessionTests(unittest.TestCase):
         self.assertIsNotNone(user.raw['session'])
 
     def test_session_with_no_logged_in_user_raises(self):
-        anon_jira = JIRA('https://support.atlassian.com', logging=False)
+        anon_jira = JIRA('https://support.atlassian.com')
         self.assertRaises(JIRAError, anon_jira.session)
 
     # @pytest.mark.skipif(platform.python_version() < '3', reason='Does not work with Python 2')
     # @not_on_custom_jira_instance  # takes way too long
     def test_session_server_offline(self):
         try:
-            JIRA('https://127.0.0.1:1', logging=False, max_retries=0)
+            JIRA('https://127.0.0.1:1', max_retries=0)
         except Exception as e:
             self.assertIn(type(e), (JIRAError, requests.exceptions.ConnectionError, AttributeError), e)
             return


### PR DESCRIPTION
jira package used direct `logging` functions (warning, error, debug, ...),  which uses root logger for logging. If an application, that uses jira package, does not register any handlers to root logger, then a logging function automatically creates and adds a `StreamHandler` to it. That can have an unexpected results for application developer. Jira package already registered its own logger (named "jira") and attached a NullHandler to it, but it was never used.

Changelog:
* logging to "jira" logger (fixes #298)
* removed `Jira.logging` boolean
* refactored usage of logging msg formatting trough arguments
 