### PR TITLE
Hotfix: Add pbr as a module dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 argparse; python_version<'3.2'
 defusedxml
 ordereddict; python_version<'3.1'
+pbr>=3.0.0
 requests-oauthlib>=0.6.1
 requests>=2.10.0
 requests_toolbelt


### PR DESCRIPTION
This is a hotfix to issue #501, existing in current release 1.0.11. The module pbt was accidentally dropped as a module dependency (left as a setup dependency) in 3293203 - this fix replaces it with the current setup required version.