### PR TITLE
Make OPTIONAL default and allowed value of mutual_authentication

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2306,8 +2306,9 @@ class JIRA(object):
         from requests_kerberos import HTTPKerberosAuth
         from requests_kerberos import OPTIONAL
 
-        mutual_authentication = OPTIONAL
-        if kerberos_options.get('mutual_authentication') == 'DISABLED':
+        if kerberos_options.get('mutual_authentication', 'OPTIONAL') == 'OPTIONAL':
+            mutual_authentication = OPTIONAL
+        elif kerberos_options.get('mutual_authentication') == 'DISABLED':
             mutual_authentication = DISABLED
         else:
             raise ValueError("Unknown value for mutual_authentication: %s" %


### PR DESCRIPTION
Before this change Kerberos authentication worked only if
Kerberos option mutual_authentication was explicitly set to DISABLED.
OPTIONAL was not default value anymore but it wasn't among allowed
values of mutual_authentication. Therefore these authentications failed
with raised exception:

```
ValueError: Unknown value for mutual_authentication
```

Fixes: #424
Relates: #472