### PR TITLE
Fix for Issue #281: Include user key in group_members() results

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -803,7 +803,7 @@ class JIRA(object):
         result = {}
         for user in r['users']['items']:
             result[user['name']] = {'fullname': user['displayName'], 'email': user.get('emailAddress', 'hidden'),
-                                    'active': user['active']}
+                                    'active': user['active'], 'key': user['key']}
         return result
 
     def add_group(self, groupname):


### PR DESCRIPTION
Hello!  First-time contributor, so let me know if I'm doing something wrong in the PR.  😄 

This fixes Issue #281. I based this change on top of the last release tag, 1.0.10, but it looks like some of those changes hadn't yet been merged back into your develop branch. Do I need to rebase, or is merging those back OK?

Also: I tried running `make info clean flake8 test docs` locally, but some of the tests are failing even on the base 1.0.10 tag. This change didn't cause any *more* tests to fail, though. 😛

I've got a separate [branch] that also includes a fix to the `make package` target if you want that. I needed to build the package locally to test out my change.

[branch]: https://github.com/pycontribs/jira/compare/develop...NfNitLoop:add-user-key-more?expand=1