### PR TITLE
Accept custom authentication URL

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -195,6 +195,7 @@ class JIRA(object):
 
     DEFAULT_OPTIONS = {
         "server": "http://localhost:2990/jira",
+        "auth_url": '/rest/auth/1/session',
         "context_path": "/",
         "rest_path": "api",
         "rest_api_version": "2",
@@ -2222,7 +2223,7 @@ class JIRA(object):
 
     def session(self):
         """Get a dict of the current authenticated user's session information."""
-        url = '{server}/rest/auth/1/session'.format(**self._options)
+        url = '{server}{auth_url}'.format(**self._options)
 
         if isinstance(self._session.auth, tuple):
             authentication_data = {

--- a/jira/jirashell.py
+++ b/jira/jirashell.py
@@ -134,6 +134,8 @@ def process_command_line():
                             help='The JIRA instance to connect to, including context path.')
     jira_group.add_argument('-r', '--rest-path',
                             help='The root path of the REST API to use.')
+    jira_group.add_argument('--auth-url',
+                            help='Path to URL to auth against.')
     jira_group.add_argument('-v', '--rest-api-version',
                             help='The version of the API under the specified name.')
 
@@ -174,6 +176,9 @@ def process_command_line():
 
     if args.rest_path:
         options['rest_path'] = args.rest_path
+
+    if args.auth_url:
+        options['auth_url'] = args.auth_url
 
     if args.rest_api_version:
         options['rest_api_version'] = args.rest_api_version


### PR DESCRIPTION
If JIRA instance doesn't accept default URL for authentication
(/rest/auth/1/session) one can set custom one.

All following works:

- key 'auth_url' in options keyword of JIRA() class
- option name 'auth_url' in 'options' section of
  ~/.jira-python/jirashell.ini
- --auth-url option of jirashell