### PR TITLE
Allow through TRAVIS Environment Variables

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ commands=
     python -m pytest
 passenv =
     CI_JIRA_*
+    TRAVIS*
 
 [travis:after]
 toxenv = py27


### PR DESCRIPTION
- Tox as a function of isolation will block most environment variables,
  so as a result they were causing some of the tests to not "know" that
  they were running inside of TRAVIS which they should.