### PR TITLE
Fix for #325

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -398,7 +398,7 @@ class JIRA(object):
             if isinstance(resource, dict):
                 total = resource.get('total')
                 # 'isLast' is the optional key added to responses in JIRA Agile 6.7.6. So far not used in basic JIRA API.
-                is_last = resource.get('isLast', True)
+                is_last = resource.get('isLast', False)
                 start_at_from_response = resource.get('startAt', 0)
                 max_results_from_response = resource.get('maxResults', 1)
             else:


### PR DESCRIPTION
Fixing the issue #325

If the resource that is returned does not contain the 'isLast' key, the is_last variable is set to True.
This means that the while loop does not run and, therefore, the method returns only 50 records.
This breaks any functionality that depends on getting _all_ the records.