### PR TITLE
Update client.py with new backup endpoint

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2565,7 +2565,7 @@ class JIRA(object):
     def backup(self, filename='backup.zip', attachments=False):
         """Will call jira export to backup as zipped xml. Returning with success does not mean that the backup process finished."""
         if self.deploymentType == 'Cloud':
-            url = self._options['server'] + '/rest/obm/1.0/runbackup'
+            url = self._options['server'] + '/rest/backup/1/export/runbackup'
             payload = json.dumps({"cbAttachments": attachments})
             self._options['headers']['X-Requested-With'] = 'XMLHttpRequest'
         else:


### PR DESCRIPTION
Notated this as an issue here. Seems the endpoint has changed for the rest API. Returns 

ERROR:root:I see JiraError HTTP 404 url: https://XXXXXX.atlassian.net/rest/obm/1.0/runbackup
	text: <!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta http-equiv="X-UA-Compatible" content="IE=edge"><title>Oops, you&#39;ve found a dead link. - JIRA</title>

Pointing to the new endpoint resolved this /rest/backup/1/export/runbackup

See JIRA notes here https://jira.atlassian.com/browse/JRACLOUD-67169
	