### PR TITLE
add the ability to use a cookies.txt file for auth

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -93,6 +93,15 @@ To enable Kerberos auth, set ``kerberos=True``::
 
 .. _jirashell-label:
 
+cookiestxt
+^^^^^^^^^^
+
+To access a corporate instance of JIRA that is authenticated behind some single sign-on solution, log in via Firefox with the `Export Cookies addon <https://addons.mozilla.org/EN-US/firefox/addon/export-cookies/>`_ and export the cookies.
+
+Pass a cookies.txt path ``cookiestxt`` constructor argument::
+
+    authed_jira = JIRA(cookiestxt="/tmp/cookies.txt")
+
 Issues
 ------
 

--- a/jira/jirashell.py
+++ b/jira/jirashell.py
@@ -147,6 +147,9 @@ def process_command_line():
                                   help='The password associated with this user.')
     basic_auth_group.add_argument('-P', '--prompt-for-password', action='store_true',
                                   help='Prompt for the password at the command line.')
+    cookiestxt_group = parser.add_argument_group('cookies.txt options')
+    cookiestxt_group.add_argument('-c', '--cookiestxt',
+                                  help='The path to a cookies.txt file')
 
     oauth_group = parser.add_argument_group('OAuth options')
     oauth_group.add_argument('-od', '--oauth-dance', action='store_true',
@@ -196,6 +199,9 @@ def process_command_line():
     if args.key_cert:
         with open(args.key_cert, 'r') as key_cert_file:
             key_cert_data = key_cert_file.read()
+
+    if args.cookiestxt:
+        options['cookiestxt'] = args.cookiestxt
 
     oauth = {}
     if args.oauth_dance:
@@ -247,7 +253,12 @@ def main():
                   oauth.get('consumer_key'), oauth.get('key_cert'))):
         oauth = None
 
-    jira = JIRA(options=options, basic_auth=basic_auth, oauth=oauth)
+    if 'cookiestxt' in options:
+        cookiestxt = options['cookiestxt']
+    else:
+        cookiestxt = None
+
+    jira = JIRA(options=options, basic_auth=basic_auth, oauth=oauth, cookiestxt=cookiestxt)
 
     from IPython.frontend.terminal.embed import InteractiveShellEmbed
 

--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -5,4 +5,5 @@
 PyJWT
 requests_jwt
 requests_kerberos
+cookiestxt
 filemagic>=1.6


### PR DESCRIPTION
At work we have an instance of JIRA that is authenticated via some SSO solution.  Also oauth is disabled.  As a workaround, I log in via a web browser and export the cookies.  I can then authenticate using those cookies.

Here I've added code to accept a cookies.txt path via the JIRA classes init and also via a jirashell option.