### PR TITLE
Minor Atlassian Connect JWT-related fixes

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -176,10 +176,12 @@ class QshGenerator(object):
         parse_result = urlparse(req.url)
 
         path = parse_result.path[len(self.context_path):] if len(self.context_path) > 1 else parse_result.path
-        query = '&'.join(sorted(parse_result.query.split("&")))
+        # Per Atlassian docs, use %20 for whitespace when generating qsh for URL
+        # https://developer.atlassian.com/cloud/jira/platform/understanding-jwt/#qsh
+        query = '&'.join(sorted(parse_result.query.split("&"))).replace('+', '%20')
         qsh = '%(method)s&%(path)s&%(query)s' % {'method': req.method.upper(), 'path': path, 'query': query}
 
-        return hashlib.sha256(qsh).hexdigest()
+        return hashlib.sha256(qsh.encode('utf-8')).hexdigest()
 
 
 class JIRA(object):
@@ -2330,6 +2332,8 @@ class JIRA(object):
         except NameError as e:
             logging.error("JWT authentication requires requests_jwt")
             raise e
+        jwt_auth.set_header_format('JWT %s')
+        
         jwt_auth.add_field("iat", lambda req: JIRA._timestamp())
         jwt_auth.add_field("exp", lambda req: JIRA._timestamp(datetime.timedelta(minutes=3)))
         jwt_auth.add_field("qsh", QshGenerator(self._options['context_path']))

--- a/jira/client.py
+++ b/jira/client.py
@@ -2333,7 +2333,7 @@ class JIRA(object):
             logging.error("JWT authentication requires requests_jwt")
             raise e
         jwt_auth.set_header_format('JWT %s')
-        
+
         jwt_auth.add_field("iat", lambda req: JIRA._timestamp())
         jwt_auth.add_field("exp", lambda req: JIRA._timestamp(datetime.timedelta(minutes=3)))
         jwt_auth.add_field("qsh", QshGenerator(self._options['context_path']))


### PR DESCRIPTION
This fixes two small bugs with Atlassian Connect JWT signing currently in `develop`.

* By default, `requests_jwt` formats the `Authorization` header as: `JWT token=<signed jwt>` which isn't compatible with Atlassian's JWT decryption. This sets the header format to `JWT <signed JWT>` which I have verified to work with the Jira API.
* The Query-String Hash (QSH) signature generation was using `+` for whitespace characters, notably when encoding JQL in GET requests. This is incompatible with the [algorithm Atlassian uses](https://developer.atlassian.com/cloud/jira/platform/understanding-jwt/#qsh) as documented which specifies to use `%20`.
* An empty ChangeLog file is added to allow CI to run properly.

Code review and feedback would be much appreciated, thank you!