### PR TITLE
Added applicationKeys parameter to add_user

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2949,7 +2949,7 @@ class JIRA(object):
         return False
 
     def add_user(self, username, email, directoryId=1, password=None,
-                 fullname=None, notify=False, active=True, ignore_existing=False,applicationKeys=None):
+                 fullname=None, notify=False, active=True, ignore_existing=False, applicationKeys=None):
         """Create a new JIRA user.
 
         :param username: the username of the new user

--- a/jira/client.py
+++ b/jira/client.py
@@ -2949,7 +2949,7 @@ class JIRA(object):
         return False
 
     def add_user(self, username, email, directoryId=1, password=None,
-                 fullname=None, notify=False, active=True, ignore_existing=False, applicationKeys=None):
+                 fullname=None, notify=False, active=True, ignore_existing=False, application_keys=None):
         """Create a new JIRA user.
 
         :param username: the username of the new user
@@ -2986,8 +2986,8 @@ class JIRA(object):
             x['password'] = password
         if notify:
             x['notification'] = 'True'
-        if applicationKeys is not None:
-            x['applicationKeys'] = applicationKeys
+        if application_keys is not None:
+            x['applicationKeys'] = application_keys
 
         payload = json.dumps(x)
         try:

--- a/jira/client.py
+++ b/jira/client.py
@@ -2949,7 +2949,7 @@ class JIRA(object):
         return False
 
     def add_user(self, username, email, directoryId=1, password=None,
-                 fullname=None, notify=False, active=True, ignore_existing=False):
+                 fullname=None, notify=False, active=True, ignore_existing=False,applicationKeys=None):
         """Create a new JIRA user.
 
         :param username: the username of the new user
@@ -2966,6 +2966,8 @@ class JIRA(object):
         :type notify: ``bool``
         :param active: Whether or not to make the new user active upon creation
         :type active: ``bool``
+        :param applicationKeys: Keys of products user should have access to
+        :type applicationKeys: ``list``
         """
         if not fullname:
             fullname = username
@@ -2984,6 +2986,8 @@ class JIRA(object):
             x['password'] = password
         if notify:
             x['notification'] = 'True'
+        if applicationKeys is not None:
+            x['applicationKeys'] = applicationKeys
 
         payload = json.dumps(x)
         try:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2013,7 +2013,7 @@ class UserAdministrationTests(unittest.TestCase):
         # test creating users with no application access (used for Service Desk)
         result = self.jira.add_user(
             self.test_username, self.test_email, password=self.test_password,
-            applicationKey=[])
+            applicationKeys=[])
         assert result, True
 
         result = self.jira.delete_user(self.test_username)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2010,6 +2010,15 @@ class UserAdministrationTests(unittest.TestCase):
         self.assertEqual(
             len(x), 0, "Found test user when it should have been deleted. Test Fails.")
 
+        # test creating users with no application access (used for Service Desk)
+        result = self.jira.add_user(
+            self.test_username, self.test_email, password=self.test_password,
+            applicationKey=[])
+        assert result, True
+
+        result = self.jira.delete_user(self.test_username)
+        assert result, True
+
     @flaky
     def test_add_group(self):
         if self._should_skip_for_pycontribs_instance():

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2013,7 +2013,7 @@ class UserAdministrationTests(unittest.TestCase):
         # test creating users with no application access (used for Service Desk)
         result = self.jira.add_user(
             self.test_username, self.test_email, password=self.test_password,
-            applicationKeys=[])
+            applicationKeys=['jira-software'])
         assert result, True
 
         result = self.jira.delete_user(self.test_username)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2013,7 +2013,7 @@ class UserAdministrationTests(unittest.TestCase):
         # test creating users with no application access (used for Service Desk)
         result = self.jira.add_user(
             self.test_username, self.test_email, password=self.test_password,
-            applicationKeys=['jira-software'])
+            application_keys=['jira-software'])
         assert result, True
 
         result = self.jira.delete_user(self.test_username)


### PR DESCRIPTION
The jira api has a parameter to allow you to specify which applications the user has access to.  By default, a user has access to all applications.  If you want to specify which applications a user can use, specify them with a list (e.g. `applicationKeys=['jira-software']`) . If a user is only being created to be a reporter for Jira Service Desk purposes, use `applicationKeys=[]`.