### PR TITLE
Support for bulk issue creation

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -151,11 +151,16 @@ You can even bulk create multiple issues::
         'description': 'Final issue of batch.',
         'issuetype': {'name': 'Bug'},
     }]
-    issues = jira.create_issues(field_list=issue_dict)
+    issues = jira.create_issues(field_list=issue_list)
 
 .. note::
     Project, summary, description and issue type are always required when creating issues. Your JIRA may require
     additional fields for creating issues; see the ``jira.createmeta`` method for getting access to that information.
+
+.. note::
+    Using bulk create will not throw an exception for a failed issue creation. It will return a list of dicts that
+    each contain a possible error signature if that issue had invalid fields. Successfully created issues will contain
+    the issue object as a value of the ``issue`` key.
 
 You can also update an issue's fields with keyword arguments::
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -130,6 +130,29 @@ Or you can use a dict::
     }
     new_issue = jira.create_issue(fields=issue_dict)
 
+You can even bulk create multiple issues::
+
+    issue_list = [
+    {
+        'project': {'id': 123},
+        'summary': 'First issue of many',
+        'description': 'Look into this one',
+        'issuetype': {'name': 'Bug'},
+    },
+    {
+        'project': {'key': 'FOO'},
+        'summary': 'Second issue',
+        'description': 'Another one',
+        'issuetype': {'name': 'Bug'},
+    },
+    {
+        'project': {'name': 'Bar'},
+        'summary': 'Last issue',
+        'description': 'Final issue of batch.',
+        'issuetype': {'name': 'Bug'},
+    }]
+    issues = jira.create_issues(field_list=issue_dict)
+
 .. note::
     Project, summary, description and issue type are always required when creating issues. Your JIRA may require
     additional fields for creating issues; see the ``jira.createmeta`` method for getting access to that information.

--- a/jira/client.py
+++ b/jira/client.py
@@ -122,15 +122,9 @@ def _get_template_list(data):
 
 
 def _field_worker(fields=None, **fieldargs):
-    data = {}
     if fields is not None:
-        data['fields'] = fields
-    else:
-        fields_dict = {}
-        for field in fieldargs:
-            fields_dict[field] = fieldargs[field]
-        data['fields'] = fields_dict
-    return data
+        return {'fields': fields}
+    return {'fields': fieldargs}
 
 
 class ResultList(list):
@@ -900,6 +894,8 @@ class JIRA(object):
 
         :param field_list: a list of dicts each containing field names and the values to use. Each dict
             is an individual issue to create and is subject to its minimum requirements.
+        :param prefetch: whether to reload the created issue Resource for each created issue so that all
+            of its data is present in the value returned from this method.
         """
         data = {'issueUpdates': []}
         for field_dict in field_list:
@@ -922,15 +918,21 @@ class JIRA(object):
 
         raw_issue_json = json_loads(r)
         issue_list = []
+        errors = {}
         for error in raw_issue_json['errors']:
-            failed_fields = field_list[error['failedElementNumber']]
-            logging.error('Error creating issue with fields: %s\n%s', failed_fields,
-                          error['elementErrors']['errors'])
-        for result in raw_issue_json['issues']:
-            if prefetch:
-                issue_list.append(self.issue(result['key']))
+            errors[error['failedElementNumber']] = error['elementErrors']['errors']
+        for index, fields in enumerate(field_list):
+            if index in errors:
+                issue_list.append({'status': 'Error', 'error': errors[index],
+                                   'issue': None, 'input_fields': fields})
             else:
-                issue_list.append(Issue(self._options, self._session, raw=result))
+                issue = raw_issue_json['issues'].pop(0)
+                if prefetch:
+                    issue = self.issue(issue['key'])
+                else:
+                    issue = Issue(self._options, self._session, raw=issue)
+                issue_list.append({'status': 'Success', 'issue': issue,
+                                   'error': None, 'input_fields': fields})
         return issue_list
 
     def createmeta(self, projectKeys=None, projectIds=[], issuetypeIds=None, issuetypeNames=None, expand=None):

--- a/jira/client.py
+++ b/jira/client.py
@@ -121,6 +121,18 @@ def _get_template_list(data):
     return template_list
 
 
+def _field_worker(fields=None, **fieldargs):
+    data = {}
+    if fields is not None:
+        data['fields'] = fields
+    else:
+        fields_dict = {}
+        for field in fieldargs:
+            fields_dict[field] = fieldargs[field]
+        data['fields'] = fields_dict
+    return data
+
+
 class ResultList(list):
 
     def __init__(self, iterable=None, _startAt=None, _maxResults=None, _total=None, _isLast=None):
@@ -857,14 +869,7 @@ class JIRA(object):
         :param prefetch: whether to reload the created issue Resource so that all of its data is present in the value
             returned from this method
         """
-        data = {}
-        if fields is not None:
-            data['fields'] = fields
-        else:
-            fields_dict = {}
-            for field in fieldargs:
-                fields_dict[field] = fieldargs[field]
-            data['fields'] = fields_dict
+        data = _field_worker(fields, **fieldargs)
 
         p = data['fields']['project']
 
@@ -887,6 +892,46 @@ class JIRA(object):
             return self.issue(raw_issue_json['key'])
         else:
             return Issue(self._options, self._session, raw=raw_issue_json)
+
+    def create_issues(self, field_list, prefetch=True):
+        """Bulk create new issues and return an issue Resource for each successfully created issue.
+
+        See `create_issue` documentation for field information.
+
+        :param field_list: a list of dicts each containing field names and the values to use. Each dict
+            is an individual issue to create and is subject to its minimum requirements.
+        """
+        data = {'issueUpdates': []}
+        for field_dict in field_list:
+            issue_data = _field_worker(field_dict)
+            p = issue_data['fields']['project']
+
+            if isinstance(p, string_types) or isinstance(p, integer_types):
+                issue_data['fields']['project'] = {'id': self.project(p).id}
+
+            p = issue_data['fields']['issuetype']
+            if isinstance(p, integer_types):
+                issue_data['fields']['issuetype'] = {'id': p}
+            if isinstance(p, string_types) or isinstance(p, integer_types):
+                issue_data['fields']['issuetype'] = {'id': self.issue_type_by_name(p).id}
+
+            data['issueUpdates'].append(issue_data)
+
+        url = self._get_url('issue/bulk')
+        r = self._session.post(url, data=json.dumps(data))
+
+        raw_issue_json = json_loads(r)
+        issue_list = []
+        for error in raw_issue_json['errors']:
+            failed_fields = field_list[error['failedElementNumber']]
+            logging.error('Error creating issue with fields: %s\n%s', failed_fields,
+                          error['elementErrors']['errors'])
+        for result in raw_issue_json['issues']:
+            if prefetch:
+                issue_list.append(self.issue(result['key']))
+            else:
+                issue_list.append(Issue(self._options, self._session, raw=result))
+        return issue_list
 
     def createmeta(self, projectKeys=None, projectIds=[], issuetypeIds=None, issuetypeNames=None, expand=None):
         """Get the metadata required to create issues, optionally filtered by projects and issue types.

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -753,22 +753,22 @@ class IssueTests(unittest.TestCase):
             'priority': {
                 'name': 'Major'}}]
         issues = self.jira.create_issues(field_list=field_list)
-        self.assertEqual(issues[0].fields.summary,
+        self.assertEqual(issues[0]['issue'].fields.summary,
                          'Issue created via bulk create #1')
-        self.assertEqual(issues[0].fields.description,
+        self.assertEqual(issues[0]['issue'].fields.description,
                          "Some new issue for test")
-        self.assertEqual(issues[0].fields.issuetype.name, 'Bug')
-        self.assertEqual(issues[0].fields.project.key, self.project_b)
-        self.assertEqual(issues[0].fields.priority.name, 'Major')
-        self.assertEqual(issues[1].fields.summary,
+        self.assertEqual(issues[0]['issue'].fields.issuetype.name, 'Bug')
+        self.assertEqual(issues[0]['issue'].fields.project.key, self.project_b)
+        self.assertEqual(issues[0]['issue'].fields.priority.name, 'Major')
+        self.assertEqual(issues[1]['issue'].fields.summary,
                          'Issue created via bulk create #2')
-        self.assertEqual(issues[1].fields.description,
+        self.assertEqual(issues[1]['issue'].fields.description,
                         "Another new issue for bulk test")
-        self.assertEqual(issues[1].fields.issuetype.name, 'Bug')
-        self.assertEqual(issues[1].fields.project.key, self.project_a)
-        self.assertEqual(issues[1].fields.priority.name, 'Major')
+        self.assertEqual(issues[1]['issue'].fields.issuetype.name, 'Bug')
+        self.assertEqual(issues[1]['issue'].fields.project.key, self.project_a)
+        self.assertEqual(issues[1]['issue'].fields.priority.name, 'Major')
         for issue in issues:
-            issue.delete()
+            issue['issue'].delete()
 
     @not_on_custom_jira_instance
     def test_create_issues_one_failure(self):
@@ -801,23 +801,29 @@ class IssueTests(unittest.TestCase):
             'priority': {
                 'name': 'Major'}}]
         issues = self.jira.create_issues(field_list=field_list)
-        self.assertEqual(issues[0].fields.summary,
+        self.assertEqual(issues[0]['issue'].fields.summary,
                          'Issue created via bulk create #1')
-        self.assertEqual(issues[0].fields.description,
+        self.assertEqual(issues[0]['issue'].fields.description,
                          "Some new issue for test")
-        self.assertEqual(issues[0].fields.issuetype.name, 'Bug')
-        self.assertEqual(issues[0].fields.project.key, self.project_b)
-        self.assertEqual(issues[0].fields.priority.name, 'Major')
-        self.assertEqual(issues[1].fields.summary,
+        self.assertEqual(issues[0]['issue'].fields.issuetype.name, 'Bug')
+        self.assertEqual(issues[0]['issue'].fields.project.key, self.project_b)
+        self.assertEqual(issues[0]['issue'].fields.priority.name, 'Major')
+        self.assertEqual(issues[0]['error'], None)
+        self.assertEqual(issues[1]['issue'], None)
+        self.assertEqual(issues[1]['error'], {'issuetype': 'issue type is required'})
+        self.assertEqual(issues[1]['input_fields'], field_list[1])
+        self.assertEqual(issues[2]['issue'].fields.summary,
                          'However, this one will.')
-        self.assertEqual(issues[1].fields.description,
+        self.assertEqual(issues[2]['issue'].fields.description,
                          "Should be seen.")
-        self.assertEqual(issues[1].fields.issuetype.name, 'Bug')
-        self.assertEqual(issues[1].fields.project.key, self.project_a)
-        self.assertEqual(issues[1].fields.priority.name, 'Major')
-        self.assertEqual(len(issues), 2)
+        self.assertEqual(issues[2]['issue'].fields.issuetype.name, 'Bug')
+        self.assertEqual(issues[2]['issue'].fields.project.key, self.project_a)
+        self.assertEqual(issues[2]['issue'].fields.priority.name, 'Major')
+        self.assertEqual(issues[2]['error'], None)
+        self.assertEqual(len(issues), 3)
         for issue in issues:
-            issue.delete()
+            if issue['issue'] is not None:
+                issue['issue'].delete()
 
     @not_on_custom_jira_instance
     def test_create_issues_without_prefetch(self):
@@ -831,14 +837,14 @@ class IssueTests(unittest.TestCase):
                           issuetype={'name': 'Bug'})]
         issues = self.jira.create_issues(field_list, prefetch=False)
 
-        assert hasattr(issues[0], 'self')
-        assert hasattr(issues[0], 'raw')
-        assert hasattr(issues[1], 'self')
-        assert hasattr(issues[1], 'raw')
-        assert 'fields' not in issues[0].raw
-        assert 'fields' not in issues[1].raw
+        assert hasattr(issues[0]['issue'], 'self')
+        assert hasattr(issues[0]['issue'], 'raw')
+        assert hasattr(issues[1]['issue'], 'self')
+        assert hasattr(issues[1]['issue'], 'raw')
+        assert 'fields' not in issues[0]['issue'].raw
+        assert 'fields' not in issues[1]['issue'].raw
         for issue in issues:
-            issue.delete()
+            issue['issue'].delete()
 
     @not_on_custom_jira_instance
     def test_update_with_fieldargs(self):


### PR DESCRIPTION
Since Atlassian has added a bulk create to their REST API, this commit
enables the use of making multiple issues in one batch. It will log
errors for each unsuccessful issue and return the list of successfully
created issues.

Testing: py.test tests/tests.py