### PR TITLE
Increase support for Service Desk, and refactor to separate module

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -46,12 +46,12 @@ from six.moves.urllib.parse import urlparse
 from jira.exceptions import JIRAError
 from jira.resilientsession import raise_on_error
 from jira.resilientsession import ResilientSession
+
 # JIRA specific resources
 from jira.resources import Attachment
 from jira.resources import Board
 from jira.resources import Comment
 from jira.resources import Component
-from jira.resources import Customer
 from jira.resources import CustomFieldOption
 from jira.resources import Dashboard
 from jira.resources import Filter
@@ -63,12 +63,10 @@ from jira.resources import IssueType
 from jira.resources import Priority
 from jira.resources import Project
 from jira.resources import RemoteLink
-from jira.resources import RequestType
 from jira.resources import Resolution
 from jira.resources import Resource
 from jira.resources import Role
 from jira.resources import SecurityLevel
-from jira.resources import ServiceDesk
 from jira.resources import Sprint
 from jira.resources import Status
 from jira.resources import User
@@ -76,6 +74,8 @@ from jira.resources import Version
 from jira.resources import Votes
 from jira.resources import Watchers
 from jira.resources import Worklog
+
+from jira.service_desk import JiraServiceDesk
 
 from jira import __version__
 from jira.utils import CaseInsensitiveDict
@@ -358,6 +358,7 @@ class JIRA(object):
             if 'clauseNames' in f:
                 for name in f['clauseNames']:
                     self._fields[name] = f['id']
+        self.desk = JiraServiceDesk(self)
 
     def _check_update_(self):
         """Check if the current version of the library is outdated."""
@@ -397,7 +398,7 @@ class JIRA(object):
             return False
         return True
 
-    def _fetch_pages(self, item_type, items_key, request_path, startAt=0, maxResults=50, params=None, base=JIRA_BASE_URL):
+    def _fetch_pages(self, item_type, items_key, request_path, startAt=0, maxResults=50, params=None, headers=CaseInsensitiveDict(), base=JIRA_BASE_URL):
         """Fetch pages.
 
         :param item_type: Type of single item. ResultList of such items will be returned.
@@ -419,7 +420,7 @@ class JIRA(object):
             page_params['maxResults'] = maxResults
 
         try:
-            resource = self._get_json(request_path, params=page_params, base=base)
+            resource = self._get_json(request_path, params=page_params, headers=headers, base=base)
             next_items_page = [item_type(self._options, self._session, raw_issue_json) for raw_issue_json in
                                (resource[items_key] if items_key else resource)]
         except KeyError as e:
@@ -450,7 +451,7 @@ class JIRA(object):
                 while not is_last and (total is None or page_start < total) and len(next_items_page) == page_size:
                     page_params['startAt'] = page_start
                     page_params['maxResults'] = page_size
-                    resource = self._get_json(request_path, params=page_params, base=base)
+                    resource = self._get_json(request_path, params=page_params, headers=headers, base=base)
                     if resource:
                         try:
                             next_items_page = [item_type(self._options, self._session, raw_issue_json) for raw_issue_json in
@@ -979,95 +980,21 @@ class JIRA(object):
                                    'error': None, 'input_fields': fields})
         return issue_list
 
-    def supports_service_desk(self):
-        url = self._options['server'] + '/rest/servicedeskapi/info'
-        headers = {'X-ExperimentalApi': 'opt-in'}
-        try:
-            r = self._session.get(url, headers=headers)
-            return r.status_code == 200
-        except JIRAError:
-            return False
+    def delete_issue(self, id):
+        """Delete Issue.
 
-    def create_customer(self, email, displayName):
-        """Create a new customer and return an issue Resource for it."""
-        url = self._options['server'] + '/rest/servicedeskapi/customer'
-        headers = {'X-ExperimentalApi': 'opt-in'}
-        r = self._session.post(url, headers=headers, data=json.dumps({
-            'email': email,
-            'displayName': displayName
-        }))
-
-        raw_customer_json = json_loads(r)
-
-        if r.status_code != 201:
-            raise JIRAError(r.status_code, request=r)
-        return Customer(self._options, self._session, raw=raw_customer_json)
-
-    def service_desks(self):
-        """Get a list of ServiceDesk Resources from the server visible to the current authenticated user."""
-        url = self._options['server'] + '/rest/servicedeskapi/servicedesk'
-        headers = {'X-ExperimentalApi': 'opt-in'}
-        r_json = json_loads(self._session.get(url, headers=headers))
-        projects = [ServiceDesk(self._options, self._session, raw_project_json)
-                    for raw_project_json in r_json['values']]
-        return projects
-
-    def service_desk(self, id):
-        """Get a Service Desk Resource from the server.
-
-        :param id: ID or key of the Service Desk to get
+        :param id: issue Id or Key or Issue object.
+        :return: Boolean. Returns True on success.
         """
-        return self._find_for_resource(ServiceDesk, id)
 
-    def create_customer_request(self, fields=None, prefetch=True, **fieldargs):
-        """Create a new customer request and return an issue Resource for it.
+        if isinstance(id, Issue):
+            id = Issue.id
 
-        Each keyword argument (other than the predefined ones) is treated as a field name and the argument's value
-        is treated as the intended value for that field -- if the fields argument is used, all other keyword arguments
-        will be ignored.
-
-        By default, the client will immediately reload the issue Resource created by this method in order to return
-        a complete Issue object to the caller; this behavior can be controlled through the 'prefetch' argument.
-
-        JIRA projects may contain many different issue types. Some issue screens have different requirements for
-        fields in a new issue. This information is available through the 'createmeta' method. Further examples are
-        available here: https://developer.atlassian.com/display/JIRADEV/JIRA+REST+API+Example+-+Create+Issue
-
-        :param fields: a dict containing field names and the values to use. If present, all other keyword arguments
-            will be ignored
-        :param prefetch: whether to reload the created issue Resource so that all of its data is present in the value
-            returned from this method
-        """
-        data = fields
-
-        p = data['serviceDeskId']
-        service_desk = None
-
-        if isinstance(p, string_types) or isinstance(p, integer_types):
-            service_desk = self.service_desk(p)
-        elif isinstance(p, ServiceDesk):
-            service_desk = p
-
-        data['serviceDeskId'] = service_desk.id
-
-        p = data['requestTypeId']
-        if isinstance(p, integer_types):
-            data['requestTypeId'] = p
-        elif isinstance(p, string_types):
-            data['requestTypeId'] = self.request_type_by_name(
-                service_desk, p).id
-
-        url = self._options['server'] + '/rest/servicedeskapi/request'
-        headers = {'X-ExperimentalApi': 'opt-in'}
-        r = self._session.post(url, headers=headers, data=json.dumps(data))
-
-        raw_issue_json = json_loads(r)
-        if 'issueKey' not in raw_issue_json:
-            raise JIRAError(r.status_code, request=r)
-        if prefetch:
-            return self.issue(raw_issue_json['issueKey'])
-        else:
-            return Issue(self._options, self._session, raw=raw_issue_json)
+        url = self._options['server'] + '/rest/api/2/issue/%s' % id
+        result = self._session.delete(url)
+        if result.status_code != 204:
+            raise JIRAError(result.status_code, request=result)
+        return True
 
     def createmeta(self, projectKeys=None, projectIds=[], issuetypeIds=None, issuetypeNames=None, expand=None):
         """Get the metadata required to create issues, optionally filtered by projects and issue types.
@@ -1613,27 +1540,6 @@ class JIRA(object):
         except IndexError:
             raise KeyError("Issue type '%s' is unknown." % name)
         return issue_type
-
-    def request_types(self, service_desk):
-        if hasattr(service_desk, 'id'):
-            service_desk = service_desk.id
-        url = (self._options['server'] +
-               '/rest/servicedeskapi/servicedesk/%s/requesttype'
-               % service_desk)
-        headers = {'X-ExperimentalApi': 'opt-in'}
-        r_json = json_loads(self._session.get(url, headers=headers))
-        request_types = [
-            RequestType(self._options, self._session, raw_type_json)
-            for raw_type_json in r_json['values']]
-        return request_types
-
-    def request_type_by_name(self, service_desk, name):
-        request_types = self.request_types(service_desk)
-        try:
-            request_type = [rt for rt in request_types if rt.name == name][0]
-        except IndexError:
-            raise KeyError("Request type '%s' is unknown." % name)
-        return request_type
 
     # User permissions
 
@@ -2315,9 +2221,9 @@ class JIRA(object):
         options.update({'path': path})
         return base.format(**options)
 
-    def _get_json(self, path, params=None, base=JIRA_BASE_URL):
+    def _get_json(self, path, params=None, headers=CaseInsensitiveDict(), base=JIRA_BASE_URL):
         url = self._get_url(path, base)
-        r = self._session.get(url, params=params)
+        r = self._session.get(url, params=params, headers=headers)
         try:
             r_json = json_loads(r)
         except ValueError as e:
@@ -2783,7 +2689,7 @@ class JIRA(object):
         return False
 
     def add_user(self, username, email, directoryId=1, password=None,
-                 fullname=None, notify=False, active=True, ignore_existing=False):
+                 fullname=None, notify=False, active=True, application_keys=None, ignore_existing=False):
         """Create a new JIRA user.
 
         :param username: the username of the new user
@@ -2818,6 +2724,8 @@ class JIRA(object):
             x['password'] = password
         if notify:
             x['notification'] = 'True'
+        if application_keys is not None:
+            x['applicationKeys'] = application_keys
 
         payload = json.dumps(x)
         try:

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -50,9 +50,15 @@ __all__ = (
     'User',
     'CustomFieldOption',
     'RemoteLink',
+    # Service Desk
     'Customer',
     'ServiceDesk',
+    'ServiceDeskInfo',
+    'Organization',
+    'RequestTemporaryAttachment',
+    'RequestAttachment',
     'RequestType',
+    'Request',
 )
 
 logging.getLogger('jira').addHandler(NullHandler())
@@ -187,7 +193,7 @@ class Resource(object):
     #     self._parse_raw(raw_pickled)
     #
 
-    def find(self, id, params=None):
+    def find(self, id, params=None, headers=CaseInsensitiveDict()):
 
         if params is None:
             params = {}
@@ -197,7 +203,7 @@ class Resource(object):
         else:
             path = self._resource.format(id)
         url = self._get_url(path)
-        self._load(url, params=params)
+        self._load(url, params=params, headers=headers)
 
     def _get_url(self, path):
         options = self._options.copy()
@@ -848,13 +854,76 @@ class ServiceDesk(Resource):
             self._parse_raw(raw)
 
 
-class RequestType(Resource):
-    """A Service Desk Request Type."""
+class ServiceDeskInfo(Resource):
+    """The JIRA Service Desk application."""
 
     def __init__(self, options, session, raw=None):
-        Resource.__init__(self, 'servicedesk/{0}/requesttype', options, session, '{server}/rest/servicedeskapi/{path}')
+        Resource.__init__(self, 'info', options, session, '{server}/rest/servicedeskapi/{path}')
         if raw:
             self._parse_raw(raw)
+
+
+class Organization(Resource):
+    """A Service Desk Organization."""
+
+    def __init__(self, options, session, raw=None):
+        Resource.__init__(self, 'organization/{0}', options, session, '{server}/rest/servicedeskapi/{path}')
+        if raw:
+            self._parse_raw(raw)
+
+
+class RequestTemporaryAttachment(Resource):
+    """A Service Desk temporary attachment."""
+
+    def __init__(self, options, session, raw=None):
+        Resource.__init__(self, 'request/{0}/attachment', options, session, '{server}/rest/servicedeskapi/{path}')
+        if raw:
+            self._parse_raw(raw)
+
+
+class RequestAttachment(Resource):
+    """A Service Desk attachment."""
+
+    def __init__(self, options, session, raw=None):
+        Resource.__init__(self, 'servicedesk/{0}/attachTemporaryFile', options, session,
+                          '{server}/rest/servicedeskapi/{path}')
+        if raw:
+            self._parse_raw(raw)
+
+
+class RequestType(Resource):
+    """A Service Desk RequestType."""
+
+    def __init__(self, options, session, raw=None):
+        Resource.__init__(self, 'servicedesk/{0}/requesttype/{1}', options, session,
+                          '{server}/rest/servicedeskapi/{path}')
+        if raw:
+            self._parse_raw(raw)
+
+
+class Request(Resource):
+    """A JIRA Service Desk customer request (issue)."""
+
+    def __init__(self, options, session, raw=None):
+        Resource.__init__(self, 'request/{0}', options, session,
+                          '{server}/rest/servicedeskapi/{path}')
+        if raw:
+            self._parse_raw(raw)
+
+    def _parse_raw(self, raw):
+        self.raw = raw
+        if not raw:
+            raise NotImplementedError("We cannot instantiate empty resources: %s" % raw)
+
+        raw['id'] = raw['issueId']
+        raw['key'] = raw['issueKey']
+        raw['fields'] = {}
+        for val in raw['requestFieldValues']:
+            raw['fields'][val['fieldId']] = val['value']
+        del raw['issueId']
+        del raw['issueKey']
+        del raw['requestFieldValues']
+        dict2resource(raw, self, self._options, self._session)
 
 # Utilities
 

--- a/jira/service_desk.py
+++ b/jira/service_desk.py
@@ -1,0 +1,510 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from __future__ import print_function
+
+"""
+This module implements a friendly (well, friendlier) interface between the raw JSON
+responses from JIRA ServiceDesk and the Resource/dict abstractions provided by this library
+"""
+
+import json
+import logging
+import os
+try:  # Python 2.7+
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+
+        def emit(self, record):
+            pass
+import warnings
+
+from jira.exceptions import JIRAError
+
+from jira.resources import Comment
+from jira.resources import Customer
+from jira.resources import Issue
+from jira.resources import Organization
+from jira.resources import Request
+from jira.resources import RequestAttachment
+from jira.resources import RequestTemporaryAttachment
+from jira.resources import RequestType
+from jira.resources import ServiceDesk
+from jira.resources import ServiceDeskInfo
+from jira.resources import User
+
+from jira.utils import CaseInsensitiveDict
+from jira.utils import json_loads
+
+from six import integer_types
+from six import string_types
+
+try:
+    # noinspection PyUnresolvedReferences
+    from requests_toolbelt import MultipartEncoder
+except ImportError:
+    pass
+
+logging.getLogger('jira').addHandler(NullHandler())
+
+
+class JiraServiceDesk(object):
+    """Service desk related functionality"""
+
+    def __init__(self, jira):
+        self._jira = jira
+
+    def supports_service_desk(self):
+        url = self._options['server'] + '/rest/servicedeskapi/info'
+        headers = {'X-ExperimentalApi': 'opt-in'}
+        try:
+            r = self._jira._session.get(url, headers=headers)
+            return r.status_code == 200
+        except JIRAError:
+            return False
+
+    def create_customer(self, email, fullname):
+        """Creates a customer that is not associated with a service desk project.
+
+        :param email: email of the user (customer) to create
+        :param fullname: user full name
+        :return Customer
+        """
+        url = self._jira._options['server'] + '/rest/servicedeskapi/customer'
+        headers = {'X-ExperimentalApi': 'opt-in'}
+        result = self._jira._session.post(url, headers=headers, data=json.dumps({'email': email, 'fullName': fullname}))
+        if result.status_code != 201:
+            raise JIRAError(result.status_code, request=result)
+        return Customer(self._jira._options, self._jira._session, raw=json_loads(result))
+
+    def servicedesk_info(self):
+        """Returns runtime information about JIRA Service Desk.
+
+        :return ServiceDeskInfo
+        """
+        url = self._jira._options['server'] + '/rest/servicedeskapi/info'
+        result = self._jira._session.get(url)
+        if result.status_code != 200:
+            raise JIRAError(result.status_code, request=result)
+        return ServiceDeskInfo(self._jira._options, self._jira._session, raw=json_loads(result))
+
+    def create_organization(self, name):
+        """Creates an organization
+
+        :param name: name of the organization to create
+        :return Organization
+        """
+        url = self._jira._options['server'] + '/rest/servicedeskapi/organization'
+        headers = CaseInsensitiveDict({'X-ExperimentalApi': 'opt-in'})
+        result = self._jira._session.post(url, headers=headers, data=json.dumps({'name': name}))
+        if result.status_code != 201:
+            raise JIRAError(result.status_code, request=result)
+        return Organization(self._jira._options, self._jira._session, raw=json_loads(result))
+
+    def delete_organization(self, organization_id):
+        """Delete organization
+
+        :param organization_id: ID of the organization to delete
+        :return boolean
+        """
+        url = self._jira._options['server'] + '/rest/servicedeskapi/organization/%i' % int(organization_id)
+        headers = CaseInsensitiveDict({'X-ExperimentalApi': 'opt-in'})
+        result = self._jira._session.delete(url, headers=headers)
+        if result.status_code != 204:
+            raise JIRAError(result.status_code, request=result)
+        return True
+
+    def organization(self, id):
+        """Get an organization for a given organization ID
+
+        :param id: ID of the organization to get
+        :return Organization
+        """
+        headers = CaseInsensitiveDict({'X-ExperimentalApi': 'opt-in'})
+        organization = Organization(self._jira._options, self._jira._session)
+        organization.find(id, headers=headers)
+        return organization
+
+    def organizations(self, start=0, limit=50):
+        """Returns a list of organizations in the JIRA instance.
+
+        If the user is not an agent, the resource returns a list of organizations the user is a member of.
+
+        :param start: index of the first organization to return.
+        :param limit: maximum number of organizations to return. If limit evaluates as False, it will try to get all
+        items in batches.
+        :return list of Organization resources
+        """
+        params = {'start': start, 'limit': limit}
+        headers = CaseInsensitiveDict({'X-ExperimentalApi': 'opt-in'})
+        base = self._jira._options['server'] + '/rest/servicedeskapi/organization'
+        return self._jira._fetch_pages(Organization,
+                                       'values',
+                                       'organization',
+                                       params=params,
+                                       headers=headers,
+                                       base=base)
+
+    def add_users_to_organization(self, organization_id, usernames):
+        """Add users to organization
+
+        :param organization_id: organization ID
+        :param usernames: list with usernames
+        :return boolean
+        """
+        url = self._jira._options['server'] + '/rest/servicedeskapi/organization/%i/user' % int(organization_id)
+        headers = CaseInsensitiveDict({'X-ExperimentalApi': 'opt-in'})
+        params = {}
+        if isinstance(usernames, list):
+            params['usernames'] = usernames
+        else:
+            params['usernames'] = [usernames]
+        result = self._jira._session.post(url, headers=headers, data=json.dumps(params))
+        if result.status_code != 204:
+            raise JIRAError(result.status_code, request=result)
+        return True
+
+    def remove_users_from_organization(self, organization_id, usernames):
+        """Remove users from organization
+
+        :param organization_id: organization ID
+        :param usernames: list with usernames
+        :return boolean
+        """
+        url = self._jira._options['server'] + '/rest/servicedeskapi/organization/%i/user' % int(organization_id)
+        headers = CaseInsensitiveDict({'X-ExperimentalApi': 'opt-in'})
+        params = {}
+        if isinstance(usernames, list):
+            params['usernames'] = usernames
+        else:
+            params['usernames'] = [usernames]
+        result = self._jira._session.delete(url, headers=headers, data=json.dumps(params))
+        if result.status_code != 204:
+            raise JIRAError(result.status_code, request=result)
+        return True
+
+    def get_users_from_organization(self, organization_id, start=0, limit=50):
+        """Returns a list of users in organization.
+
+        :param organization_id: organization ID
+        :param start: index of the first user to return.
+        :param limit: maximum number of organizations to return.
+                      If limit evaluates as False, it will try to get all items in batches.
+        """
+        params = {'start': start, 'limit': limit}
+        headers = CaseInsensitiveDict({'X-ExperimentalApi': 'opt-in'})
+        base = self._jira._options['server'] + '/rest/servicedeskapi/organization/%i/user' % int(organization_id)
+        return self._jira._fetch_pages(User,
+                                       'values',
+                                       None,
+                                       params=params,
+                                       headers=headers,
+                                       base=base)
+
+    def service_desks(self, start=0, limit=50):
+        """Returns a list of service desks
+
+        :param start: index of the first service desk to return.
+        :param limit: maximum number of service desks to return.
+                      If limit evaluates as False, it will try to get all items in batches.
+        """
+        params = {'start': start, 'limit': limit}
+        base = self._jira._options['server'] + '/rest/servicedeskapi/servicedesk'
+        return self._jira._fetch_pages(ServiceDesk,
+                                       'values',
+                                       None,
+                                       params=params,
+                                       base=base)
+
+    def service_desk(self, id):
+        """Returns the service desk for a given service desk Id.
+
+        :param id: servicedesk ID
+        :return: Servicedesk
+        """
+        service_desk = ServiceDesk(self._jira._options, self._jira._session)
+        service_desk.find(id)
+        return service_desk
+
+    def create_customer_request(self, fields=None, prefetch=True, **fieldargs):
+        """Create a new customer request and return an issue Resource for it.
+
+        Deprecated method. Use "create_request" instead.
+
+        Each keyword argument (other than the predefined ones) is treated as a field name and the argument's value
+        is treated as the intended value for that field -- if the fields argument is used, all other keyword arguments
+        will be ignored.
+
+        By default, the client will immediately reload the issue Resource created by this method in order to return
+        a complete Issue object to the caller; this behavior can be controlled through the 'prefetch' argument.
+
+        JIRA projects may contain many different issue types. Some issue screens have different requirements for
+        fields in a new issue. This information is available through the 'createmeta' method. Further examples are
+        available here: https://developer.atlassian.com/display/JIRADEV/JIRA+REST+API+Example+-+Create+Issue
+
+        :param fields: a dict containing field names and the values to use. If present, all other keyword arguments
+            will be ignored
+        :param prefetch: whether to reload the created issue Resource so that all of its data is present in the value
+            returned from this method
+        """
+
+        warnings.warn("Use 'create_request' method instead", DeprecationWarning)
+
+        if isinstance(fields['serviceDeskId'], ServiceDesk):
+            fields['serviceDeskId'] = fields['serviceDeskId'].id
+
+        if isinstance(fields['requestTypeId'], string_types):
+            fields['requestTypeId'] = self.request_type_by_name(fields['serviceDeskId'], fields['requestTypeId']).id
+
+        url = self._jira._options['server'] + '/rest/servicedeskapi/request'
+        headers = CaseInsensitiveDict({'X-ExperimentalApi': 'opt-in'})
+        result = self._jira._session.post(url, headers=headers, data=json.dumps(fields))
+
+        raw_issue_json = json_loads(result)
+        if 'issueKey' not in raw_issue_json:
+            raise JIRAError(result.status_code, request=result)
+        if prefetch:
+            return self._jira.issue(raw_issue_json['issueKey'])
+        else:
+            return Issue(self._jira._options, self._jira._session, raw=raw_issue_json)
+
+    def create_request(self, fields=None, prefetch=True, **fieldargs):
+        """Create a new customer request and return an issue Resource for it.
+
+        Each keyword argument (other than the predefined ones) is treated as a field name and the argument's value
+        is treated as the intended value for that field -- if the fields argument is used, all other keyword arguments
+        will be ignored.
+
+        By default, the client will immediately reload the issue Resource created by this method in order to return
+        a complete Issue object to the caller; this behavior can be controlled through the 'prefetch' argument.
+
+        JIRA projects may contain many different issue types. Some issue screens have different requirements for
+        fields in a new issue. This information is available through the 'createmeta' method. Further examples are
+        available here: https://developer.atlassian.com/display/JIRADEV/JIRA+REST+API+Example+-+Create+Issue
+
+        :param fields: a dict containing field names and the values to use. If present, all other keyword arguments
+            will be ignored
+        :param prefetch: whether to reload the created issue Resource so that all of its data is present in the value
+            returned from this method
+        :return: Request
+        """
+
+        if isinstance(fields['serviceDeskId'], ServiceDesk):
+            fields['serviceDeskId'] = fields['serviceDeskId'].id
+
+        if isinstance(fields['requestTypeId'], string_types):
+            fields['requestTypeId'] = self.request_type_by_name(fields['serviceDeskId'], fields['requestTypeId']).id
+
+        url = self._jira._options['server'] + '/rest/servicedeskapi/request'
+        headers = CaseInsensitiveDict({'X-ExperimentalApi': 'opt-in'})
+        result = self._jira._session.post(url, headers=headers, data=json.dumps(fields))
+
+        raw_issue_json = json_loads(result)
+        if 'issueId' not in raw_issue_json:
+            raise JIRAError(result.status_code, request=result)
+        if prefetch:
+            return self.request(raw_issue_json['issueId'])
+        else:
+            return Request(self._jira._options, self._jira._session, raw=raw_issue_json)
+
+    def request(self, id, expand=None):
+        """Get an issue Resource from the server.
+
+        :param id: ID or key of the customer request (issue) to get
+        :param expand: This is a multi-value parameter indicating which properties of the customer request to expand:
+            serviceDesk - Return additional details for each service desk in the response.
+            requestType - Return additional details for each request type in the response.
+            participant - Return the participant details, if any, for each customer request in the response.
+            sla - Return the SLA information on the given request.
+            status - Return the status transitions, in chronological order, for each customer request in the response.
+        :return: list of Request resources
+        """
+        params = {}
+        if expand is not None:
+            params['expand'] = expand
+
+        request = Request(self._jira._options, self._jira._session)
+        request.find(id, params=params)
+        return request
+
+    def my_customer_requests(self,
+                             search_term=None,
+                             request_ownership=None,
+                             request_status=None,
+                             servicedesk_id=None,
+                             request_type_id=None,
+                             expand=None,
+                             start=0, limit=50):
+        """Returns all customer requests for the user that is executing the query.
+
+        :param search_term: (string) Filters results to customer requests where the issue summary matches the
+        searchTerm. You can use wildcards in the searchTerm.
+        :param request_ownership: (string) Filters results to customer requests where the user is the creator
+        and/or participant:
+            - OWNED_REQUESTS - Only return customer requests where the user is the creator.
+            - PARTICIPATED_REQUESTS - Only return customer requests where the user is a participant.
+            - ALL_REQUESTS - Return customer requests where the user is the creator or a participant.
+        :param request_status: (string) Filters results to customer requests that are resolved, unresolved,
+        or either of the two:
+            - CLOSED_REQUESTS - Only return customer requests that are resolved.
+            - OPEN_REQUESTS - Only return customer requests that are unresolved.
+            - ALL_REQUESTS - Returns customer requests that are either resolved or unresolved.
+        :param servicedesk_id: (int) Filters results to customer requests from a specific service desk.
+        :param request_type_id: (int) Filters results to customer requests of a specific request type.
+        You must also specify the serviceDeskID for the service desk that the request type belongs to.
+        :param expand: (string) This is a multi-value parameter indicating which properties of the customer request
+        to expand:
+            - serviceDesk - Return additional details for each service desk in the response.
+            - requestType - Return additional details for each request type in the response.
+            - participant - Return the participant details, if any, for each customer request in the response.
+            - sla - Return the SLA information on the given request.
+            - status - Return the status transitions, in chronological order, for each customer request in the response.
+        :param start: (int) The starting index of the returned objects. Base index: 0.
+        :param limit: (int) The maximum number of items to return per page. Default: 50.
+        :return: list of Request resources
+        """
+        params = {'start': start, 'limit': limit}
+        if isinstance(search_term, string_types):
+            params['searchTerm'] = search_term
+        if isinstance(request_ownership, string_types):
+            params['requestOwnership'] = request_ownership
+        if isinstance(request_status, string_types):
+            params['requestStatus'] = request_status
+        if isinstance(servicedesk_id, integer_types):
+            params['serviceDeskId'] = servicedesk_id
+        if isinstance(request_type_id, integer_types):
+            params['requestTypeId'] = request_type_id
+        if isinstance(expand, string_types):
+            params['expand'] = expand
+        base = self._jira._options['server'] + '/rest/servicedeskapi/request'
+        return self._jira._fetch_pages(Request,
+                                       'values',
+                                       None,
+                                       params=params,
+                                       base=base)
+
+    def request_comments(self, issue, public=None, internal=None, start=0, limit=50):
+        """Returns all comments on a customer request, for a given request Id/key.
+
+        :param issue: ID or key of the customer request (issue)
+        :param public: Specifies whether to return public comments or not. Default: True.
+        :param internal: Specifies whether to return internal comments or not. Default: true.
+        :param start: (int) The starting index of the returned objects. Base index: 0.
+        :param limit: (int) The maximum number of items to return per page. Default: 50.
+        :return:
+        """
+        params = {'start': start, 'limit': limit}
+        if isinstance(public, bool):
+            params['public'] = public
+        if isinstance(internal, bool):
+            params['internal'] = internal
+        base = self._jira._options['server'] + '/rest/servicedeskapi/request/%s/comment' % str(issue)
+        return self._jira._fetch_pages(Comment,
+                                       'values',
+                                       None,
+                                       params=params,
+                                       base=base)
+
+    def servicedesk_attachment(self, request_id, attachment, is_public=True, comment=None):
+        """Add attachment (from RequestTemporaryAttachment) to request
+
+        :param request_id: request ID or KEY
+        :param attachment: RequestTemporaryAttachment
+        :param is_public: public or internal comment
+        :param comment: comment text
+        :return: RequestAttachment
+        """
+        url = self._jira._options['server'] + '/rest/servicedeskapi/request/%s/attachment' % str(request_id)
+        headers = CaseInsensitiveDict({'X-ExperimentalApi': 'opt-in'})
+        params = {
+            'temporaryAttachmentIds': [attachment.temporaryAttachments[0].temporaryAttachmentId],
+            'public': is_public,
+        }
+        if comment is not None:
+            params['additionalComment'] = {
+                'body': comment
+            }
+
+        result = self._jira._session.post(url, headers=headers, data=json.dumps(params))
+
+        raw_json = json_loads(result)
+        if result.status_code != 201:
+            raise JIRAError(result.status_code, request=result)
+        return RequestAttachment(self._jira._options, self._jira._session, raw=raw_json)
+
+    def attach_temporary_file(self, servicedesk_id, attachment, filename=None):
+        """Create temporary attachment file
+
+        :param servicedesk_id: servicedesk ID
+        :param attachment: file
+        :param filename: optional file name
+        :return: RequestTemporaryAttachment
+        """
+        if isinstance(attachment, string_types):
+            attachment = open(attachment, "rb")
+        elif hasattr(attachment, 'read') and hasattr(attachment, 'mode') and attachment.mode != 'rb':
+            logging.warning("%s was not opened in 'rb' mode, attaching file may fail." % attachment.name)
+
+        url = self._jira._options['server'] + '/rest/servicedeskapi/servicedesk/%i/attachTemporaryFile' % int(servicedesk_id)
+
+        fname = filename
+        if not fname:
+            fname = os.path.basename(attachment.name)
+
+        def file_stream():
+            return MultipartEncoder(fields={'file': (fname, attachment, 'application/octet-stream')})
+        m = file_stream()
+
+        headers = CaseInsensitiveDict({
+            'content-type': m.content_type,
+            'X-Atlassian-Token': 'nocheck',
+            'X-ExperimentalApi': 'opt-in'
+        })
+        result = self._jira._session.post(url, data=m, headers=headers, retry_data=file_stream)
+
+        if result.status_code != 201:
+            raise JIRAError(result.status_code, request=result)
+        return RequestTemporaryAttachment(self._jira._options, self._jira._session, raw=json_loads(result))
+
+    def request_types(self, servicedesk_id, start=0, limit=50):
+        """Returns all request types from a service desk, for a given service desk Id.
+
+        :param service_desk: servicedesk ID or servicedesk object
+        :param start: index of the first user to return.
+        :param limit: maximum number of organizations to return.
+                      If limit evaluates as False, it will try to get all items in batches.
+        :return: list of RequestType resources
+        """
+        params = {'start': start, 'limit': limit}
+        base = self._jira._options['server'] + '/rest/servicedeskapi/servicedesk/%i/requesttype' % int(servicedesk_id)
+        return self._jira._fetch_pages(RequestType,
+                                       'values',
+                                       None,
+                                       params=params,
+                                       base=base)
+
+    def request_type(self, servicedesk_id, id):
+        """Returns a request type for a given request type Id.
+
+        :param servicedesk_id: servicedesk ID
+        :param id: request type ID
+        :return: RequestType
+        """
+        request_type = RequestType(self._jira._options, self._jira._session)
+        request_type.find((servicedesk_id, id))
+        return request_type
+
+    def request_type_by_name(self, servicedesk_id, name):
+        """Return request type id by it name
+
+        :param servicedesk_id: servicedesk ID
+        :param name: request type name
+        :return: RequestType
+        """
+        request_types = self.request_types(servicedesk_id)
+        try:
+            request_type = [rt for rt in request_types if rt.name == name][0]
+        except IndexError:
+            raise KeyError("Request type '%s' is unknown." % name)
+        return request_type

--- a/tests/jira_test_manager.py
+++ b/tests/jira_test_manager.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python
+from __future__ import print_function
+import getpass
+import hashlib
+import logging
+import os
+import re
+import sys
+from time import sleep
+import traceback
+
+import py
+from tenacity import retry
+from tenacity import stop_after_attempt
+
+from jira import JIRA  # noqa
+
+
+OAUTH = False
+CONSUMER_KEY = 'oauth-consumer'
+KEY_CERT_FILE = '/home/bspeakmon/src/atlassian-oauth-examples/rsa.pem'
+KEY_CERT_DATA = None
+try:
+    with open(KEY_CERT_FILE, 'r') as cert:
+        KEY_CERT_DATA = cert.read()
+    OAUTH = True
+except Exception:
+    pass
+
+
+def hashify(some_string, max_len=8):
+    return hashlib.md5(some_string.encode('utf-8')).hexdigest()[:8].upper()
+
+
+def get_unique_project_name():
+    jid = ""
+    user = re.sub("[^A-Z_]", "", getpass.getuser().upper())
+
+    if user == 'TRAVIS' and 'TRAVIS_JOB_NUMBER' in os.environ:
+        # please note that user underline (_) is not suppored by
+        # jira even if is documented as supported.
+        jid = 'T' + hashify(user + os.environ['TRAVIS_JOB_NUMBER'])
+    else:
+        identifier = user + \
+            chr(ord('A') + sys.version_info[0]) + \
+            chr(ord('A') + sys.version_info[1])
+        jid = 'Z' + hashify(identifier)
+    return jid
+
+
+class Singleton(type):
+
+    def __init__(cls, name, bases, dict):
+        super(Singleton, cls).__init__(name, bases, dict)
+        cls.instance = None
+
+    def __call__(cls, *args, **kw):
+        if cls.instance is None:
+            cls.instance = super(Singleton, cls).__call__(*args, **kw)
+        return cls.instance
+
+
+class JiraTestManager(object):
+    """Used to instantiate and populate the JIRA instance with data used by the unit tests.
+
+    Attributes:
+        CI_JIRA_ADMIN (str): Admin user account name.
+        CI_JIRA_USER (str): Limited user account name.
+        max_retries (int): number of retries to perform for recoverable HTTP errors.
+    """
+
+    # __metaclass__ = Singleton
+
+    # __instance = None
+    #
+    # Singleton implementation
+    # def __new__(cls, *args, **kwargs):
+    #     if not cls.__instance:
+    #         cls.__instance = super(JiraTestManager, cls).__new__(
+    #                             cls, *args, **kwargs)
+    #     return cls.__instance
+
+    #  Implementing some kind of Singleton, to prevent test initialization
+    # http://stackoverflow.com/questions/31875/is-there-a-simple-elegant-way-to-define-singletons-in-python/33201#33201
+    __shared_state = {}
+
+    @retry(stop=stop_after_attempt(2))
+    def __init__(self):
+        self.__dict__ = self.__shared_state
+
+        if not self.__dict__:
+            self.initialized = 0
+
+            try:
+
+                if 'CI_JIRA_URL' in os.environ:
+                    self.CI_JIRA_URL = os.environ['CI_JIRA_URL']
+                    self.max_retries = 5
+                else:
+                    self.CI_JIRA_URL = "https://pycontribs.atlassian.net"
+                    self.max_retries = 5
+
+                if 'CI_JIRA_ADMIN' in os.environ:
+                    self.CI_JIRA_ADMIN = os.environ['CI_JIRA_ADMIN']
+                else:
+                    self.CI_JIRA_ADMIN = 'ci-admin'
+
+                if 'CI_JIRA_ADMIN_PASSWORD' in os.environ:
+                    self.CI_JIRA_ADMIN_PASSWORD = os.environ[
+                        'CI_JIRA_ADMIN_PASSWORD']
+                else:
+                    self.CI_JIRA_ADMIN_PASSWORD = 'sd4s3dgec5fhg4tfsds3434'
+
+                if 'CI_JIRA_USER' in os.environ:
+                    self.CI_JIRA_USER = os.environ['CI_JIRA_USER']
+                else:
+                    self.CI_JIRA_USER = 'ci-user'
+
+                if 'CI_JIRA_USER_PASSWORD' in os.environ:
+                    self.CI_JIRA_USER_PASSWORD = os.environ[
+                        'CI_JIRA_USER_PASSWORD']
+                else:
+                    self.CI_JIRA_USER_PASSWORD = 'sd4s3dgec5fhg4tfsds3434'
+
+                self.CI_JIRA_ISSUE = os.environ.get('CI_JIRA_ISSUE', 'Bug')
+
+                if OAUTH:
+                    self.jira_admin = JIRA(oauth={
+                        'access_token': 'hTxcwsbUQiFuFALf7KZHDaeAJIo3tLUK',
+                        'access_token_secret': 'aNCLQFP3ORNU6WY7HQISbqbhf0UudDAf',
+                        'consumer_key': CONSUMER_KEY,
+                        'key_cert': KEY_CERT_DATA})
+                else:
+                    if self.CI_JIRA_ADMIN:
+                        self.jira_admin = JIRA(self.CI_JIRA_URL, basic_auth=(self.CI_JIRA_ADMIN,
+                                                                             self.CI_JIRA_ADMIN_PASSWORD),
+                                               logging=False, validate=True, max_retries=self.max_retries)
+                    else:
+                        self.jira_admin = JIRA(self.CI_JIRA_URL, validate=True,
+                                               logging=False, max_retries=self.max_retries)
+                if self.jira_admin.current_user() != self.CI_JIRA_ADMIN:
+                    # self.jira_admin.
+                    self.initialized = 1
+                    sys.exit(3)
+
+                if OAUTH:
+                    self.jira_sysadmin = JIRA(oauth={
+                        'access_token': '4ul1ETSFo7ybbIxAxzyRal39cTrwEGFv',
+                        'access_token_secret':
+                            'K83jBZnjnuVRcfjBflrKyThJa0KSjSs2',
+                        'consumer_key': CONSUMER_KEY,
+                        'key_cert': KEY_CERT_DATA}, logging=False, max_retries=self.max_retries)
+                else:
+                    if self.CI_JIRA_ADMIN:
+                        self.jira_sysadmin = JIRA(self.CI_JIRA_URL,
+                                                  basic_auth=(self.CI_JIRA_ADMIN,
+                                                              self.CI_JIRA_ADMIN_PASSWORD),
+                                                  logging=False, validate=True, max_retries=self.max_retries)
+                    else:
+                        self.jira_sysadmin = JIRA(self.CI_JIRA_URL,
+                                                  logging=False, max_retries=self.max_retries)
+
+                if OAUTH:
+                    self.jira_normal = JIRA(oauth={
+                        'access_token': 'ZVDgYDyIQqJY8IFlQ446jZaURIz5ECiB',
+                        'access_token_secret':
+                            '5WbLBybPDg1lqqyFjyXSCsCtAWTwz1eD',
+                        'consumer_key': CONSUMER_KEY,
+                        'key_cert': KEY_CERT_DATA})
+                else:
+                    if self.CI_JIRA_ADMIN:
+                        self.jira_normal = JIRA(self.CI_JIRA_URL,
+                                                basic_auth=(self.CI_JIRA_USER,
+                                                            self.CI_JIRA_USER_PASSWORD),
+                                                validate=True, logging=False, max_retries=self.max_retries)
+                    else:
+                        self.jira_normal = JIRA(self.CI_JIRA_URL,
+                                                validate=True, logging=False, max_retries=self.max_retries)
+
+                # now we need some data to start with for the tests
+
+                # jira project key is max 10 chars, no letter.
+                # [0] always "Z"
+                # [1-6] username running the tests (hope we will not collide)
+                # [7-8] python version A=0, B=1,..
+                # [9] A,B -- we may need more than one project
+
+                """ `jid` is important for avoiding concurency problems when
+                executing tests in parallel as we have only one test instance.
+
+                jid length must be less than 9 characters because we may append
+                another one and the JIRA Project key length limit is 10.
+
+                Tests run in parallel:
+                * git branches master or developer, git pr or developers running
+                  tests outside Travis
+                * Travis is using "Travis" username
+
+                https://docs.travis-ci.com/user/environment-variables/
+                """
+
+                self.jid = get_unique_project_name()
+
+                self.project_a = self.jid + 'A'  # old XSS
+                self.project_a_name = "Test user=%s key=%s A" \
+                                      % (getpass.getuser(), self.project_a)
+                self.project_b = self.jid + 'B'  # old BULK
+                self.project_b_name = "Test user=%s key=%s B" \
+                                      % (getpass.getuser(), self.project_b)
+                self.project_c = self.jid + 'C'  # For Service Desk
+                self.project_c_name = "Test user=%s key=%s C" \
+                                      % (getpass.getuser(), self.project_c)
+
+                # TODO(ssbarnea): find a way to prevent SecurityTokenMissing for On Demand
+                # https://jira.atlassian.com/browse/JRA-39153
+                try:
+                    self.jira_admin.project(self.project_a)
+                except Exception as e:
+                    logging.warning(e)
+                    pass
+                else:
+                    try:
+                        self.jira_admin.delete_project(self.project_a)
+                    except Exception as e:
+                        pass
+
+                try:
+                    self.jira_admin.project(self.project_b)
+                except Exception as e:
+                    logging.warning(e)
+                    pass
+                else:
+                    try:
+                        self.jira_admin.delete_project(self.project_b)
+                    except Exception as e:
+                        pass
+
+                try:
+                    self.jira_admin.project(self.project_c)
+                except Exception as e:
+                    logging.warning(e)
+                    pass
+                else:
+                    try:
+                        self.jira_admin.delete_project(self.project_c)
+                    except Exception as e:
+                        pass
+
+                # wait for the project to be deleted
+                for i in range(1, 20):
+                    try:
+                        self.jira_admin.project(self.project_b)
+                    except Exception as e:
+                        break
+                    sleep(2)
+
+                try:
+                    self.jira_admin.create_project(self.project_a,
+                                                   self.project_a_name)
+                except Exception:
+                    # we care only for the project to exist
+                    pass
+                self.project_a_id = self.jira_admin.project(self.project_a).id
+                # except Exception as e:
+                #    logging.warning("Got %s" % e)
+                # try:
+                # assert self.jira_admin.create_project(self.project_b,
+                # self.project_b_name) is  True, "Failed to create %s" %
+                # self.project_b
+
+                try:
+                    self.jira_admin.create_project(self.project_b,
+                                                   self.project_b_name)
+                except Exception:
+                    # we care only for the project to exist
+                    pass
+
+                # Create project for Jira Service Desk
+                try:
+                    self.jira_admin.create_project(self.project_c,
+                                                   self.project_c_name,
+                                                   template_name='IT Service Desk')
+                except Exception:
+                    pass
+
+                sleep(1)  # keep it here as often JIRA will report the
+                # project as missing even after is created
+                self.project_b_issue1_obj = self.jira_admin.create_issue(project=self.project_b,
+                                                                         summary='issue 1 from %s'
+                                                                                 % self.project_b,
+                                                                         issuetype=self.CI_JIRA_ISSUE)
+                self.project_b_issue1 = self.project_b_issue1_obj.key
+
+                self.project_b_issue2_obj = self.jira_admin.create_issue(project=self.project_b,
+                                                                         summary='issue 2 from %s'
+                                                                                 % self.project_b,
+                                                                         issuetype={'name': self.CI_JIRA_ISSUE})
+                self.project_b_issue2 = self.project_b_issue2_obj.key
+
+                self.project_b_issue3_obj = self.jira_admin.create_issue(project=self.project_b,
+                                                                         summary='issue 3 from %s'
+                                                                                 % self.project_b,
+                                                                         issuetype={'name': self.CI_JIRA_ISSUE})
+                self.project_b_issue3 = self.project_b_issue3_obj.key
+
+            except Exception as e:
+                logging.exception("Basic test setup failed")
+                self.initialized = 1
+                py.test.exit("FATAL: %s\n%s" % (e, traceback.format_exc()))
+
+            if not hasattr(self, 'jira_normal') or not hasattr(self, 'jira_admin'):
+                py.test.exit("FATAL: WTF!?")
+
+            self.initialized = 1
+
+        else:
+            # already exist but we need to be sure it was initialized
+            counter = 0
+            while not self.initialized:
+                sleep(1)
+                counter += 1
+                if counter > 60:
+                    logging.fatal("Something is clearly not right with " +
+                                  "initialization, killing the tests to prevent a " +
+                                  "deadlock.")
+                    sys.exit(3)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,9 +2,10 @@ from flaky import flaky
 import getpass
 import json
 import pytest
-from tests import get_unique_project_name
-from tests import JiraTestManager
 import time
+
+from tests.jira_test_manager import get_unique_project_name
+from tests.jira_test_manager import JiraTestManager
 
 from jira import Role, Issue, JIRA, JIRAError, Project  # noqa
 import jira.client

--- a/tests/test_service_desk.py
+++ b/tests/test_service_desk.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python
+from __future__ import print_function
+import inspect
+import logging
+import os
+import platform
+import sys
+from time import sleep
+
+from flaky import flaky
+import pytest
+import requests
+
+from tests.jira_test_manager import JiraTestManager
+
+
+# _non_parallel is used to prevent some tests from failing due to concurrency
+# issues because detox, Travis or Jenkins can run test in parallel for multiple
+# python versions.
+# The current workaround is to run these problematic tests only on py27
+
+_non_parallel = True
+if platform.python_version() < '3':
+    _non_parallel = False
+
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        import pip
+
+        if hasattr(sys, 'real_prefix'):
+            pip.main(['install', '--upgrade', 'unittest2'])
+        else:
+            pip.main(['install', '--upgrade', '--user', 'unittest2'])
+        import unittest2 as unittest
+else:
+    import unittest
+
+cmd_folder = os.path.abspath(os.path.join(os.path.split(inspect.getfile(
+    inspect.currentframe()))[0], ".."))
+if cmd_folder not in sys.path:
+    sys.path.insert(0, cmd_folder)
+
+import jira  # noqa
+from jira import Role, Issue, JIRA, JIRAError, Project  # noqa
+from jira.resources import Resource, cls_for_resource   # noqa
+
+TEST_ROOT = os.path.dirname(__file__)
+TEST_ICON_PATH = os.path.join(TEST_ROOT, 'icon.png')
+TEST_ATTACH_PATH = os.path.join(TEST_ROOT, 'tests.py')
+
+OAUTH = False
+CONSUMER_KEY = 'oauth-consumer'
+KEY_CERT_FILE = '/home/bspeakmon/src/atlassian-oauth-examples/rsa.pem'
+KEY_CERT_DATA = None
+try:
+    with open(KEY_CERT_FILE, 'r') as cert:
+        KEY_CERT_DATA = cert.read()
+    OAUTH = True
+except Exception:
+    pass
+
+if 'CI_JIRA_URL' in os.environ:
+    not_on_custom_jira_instance = pytest.mark.skipif(True, reason="Not applicable for custom JIRA instance")
+    logging.info('Picked up custom JIRA engine.')
+else:
+    def noop(arg):
+        return arg
+    not_on_custom_jira_instance = noop
+
+
+def jira_servicedesk_detection():
+    if 'CI_JIRA_URL' in os.environ:
+        url = os.environ['CI_JIRA_URL']
+    else:
+        url = 'https://pycontribs.atlassian.net'
+    url += '/rest/servicedeskapi/info'
+    return requests.get(url).status_code != 200
+
+jira_servicedesk = pytest.mark.skipif(jira_servicedesk_detection(), reason="JIRA Service Desk is not available.")
+
+
+@flaky
+@jira_servicedesk
+class ServiceDeskTests(unittest.TestCase):
+
+    def setUp(self):
+        self.test_manager = JiraTestManager()
+        self.jira = self.test_manager.jira_admin
+        self.desk = self.jira.desk
+        self.test_fullname_a = "TestCustomerFullName %s" % self.test_manager.project_a
+        self.test_email_a = "test_customer_%s@example.com" % self.test_manager.project_a
+        self.test_fullname_b = "TestCustomerFullName %s" % self.test_manager.project_b
+        self.test_email_b = "test_customer_%s@example.com" % self.test_manager.project_b
+        self.test_organization_name_a = "test_organization_%s" % self.test_manager.project_a
+        self.test_organization_name_b = "test_organization_%s" % self.test_manager.project_b
+
+    def test_create_and_delete_customer(self):
+        try:
+            self.jira.delete_user(self.test_email_a)
+        except JIRAError:
+            pass
+
+        customer = self.desk.create_customer(self.test_email_a, self.test_fullname_a)
+        self.assertEqual(customer.emailAddress, self.test_email_a)
+        self.assertEqual(customer.displayName, self.test_fullname_a)
+
+        result = self.jira.delete_user(self.test_email_a)
+        self.assertTrue(result)
+
+    def test_get_servicedesk_info(self):
+        result = self.desk.servicedesk_info()
+        self.assertNotEqual(result, False)
+
+    def test_create_and_delete_organization(self):
+        organization = self.desk.create_organization(self.test_organization_name_a)
+        self.assertEqual(organization.name, self.test_organization_name_a)
+
+        result = self.desk.delete_organization(organization.id)
+        self.assertTrue(result)
+
+    def test_get_organization(self):
+        organization = self.desk.create_organization(self.test_organization_name_a)
+        self.assertEqual(organization.name, self.test_organization_name_a)
+
+        result = self.desk.organization(organization.id)
+        self.assertEqual(result.id, organization.id)
+        self.assertEqual(result.name, self.test_organization_name_a)
+
+        result = self.desk.delete_organization(organization.id)
+        self.assertTrue(result)
+
+    def test_add_users_to_organization(self):
+        organization = self.desk.create_organization(self.test_organization_name_a)
+        self.assertEqual(organization.name, self.test_organization_name_a)
+
+        try:
+            self.jira.delete_user(self.test_email_a)
+        except JIRAError:
+            pass
+
+        try:
+            self.jira.delete_user(self.test_email_b)
+        except JIRAError:
+            pass
+
+        customer_a = self.desk.create_customer(self.test_email_a, self.test_fullname_a)
+        self.assertEqual(customer_a.emailAddress, self.test_email_a)
+        self.assertEqual(customer_a.displayName, self.test_fullname_a)
+
+        customer_b = self.desk.create_customer(self.test_email_b, self.test_fullname_b)
+        self.assertEqual(customer_b.emailAddress, self.test_email_b)
+        self.assertEqual(customer_b.displayName, self.test_fullname_b)
+
+        result = self.desk.add_users_to_organization(organization.id, [self.test_email_a, self.test_email_b])
+        self.assertTrue(result)
+
+        result = self.jira.delete_user(self.test_email_a)
+        self.assertTrue(result)
+
+        result = self.jira.delete_user(self.test_email_b)
+        self.assertTrue(result)
+
+        result = self.desk.delete_organization(organization.id)
+        self.assertTrue(result)
+
+    def test_remove_users_from_organization(self):
+        organization = self.desk.create_organization(self.test_organization_name_a)
+        self.assertEqual(organization.name, self.test_organization_name_a)
+
+        try:
+            self.jira.delete_user(self.test_email_a)
+        except JIRAError:
+            pass
+
+        try:
+            self.jira.delete_user(self.test_email_b)
+        except JIRAError:
+            pass
+
+        customer_a = self.desk.create_customer(self.test_email_a, self.test_fullname_a)
+        self.assertEqual(customer_a.emailAddress, self.test_email_a)
+        self.assertEqual(customer_a.displayName, self.test_fullname_a)
+
+        customer_b = self.desk.create_customer(self.test_email_b, self.test_fullname_b)
+        self.assertEqual(customer_b.emailAddress, self.test_email_b)
+        self.assertEqual(customer_b.displayName, self.test_fullname_b)
+
+        result = self.desk.add_users_to_organization(organization.id, [self.test_email_a, self.test_email_b])
+        self.assertTrue(result)
+
+        result = self.desk.remove_users_from_organization(organization.id, [self.test_email_a, self.test_email_b])
+        self.assertTrue(result)
+
+        result = self.jira.delete_user(self.test_email_a)
+        self.assertTrue(result)
+
+        result = self.jira.delete_user(self.test_email_b)
+        self.assertTrue(result)
+
+        result = self.desk.delete_organization(organization.id)
+        self.assertTrue(result)
+
+    def test_get_organizations(self):
+        organization_a = self.desk.create_organization(self.test_organization_name_a)
+        self.assertEqual(organization_a.name, self.test_organization_name_a)
+
+        organization_b = self.desk.create_organization(self.test_organization_name_b)
+        self.assertEqual(organization_b.name, self.test_organization_name_b)
+
+        organizations = self.desk.organizations(0, 1)
+        self.assertEqual(len(organizations), 1)
+
+        result = self.desk.delete_organization(organization_a.id)
+        self.assertTrue(result)
+
+        result = self.desk.delete_organization(organization_b.id)
+        self.assertTrue(result)
+
+    def test_get_users_in_organization(self):
+        organization = self.desk.create_organization(self.test_organization_name_a)
+        self.assertEqual(organization.name, self.test_organization_name_a)
+
+        try:
+            self.jira.delete_user(self.test_email_a)
+        except JIRAError:
+            pass
+
+        try:
+            self.jira.delete_user(self.test_email_b)
+        except JIRAError:
+            pass
+
+        customer_a = self.desk.create_customer(self.test_email_a, self.test_fullname_a)
+        self.assertEqual(customer_a.emailAddress, self.test_email_a)
+        self.assertEqual(customer_a.displayName, self.test_fullname_a)
+
+        customer_b = self.desk.create_customer(self.test_email_b, self.test_fullname_b)
+        self.assertEqual(customer_b.emailAddress, self.test_email_b)
+        self.assertEqual(customer_b.displayName, self.test_fullname_b)
+
+        result = self.desk.add_users_to_organization(organization.id, [self.test_email_a, self.test_email_b])
+        self.assertTrue(result)
+
+        result = self.desk.get_users_from_organization(organization.id)
+        self.assertEqual(len(result), 2)
+
+        result = self.jira.delete_user(self.test_email_a)
+        self.assertTrue(result)
+
+        result = self.jira.delete_user(self.test_email_b)
+        self.assertTrue(result)
+
+        result = self.desk.delete_organization(organization.id)
+        self.assertTrue(result)
+
+    def test_service_desks(self):
+        service_desks = self.desk.service_desks()
+        self.assertGreater(len(service_desks), 0)
+
+    def test_servicedesk(self):
+        service_desks = self.desk.service_desks()
+        self.assertGreater(len(service_desks), 0)
+
+        service_desk = self.desk.service_desk(service_desks[0].id)
+        self.assertEqual(service_desk.id, service_desks[0].id)
+
+    def test_request_types(self):
+        service_desks = self.desk.service_desks()
+        self.assertGreater(len(service_desks), 0)
+
+        request_types = self.desk.request_types(service_desks[0].id)
+        self.assertGreater(len(request_types), 0)
+
+    def test_request_type(self):
+        service_desks = self.desk.service_desks()
+        self.assertGreater(len(service_desks), 0)
+
+        request_types = self.desk.request_types(service_desks[0].id)
+        self.assertGreater(len(request_types), 0)
+
+        request_type = self.desk.request_type(service_desks[0].id, request_types[0].id)
+        self.assertEqual(request_type.id, request_types[0].id)
+        self.assertEqual(request_type.name, request_types[0].name)
+
+    def test_request_type_by_name(self):
+        service_desks = self.desk.service_desks()
+        self.assertGreater(len(service_desks), 0)
+
+        request_types = self.desk.request_types(service_desks[0].id)
+        self.assertGreater(len(request_types), 0)
+
+        request_type_by_name = self.desk.request_type_by_name(service_desks[0].id, request_types[0].name)
+        self.assertEqual(request_types[0].id, request_type_by_name.id)
+        self.assertEqual(request_types[0].name, request_type_by_name.name)
+
+    def test_create_and_delete_customer_request_with_prefetch(self):
+        service_desks = self.desk.service_desks()
+        self.assertGreater(len(service_desks), 0)
+
+        request_types = self.desk.request_types(service_desks[0].id)
+        self.assertGreater(len(request_types), 0)
+
+        fields = {
+            "serviceDeskId": int(service_desks[0].id),
+            "requestTypeId": int(request_types[0].id),
+            "raiseOnBehalfOf": self.test_manager.CI_JIRA_USER,
+            "requestFieldValues": {
+                "summary": "Request summary",
+                "description": "Request description"
+            }
+        }
+        request = self.desk.create_request(fields, prefetch=True)
+
+        self.jira.delete_issue(request.id)
+
+        self.assertIsNotNone(request.id)
+        self.assertIsNotNone(request.key)
+        self.assertEqual(request.fields.summary, "Request summary")
+        self.assertEqual(request.fields.description, "Request description")
+
+    def test_create_and_delete_customer_request_without_prefetch(self):
+        service_desks = self.desk.service_desks()
+        self.assertGreater(len(service_desks), 0)
+
+        request_types = self.desk.request_types(service_desks[0].id)
+        self.assertGreater(len(request_types), 0)
+
+        fields = {
+            "serviceDeskId": int(service_desks[0].id),
+            "requestTypeId": int(request_types[0].id),
+            "raiseOnBehalfOf": self.test_manager.CI_JIRA_USER,
+            "requestFieldValues": {
+                "summary": "Request summary",
+                "description": "Request description"
+            }
+        }
+        request = self.desk.create_request(fields, prefetch=False)
+
+        self.jira.delete_issue(request.id)
+
+        self.assertIsNotNone(request.id)
+        self.assertIsNotNone(request.key)
+        self.assertEqual(request.fields.summary, "Request summary")
+        self.assertEqual(request.fields.description, "Request description")
+
+    def test_get_customer_request_by_key_or_id(self):
+        service_desks = self.desk.service_desks()
+        self.assertGreater(len(service_desks), 0)
+
+        request_types = self.desk.request_types(service_desks[0].id)
+        self.assertGreater(len(request_types), 0)
+
+        fields = {
+            "serviceDeskId": int(service_desks[0].id),
+            "requestTypeId": int(request_types[0].id),
+            "raiseOnBehalfOf": self.test_manager.CI_JIRA_USER,
+            "requestFieldValues": {
+                "summary": "Request summary",
+                "description": "Request description"
+            }
+        }
+        request = self.desk.create_request(fields, prefetch=False)
+
+        expand = 'serviceDesk,requestType,participant,sla,status'
+        request_by_key = self.desk.request(request.key, expand=expand)
+
+        self.assertEqual(request.id, request_by_key.id)
+        self.assertEqual(request.key, request_by_key.key)
+        self.assertEqual(request_by_key.fields.summary, "Request summary")
+        self.assertEqual(request_by_key.fields.description, "Request description")
+
+        expand = 'serviceDesk,requestType,participant,sla,status'
+        request_by_id = self.desk.request(request.id, expand=expand)
+
+        self.jira.delete_issue(request.id)
+
+        self.assertEqual(request.id, request_by_id.id)
+        self.assertEqual(request.key, request_by_id.key)
+        self.assertEqual(request_by_id.fields.summary, "Request summary")
+        self.assertEqual(request_by_id.fields.description, "Request description")
+
+    def test_get_my_customer_requests(self):
+        service_desks = self.desk.service_desks()
+        self.assertGreater(len(service_desks), 0)
+
+        request_types = self.desk.request_types(service_desks[0].id)
+        self.assertGreater(len(request_types), 0)
+
+        fields = {
+            "serviceDeskId": int(service_desks[0].id),
+            "requestTypeId": int(request_types[0].id),
+            "raiseOnBehalfOf": self.test_manager.CI_JIRA_USER,
+            "requestFieldValues": {
+                "summary": "Request summary",
+                "description": "Request description"
+            }
+        }
+        request1 = self.desk.create_request(fields, prefetch=False)
+
+        fields = {
+            "serviceDeskId": int(service_desks[0].id),
+            "requestTypeId": int(request_types[0].id),
+            "raiseOnBehalfOf": self.test_manager.CI_JIRA_ADMIN,
+            "requestFieldValues": {
+                "summary": "Request summary",
+                "description": "Request description"
+            }
+        }
+        request2 = self.desk.create_request(fields, prefetch=False)
+
+        result = self.desk.my_customer_requests(request_ownership='OWNED_REQUESTS',
+                                                servicedesk_id=int(service_desks[0].id),
+                                                request_type_id=int(request_types[0].id))
+        count = 0
+        requests = (request1.id, request2.id)
+        for i in result:
+            if i.id in requests:
+                count += 1
+
+        self.assertEqual(count, 1)
+
+        result = self.desk.my_customer_requests(request_ownership='PARTICIPATED_REQUESTS',
+                                                servicedesk_id=int(service_desks[0].id),
+                                                request_type_id=int(request_types[0].id))
+        count = 0
+        requests_list = (request1.id, request2.id)
+        for i in result:
+            if i.id in requests_list:
+                count += 1
+
+        self.jira.delete_issue(request1.id)
+        self.jira.delete_issue(request2.id)
+
+        self.assertEqual(count, 0)
+
+    def test_request_comments(self):
+        service_desks = self.desk.service_desks()
+        self.assertGreater(len(service_desks), 0)
+
+        request_types = self.desk.request_types(service_desks[0].id)
+        self.assertGreater(len(request_types), 0)
+
+        fields = {
+            "serviceDeskId": int(service_desks[0].id),
+            "requestTypeId": int(request_types[0].id),
+            "raiseOnBehalfOf": self.test_manager.CI_JIRA_USER,
+            "requestFieldValues": {
+                "summary": "Request summary",
+                "description": "Request description"
+            }
+        }
+        request = self.desk.create_request(fields, prefetch=False)
+
+        self.jira.add_comment(request.id, "Public comment #1", is_internal=False)
+        self.jira.add_comment(request.id, "Internal comment #1", is_internal=True)
+        self.jira.add_comment(request.id, "Public comment #2", is_internal=False)
+        self.jira.add_comment(request.id, "Public comment #3", is_internal=False)
+        sleep(1)
+        public_comments = self.desk.request_comments(request.id, public=True, internal=False)
+        internal_comments = self.desk.request_comments(request.id, public=False, internal=True)
+        all_comments = self.desk.request_comments(request.id)
+
+        self.assertEqual(len(public_comments), 3)
+        self.assertEqual(len(internal_comments), 1)
+        self.assertEqual(len(all_comments), 4)
+
+        for comment in public_comments:
+            self.assertEqual(comment.public, True)
+
+        for comment in internal_comments:
+            self.assertEqual(comment.public, False)
+
+        self.jira.delete_issue(request.id)
+
+    def test_create_attachment(self):
+        service_desks = self.desk.service_desks()
+        self.assertGreater(len(service_desks), 0)
+
+        request_types = self.desk.request_types(service_desks[0].id)
+        self.assertGreater(len(request_types), 0)
+
+        fields = {
+            "serviceDeskId": int(service_desks[0].id),
+            "requestTypeId": int(request_types[0].id),
+            "raiseOnBehalfOf": self.test_manager.CI_JIRA_USER,
+            "requestFieldValues": {
+                "summary": "Request summary",
+                "description": "Request description"
+            }
+        }
+        request = self.desk.create_request(fields)
+
+        tmp_attachment = self.desk.attach_temporary_file(service_desks[0].id, open(TEST_ICON_PATH, 'rb'), "test.png")
+
+        self.assertEqual(len(tmp_attachment.temporaryAttachments), 1)
+        self.assertEqual(tmp_attachment.temporaryAttachments[0].fileName, 'test.png')
+
+        request_attachment = self.desk.servicedesk_attachment(request.id, tmp_attachment, is_public=False,
+                                                              comment='Comment text')
+        self.jira.delete_issue(request.id)
+
+        self.assertEqual(request_attachment.comment.body, 'Comment text\n\n!test.png|thumbnail!')
+
+        if hasattr(request_attachment.attachments, 'values'):
+            # For Jira Servicedesk Cloud
+            self.assertGreater(len(request_attachment.attachments.values), 0)
+            self.assertEqual(request_attachment.attachments.values[0].filename, 'test.png')
+            self.assertGreater(request_attachment.attachments.values[0].size, 0)
+        else:
+            # For Jira Servicedesk Server
+            self.assertGreater(len(request_attachment.attachments), 0)
+            self.assertEqual(request_attachment.attachments[0].filename, 'test.png')
+            self.assertGreater(request_attachment.attachments[0].size, 0)
+
+    def test_attach_temporary_file(self):
+        service_desks = self.desk.service_desks()
+        self.assertGreater(len(service_desks), 0)
+
+        tmp_attachment = self.desk.attach_temporary_file(service_desks[0].id, open(TEST_ICON_PATH, 'rb'), "test.png")
+
+        self.assertEqual(len(tmp_attachment.temporaryAttachments), 1)
+        self.assertEqual(tmp_attachment.temporaryAttachments[0].fileName, 'test.png')
+
+    def test_create_customer_request(self):
+        try:
+            self.jira.create_project('TESTSD', template_name='IT Service Desk')
+        except JIRAError:
+            pass
+        service_desk = self.desk.service_desks()[0]
+        request_type = self.desk.request_types(service_desk.id)[0]
+
+        request = self.desk.create_customer_request(dict(
+            serviceDeskId=service_desk.id,
+            requestTypeId=int(request_type.id),
+            requestFieldValues=dict(
+                summary='Ticket title here',
+                description='Ticket body here'
+            )
+        ))
+
+        self.assertEqual(request.fields.summary, 'Ticket title here')
+        self.assertEqual(request.fields.description, 'Ticket body here')
+
+
+if __name__ == '__main__':
+
+    # when running tests we expect various errors and we don't want to display them by default
+    logging.getLogger("requests").setLevel(logging.FATAL)
+    logging.getLogger("urllib3").setLevel(logging.FATAL)
+    logging.getLogger("jira").setLevel(logging.FATAL)
+
+    # j = JIRA("https://issues.citrite.net")
+    # print(j.session())
+
+    dirname = "test-reports-%s%s" % (sys.version_info[0], sys.version_info[1])
+    unittest.main()
+    # pass

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 from __future__ import print_function
-import getpass
-import hashlib
 import inspect
 import logging
 import os
@@ -12,15 +10,11 @@ import re
 import string
 import sys
 from time import sleep
-import traceback
 
 from flaky import flaky
-import py
 import pytest
 import requests
 from six import integer_types
-from tenacity import retry
-from tenacity import stop_after_attempt
 
 # _non_parallel is used to prevent some tests from failing due to concurrency
 # issues because detox, Travis or Jenkins can run test in parallel for multiple
@@ -57,16 +51,8 @@ TEST_ROOT = os.path.dirname(__file__)
 TEST_ICON_PATH = os.path.join(TEST_ROOT, 'icon.png')
 TEST_ATTACH_PATH = os.path.join(TEST_ROOT, 'tests.py')
 
-OAUTH = False
-CONSUMER_KEY = 'oauth-consumer'
-KEY_CERT_FILE = '/home/bspeakmon/src/atlassian-oauth-examples/rsa.pem'
-KEY_CERT_DATA = None
-try:
-    with open(KEY_CERT_FILE, 'r') as cert:
-        KEY_CERT_DATA = cert.read()
-    OAUTH = True
-except Exception:
-    pass
+from tests.jira_test_manager import JiraTestManager
+
 
 if 'CI_JIRA_URL' in os.environ:
     not_on_custom_jira_instance = pytest.mark.skipif(True, reason="Not applicable for custom JIRA instance")
@@ -88,282 +74,6 @@ def rndpassword():
         ''.join(random.sample(string.digits, 2)) + \
         ''.join(random.sample('~`!@#$%^&*()_+-=[]\\{}|;\':<>?,./', 2))
     return ''.join(random.sample(s, len(s)))
-
-
-def hashify(some_string, max_len=8):
-    return hashlib.md5(some_string.encode('utf-8')).hexdigest()[:8].upper()
-
-
-def get_unique_project_name():
-    jid = ""
-    user = re.sub("[^A-Z_]", "", getpass.getuser().upper())
-
-    if user == 'TRAVIS' and 'TRAVIS_JOB_NUMBER' in os.environ:
-        # please note that user underline (_) is not suppored by
-        # jira even if is documented as supported.
-        jid = 'T' + hashify(user + os.environ['TRAVIS_JOB_NUMBER'])
-    else:
-        identifier = user + \
-            chr(ord('A') + sys.version_info[0]) + \
-            chr(ord('A') + sys.version_info[1])
-        jid = 'Z' + hashify(identifier)
-    return jid
-
-
-class Singleton(type):
-
-    def __init__(cls, name, bases, dict):
-        super(Singleton, cls).__init__(name, bases, dict)
-        cls.instance = None
-
-    def __call__(cls, *args, **kw):
-        if cls.instance is None:
-            cls.instance = super(Singleton, cls).__call__(*args, **kw)
-        return cls.instance
-
-
-class JiraTestManager(object):
-    """Used to instantiate and populate the JIRA instance with data used by the unit tests.
-
-    Attributes:
-        CI_JIRA_ADMIN (str): Admin user account name.
-        CI_JIRA_USER (str): Limited user account name.
-        max_retries (int): number of retries to perform for recoverable HTTP errors.
-    """
-
-    # __metaclass__ = Singleton
-
-    # __instance = None
-    #
-    # Singleton implementation
-    # def __new__(cls, *args, **kwargs):
-    #     if not cls.__instance:
-    #         cls.__instance = super(JiraTestManager, cls).__new__(
-    #                             cls, *args, **kwargs)
-    #     return cls.__instance
-
-    #  Implementing some kind of Singleton, to prevent test initialization
-    # http://stackoverflow.com/questions/31875/is-there-a-simple-elegant-way-to-define-singletons-in-python/33201#33201
-    __shared_state = {}
-
-    @retry(stop=stop_after_attempt(2))
-    def __init__(self):
-        self.__dict__ = self.__shared_state
-
-        if not self.__dict__:
-            self.initialized = 0
-
-            try:
-
-                if 'CI_JIRA_URL' in os.environ:
-                    self.CI_JIRA_URL = os.environ['CI_JIRA_URL']
-                    self.max_retries = 5
-                else:
-                    self.CI_JIRA_URL = "https://pycontribs.atlassian.net"
-                    self.max_retries = 5
-
-                if 'CI_JIRA_ADMIN' in os.environ:
-                    self.CI_JIRA_ADMIN = os.environ['CI_JIRA_ADMIN']
-                else:
-                    self.CI_JIRA_ADMIN = 'ci-admin'
-
-                if 'CI_JIRA_ADMIN_PASSWORD' in os.environ:
-                    self.CI_JIRA_ADMIN_PASSWORD = os.environ[
-                        'CI_JIRA_ADMIN_PASSWORD']
-                else:
-                    self.CI_JIRA_ADMIN_PASSWORD = 'sd4s3dgec5fhg4tfsds3434'
-
-                if 'CI_JIRA_USER' in os.environ:
-                    self.CI_JIRA_USER = os.environ['CI_JIRA_USER']
-                else:
-                    self.CI_JIRA_USER = 'ci-user'
-
-                if 'CI_JIRA_USER_PASSWORD' in os.environ:
-                    self.CI_JIRA_USER_PASSWORD = os.environ[
-                        'CI_JIRA_USER_PASSWORD']
-                else:
-                    self.CI_JIRA_USER_PASSWORD = 'sd4s3dgec5fhg4tfsds3434'
-
-                self.CI_JIRA_ISSUE = os.environ.get('CI_JIRA_ISSUE', 'Bug')
-
-                if OAUTH:
-                    self.jira_admin = JIRA(oauth={
-                        'access_token': 'hTxcwsbUQiFuFALf7KZHDaeAJIo3tLUK',
-                        'access_token_secret': 'aNCLQFP3ORNU6WY7HQISbqbhf0UudDAf',
-                        'consumer_key': CONSUMER_KEY,
-                        'key_cert': KEY_CERT_DATA})
-                else:
-                    if self.CI_JIRA_ADMIN:
-                        self.jira_admin = JIRA(self.CI_JIRA_URL, basic_auth=(self.CI_JIRA_ADMIN,
-                                                                             self.CI_JIRA_ADMIN_PASSWORD),
-                                               logging=False, validate=True, max_retries=self.max_retries)
-                    else:
-                        self.jira_admin = JIRA(self.CI_JIRA_URL, validate=True,
-                                               logging=False, max_retries=self.max_retries)
-                if self.jira_admin.current_user() != self.CI_JIRA_ADMIN:
-                    # self.jira_admin.
-                    self.initialized = 1
-                    sys.exit(3)
-
-                if OAUTH:
-                    self.jira_sysadmin = JIRA(oauth={
-                        'access_token': '4ul1ETSFo7ybbIxAxzyRal39cTrwEGFv',
-                        'access_token_secret':
-                            'K83jBZnjnuVRcfjBflrKyThJa0KSjSs2',
-                        'consumer_key': CONSUMER_KEY,
-                        'key_cert': KEY_CERT_DATA}, logging=False, max_retries=self.max_retries)
-                else:
-                    if self.CI_JIRA_ADMIN:
-                        self.jira_sysadmin = JIRA(self.CI_JIRA_URL,
-                                                  basic_auth=(self.CI_JIRA_ADMIN,
-                                                              self.CI_JIRA_ADMIN_PASSWORD),
-                                                  logging=False, validate=True, max_retries=self.max_retries)
-                    else:
-                        self.jira_sysadmin = JIRA(self.CI_JIRA_URL,
-                                                  logging=False, max_retries=self.max_retries)
-
-                if OAUTH:
-                    self.jira_normal = JIRA(oauth={
-                        'access_token': 'ZVDgYDyIQqJY8IFlQ446jZaURIz5ECiB',
-                        'access_token_secret':
-                            '5WbLBybPDg1lqqyFjyXSCsCtAWTwz1eD',
-                        'consumer_key': CONSUMER_KEY,
-                        'key_cert': KEY_CERT_DATA})
-                else:
-                    if self.CI_JIRA_ADMIN:
-                        self.jira_normal = JIRA(self.CI_JIRA_URL,
-                                                basic_auth=(self.CI_JIRA_USER,
-                                                            self.CI_JIRA_USER_PASSWORD),
-                                                validate=True, logging=False, max_retries=self.max_retries)
-                    else:
-                        self.jira_normal = JIRA(self.CI_JIRA_URL,
-                                                validate=True, logging=False, max_retries=self.max_retries)
-
-                # now we need some data to start with for the tests
-
-                # jira project key is max 10 chars, no letter.
-                # [0] always "Z"
-                # [1-6] username running the tests (hope we will not collide)
-                # [7-8] python version A=0, B=1,..
-                # [9] A,B -- we may need more than one project
-
-                """ `jid` is important for avoiding concurency problems when
-                executing tests in parallel as we have only one test instance.
-
-                jid length must be less than 9 characters because we may append
-                another one and the JIRA Project key length limit is 10.
-
-                Tests run in parallel:
-                * git branches master or developer, git pr or developers running
-                  tests outside Travis
-                * Travis is using "Travis" username
-
-                https://docs.travis-ci.com/user/environment-variables/
-                """
-
-                self.jid = get_unique_project_name()
-
-                self.project_a = self.jid + 'A'  # old XSS
-                self.project_a_name = "Test user=%s key=%s A" \
-                                      % (getpass.getuser(), self.project_a)
-                self.project_b = self.jid + 'B'  # old BULK
-                self.project_b_name = "Test user=%s key=%s B" \
-                                      % (getpass.getuser(), self.project_b)
-
-                # TODO(ssbarnea): find a way to prevent SecurityTokenMissing for On Demand
-                # https://jira.atlassian.com/browse/JRA-39153
-                try:
-                    self.jira_admin.project(self.project_a)
-                except Exception as e:
-                    logging.warning(e)
-                    pass
-                else:
-                    try:
-                        self.jira_admin.delete_project(self.project_a)
-                    except Exception as e:
-                        pass
-
-                try:
-                    self.jira_admin.project(self.project_b)
-                except Exception as e:
-                    logging.warning(e)
-                    pass
-                else:
-                    try:
-                        self.jira_admin.delete_project(self.project_b)
-                    except Exception as e:
-                        pass
-
-                # wait for the project to be deleted
-                for i in range(1, 20):
-                    try:
-                        self.jira_admin.project(self.project_b)
-                    except Exception as e:
-                        print(e)
-                        break
-                    sleep(2)
-
-                try:
-                    self.jira_admin.create_project(self.project_a,
-                                                   self.project_a_name)
-                except Exception:
-                    # we care only for the project to exist
-                    pass
-                self.project_a_id = self.jira_admin.project(self.project_a).id
-                # except Exception as e:
-                #    logging.warning("Got %s" % e)
-                # try:
-                # assert self.jira_admin.create_project(self.project_b,
-                # self.project_b_name) is  True, "Failed to create %s" %
-                # self.project_b
-
-                try:
-                    self.jira_admin.create_project(self.project_b,
-                                                   self.project_b_name)
-                except Exception:
-                    # we care only for the project to exist
-                    pass
-                sleep(1)  # keep it here as often JIRA will report the
-                # project as missing even after is created
-                self.project_b_issue1_obj = self.jira_admin.create_issue(project=self.project_b,
-                                                                         summary='issue 1 from %s'
-                                                                                 % self.project_b,
-                                                                         issuetype=self.CI_JIRA_ISSUE)
-                self.project_b_issue1 = self.project_b_issue1_obj.key
-
-                self.project_b_issue2_obj = self.jira_admin.create_issue(project=self.project_b,
-                                                                         summary='issue 2 from %s'
-                                                                                 % self.project_b,
-                                                                         issuetype={'name': self.CI_JIRA_ISSUE})
-                self.project_b_issue2 = self.project_b_issue2_obj.key
-
-                self.project_b_issue3_obj = self.jira_admin.create_issue(project=self.project_b,
-                                                                         summary='issue 3 from %s'
-                                                                                 % self.project_b,
-                                                                         issuetype={'name': self.CI_JIRA_ISSUE})
-                self.project_b_issue3 = self.project_b_issue3_obj.key
-
-            except Exception as e:
-                logging.exception("Basic test setup failed")
-                self.initialized = 1
-                py.test.exit("FATAL: %s\n%s" % (e, traceback.format_exc()))
-
-            if not hasattr(self, 'jira_normal') or not hasattr(self, 'jira_admin'):
-                py.test.exit("FATAL: WTF!?")
-
-            self.initialized = 1
-
-        else:
-            # already exist but we need to be sure it was initialized
-            counter = 0
-            while not self.initialized:
-                sleep(1)
-                counter += 1
-                if counter > 60:
-                    logging.fatal("Something is clearly not right with " +
-                                  "initialization, killing the tests to prevent a " +
-                                  "deadlock.")
-                    sys.exit(3)
 
 
 def find_by_key(seq, key):
@@ -814,6 +524,20 @@ class IssueTests(unittest.TestCase):
         self.assertEqual(issues[1]['issue'].fields.priority.name, 'Major')
         for issue in issues:
             issue['issue'].delete()
+
+    @not_on_custom_jira_instance
+    def test_delete_issue(self):
+        issue = self.jira.create_issue(prefetch=False,
+                                       project=self.project_b,
+                                       summary='Test Delete issue',
+                                       description='blahery',
+                                       issuetype={'name': 'Bug'}
+                                       )
+        self.jira.delete_issue(issue.id)
+        try:
+            self.jira.issue(issue.id)
+        except JIRAError as e:
+            self.assertEqual(e.status_code, 404)
 
     @not_on_custom_jira_instance
     def test_create_issues_one_failure(self):
@@ -1685,8 +1409,11 @@ class UserTests(unittest.TestCase):
 
     def test_user(self):
         user = self.jira.user(self.test_manager.CI_JIRA_ADMIN)
+
         self.assertEqual(user.name, self.test_manager.CI_JIRA_ADMIN)
+        """email now is: ci-admin@ssbarnea.33mail.com, so regex doesn't work
         self.assertRegex(user.emailAddress, '.*@example.com')
+        """
 
     @pytest.mark.xfail(reason='query returns empty list')
     def test_search_assignable_users_for_projects(self):
@@ -1908,11 +1635,17 @@ class VersionTests(unittest.TestCase):
 class OtherTests(unittest.TestCase):
 
     def test_session_invalid_login(self):
+        if 'CI_JIRA_URL' in os.environ:
+            self.CI_JIRA_URL = os.environ['CI_JIRA_URL']
+        else:
+            self.CI_JIRA_URL = "https://pycontribs.atlassian.net"
+
         try:
-            JIRA('https://support.atlassian.com',
+            JIRA(self.CI_JIRA_URL,
                  basic_auth=("xxx", "xxx"),
                  validate=True,
-                 logging=False)
+                 logging=False,
+                 max_retries=0)
         except Exception as e:
             self.assertIsInstance(e, JIRAError)
             # 20161010: jira cloud returns 500
@@ -1926,6 +1659,10 @@ class OtherTests(unittest.TestCase):
 class SessionTests(unittest.TestCase):
 
     def setUp(self):
+        if 'CI_JIRA_URL' in os.environ:
+            self.CI_JIRA_URL = os.environ['CI_JIRA_URL']
+        else:
+            self.CI_JIRA_URL = "https://pycontribs.atlassian.net"
         self.jira = JiraTestManager().jira_admin
 
     def test_session(self):
@@ -1933,7 +1670,7 @@ class SessionTests(unittest.TestCase):
         self.assertIsNotNone(user.raw['session'])
 
     def test_session_with_no_logged_in_user_raises(self):
-        anon_jira = JIRA('https://support.atlassian.com', logging=False)
+        anon_jira = JIRA(self.CI_JIRA_URL, logging=False, max_retries=0)
         self.assertRaises(JIRAError, anon_jira.session)
 
     # @pytest.mark.skipif(platform.python_version() < '3', reason='Does not work with Python 2')
@@ -2102,36 +1839,6 @@ class JiraShellTests(unittest.TestCase):
     def test_jirashell_command_exists(self):
         result = os.system('jirashell --help')
         self.assertEqual(result, 0)
-
-
-class JiraServiceDeskTests(unittest.TestCase):
-
-    def setUp(self):
-        self.jira = JiraTestManager().jira_admin
-        self.test_manager = JiraTestManager()
-
-    def test_create_customer_request(self):
-        if not self.jira.supports_service_desk():
-            pytest.skip('Skipping Service Desk not enabled')
-
-        try:
-            self.jira.create_project('TESTSD', template_name='IT Service Desk')
-        except JIRAError:
-            pass
-        service_desk = self.jira.service_desks()[0]
-        request_type = self.jira.request_types(service_desk)[0]
-
-        request = self.jira.create_customer_request(dict(
-            serviceDeskId=service_desk.id,
-            requestTypeId=int(request_type.id),
-            requestFieldValues=dict(
-                summary='Ticket title here',
-                description='Ticket body here'
-            )
-        ))
-
-        self.assertEqual(request.fields.summary, 'Ticket title here')
-        self.assertEqual(request.fields.description, 'Ticket body here')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Following the suggestions in the open pull request [Added Jira ServiceDesk support](https://github.com/pycontribs/jira/pull/371), I have performed the following:

1. Moved all service desk functionality to a `service_desk.py` module. SD functionality can be accessed on the jira instance by doing `jira.desk.` Functionality is comming from work by igor-pavlenko. I have not modified anything functionality wise.
2. Reorganized the tests: service desk tests in separate module, test manager is shared for all tests

Most tests are passing: `1 failed, 130 passed, 8 skipped, 2 xfailed, 11 xpassed in 529.41 seconds`. I do not think my changes introduce new errors.
