### PR TITLE
jirashell: Import InteractiveShellEmbed depending on IPython version

### DIFF
--- a/jira/jirashell.py
+++ b/jira/jirashell.py
@@ -254,7 +254,12 @@ def main():
 
     jira = JIRA(options=options, basic_auth=basic_auth, oauth=oauth)
 
-    from IPython.frontend.terminal.embed import InteractiveShellEmbed
+    import IPython
+    # The top-level `frontend` package has been deprecated since IPython 1.0.
+    if IPython.version_info[0] >= 1:
+        from IPython.terminal.embed import InteractiveShellEmbed
+    else:
+        from IPython.frontend.terminal.embed import InteractiveShellEmbed
 
     ipshell = InteractiveShellEmbed(
         banner1='<JIRA Shell ' + __version__ + ' (' + jira.client_info() + ')>')


### PR DESCRIPTION
jirashell imported InteractiveShellEmbed from IPython.frontend. frontend
subpackage has been removed in IPython 1.0. IPython keep backawards
compatibility with old frondend imports but issues warning:

    ShimWarning: The top-level `frontend` package has been deprecated
    since IPython 1.0. All its subpackages have been moved to the top
    `IPython` level.

For more information about frontend subpackage removal see:
http://ipython.readthedocs.io/en/stable/whatsnew/version1.0.html#reorganization

This should also fix jirashell on Python 2.7 on Windows. It seems that
frontend shim module isn't present there (#251).