### PR TITLE
Add issue override options

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -204,7 +204,7 @@ class Resource(object):
         options.update({'path': path})
         return self._base_url.format(**options)
 
-    def update(self, fields=None, async=None, jira=None, notify=True, **kwargs):
+    def update(self, fields=None, async=None, jira=None, notify=True, overrideScreenSecurity=False, overrideEditableFlag=False, **kwargs):
         """Update this resource on the server.
 
         Keyword arguments are marshalled into a dict before being sent. If this
@@ -226,6 +226,12 @@ class Resource(object):
         querydict = {}
         if not notify:
             querydict['notifyUsers'] = 'false'
+
+        if overrideScreenSecurity:
+            querydict['overrideScreenSecurity'] = 'true'
+
+        if overrideEditableFlag:
+            querydict['overrideEditableFlag'] = 'true'
 
         r = self._session.put(
             self.self, params=querydict, data=data)
@@ -431,7 +437,7 @@ class Issue(Resource):
         if raw:
             self._parse_raw(raw)
 
-    def update(self, fields=None, update=None, async=None, jira=None, notify=True, **fieldargs):
+    def update(self, fields=None, update=None, async=None, jira=None, notify=True, overrideScreenSecurity=False, overrideEditableFlag=False, **fieldargs):
         """Update this issue on the server.
 
         Each keyword argument (other than the predefined ones) is treated as a field name and the argument's value
@@ -479,7 +485,7 @@ class Issue(Resource):
             else:
                 fields_dict[field] = value
 
-        super(Issue, self).update(async=async, jira=jira, notify=notify, fields=data)
+        super(Issue, self).update(async=async, jira=jira, notify=notify, overrideScreenSecurity=overrideScreenSecurity, overrideEditableFlag=overrideEditableFlag, fields=data)
 
     def add_field_value(self, field, value):
         """Add a value to a field that supports multiple values, without resetting the existing values.

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -223,13 +223,12 @@ class Resource(object):
 
         data = json.dumps(data)
 
+        querydict = {}
         if not notify:
-            querystring = "?notifyUsers=false"
-        else:
-            querystring = ""
+            querydict['notifyUsers'] = 'false'
 
         r = self._session.put(
-            self.self + querystring, data=data)
+            self.self, params=querydict, data=data)
         if 'autofix' in self._options and \
                 r.status_code == 400:
             user = None


### PR DESCRIPTION
In the JIRA API documentation[1], you can pass the query parameters `overrideScreenSecurity` and `overrideEditableFlag` to toggle additional behavior (that is only available to connect add-on users with an admin scope).

This PR:
* replaces the string concatenation of query parameters, with the `params` argument of `request.request`
* adds support for the screen security and editable flag overrides to the `Resource.update` and `Issue.update` methods

However, I need feedback on the appropriate way to name these new arguments. The general argument naming convention in this project appears to be all lowercase, so I'm not sure the best way to represent these arguments?

[1] https://docs.atlassian.com/jira/REST/cloud/#api/2/issue-editIssue