### PR TITLE
Add hashable functionality to Issue.

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -432,6 +432,14 @@ class Issue(Resource):
         if raw:
             self._parse_raw(raw)
 
+    def __hash__(self):
+        """Hash calculation."""
+        return hash(str(self.key))
+
+    def __eq__(self, other):
+        """Comparison."""
+        return str(self.key) == str(other.key)
+
     def update(self, fields=None, update=None, async=None, jira=None, notify=True, **fieldargs):
         """Update this issue on the server.
 


### PR DESCRIPTION
In Python 3, the hashable is not longer inherited by default.
Adding __hash__ and __eq__ to Issue class.