### PR TITLE
Commented out sleep that shouldn't be in Resource.update()

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -291,7 +291,7 @@ class Resource(object):
 
         # TODO(ssbarnea): compare loaded data in order to verify if resource was updated indeed
         # we had random test failures (probably) due to caching
-        time.sleep(4)
+        #time.sleep(4)
         self._load(self.self)
 
     def delete(self, params=None):


### PR DESCRIPTION
Updated to the last version today, and noticed that updates were taking significantly longer than before...because of this sleep. Can we remove it for the next release, please?