### PR TITLE
Fix #350 ( "AttributeError: 'list' object has no attribute 'values'" on Jira Error handling )

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1093,9 +1093,15 @@ class JIRA(object):
             data['issueUpdates'].append(issue_data)
 
         url = self._get_url('issue/bulk')
-        r = self._session.post(url, data=json.dumps(data))
-
-        raw_issue_json = json_loads(r)
+        try:
+            r = self._session.post(url, data=json.dumps(data))
+            raw_issue_json = json_loads(r)
+        # Catching case where none of the issues has been created. See https://github.com/pycontribs/jira/issues/350
+        except JIRAError as je:
+            if je.status_code == 400:
+                raw_issue_json = json.loads(je.response.text)
+            else:
+                raise
         issue_list = []
         errors = {}
         for error in raw_issue_json['errors']:

--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -44,7 +44,8 @@ def raise_on_error(r, verb='???', **kwargs):
                         error = errorMessages[0]
                     else:
                         error = errorMessages
-                elif 'errors' in response and len(response['errors']) > 0:
+                # Catching only 'errors' that are dict. See https://github.com/pycontribs/jira/issues/350
+                elif 'errors' in response and len(response['errors']) > 0 and isinstance(response['errors'], dict):
                     # JIRA 6.x error messages are found in this array.
                     error_list = response['errors'].values()
                     error = ", ".join(error_list)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -769,6 +769,8 @@ class IssueTests(unittest.TestCase):
             'priority': {
                 'name': 'Major'}}]
         issues = self.jira.create_issues(field_list=field_list)
+        self.assertEqual(len(issues), 2)
+        self.assertIsNotNone(issues[0]['issue'], "the first issue has not been created")
         self.assertEqual(issues[0]['issue'].fields.summary,
                          'Issue created via bulk create #1')
         self.assertEqual(issues[0]['issue'].fields.description,
@@ -776,6 +778,7 @@ class IssueTests(unittest.TestCase):
         self.assertEqual(issues[0]['issue'].fields.issuetype.name, 'Bug')
         self.assertEqual(issues[0]['issue'].fields.project.key, self.project_b)
         self.assertEqual(issues[0]['issue'].fields.priority.name, 'Major')
+        self.assertIsNotNone(issues[1]['issue'], "the second issue has not been created")
         self.assertEqual(issues[1]['issue'].fields.summary,
                          'Issue created via bulk create #2')
         self.assertEqual(issues[1]['issue'].fields.description,


### PR DESCRIPTION
Fix https://github.com/pycontribs/jira/issues/350
This is a cherry pick from https://github.com/pycontribs/jira/pull/370 .
Props to @esciara .