### PR TITLE
add_worklog user assignee field updated, now you can specify user to …

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1677,7 +1677,7 @@ class JIRA(object):
             data['author'] = {"name": user,
                               'self': self.JIRA_BASE_URL + '/rest/api/latest/user?username=' + user,
                               'displayName': user,
-                              'active': False
+                              'active': True
                               }
             data['updateAuthor'] = data['author']
         # report bug to Atlassian: author and updateAuthor parameters are


### PR DESCRIPTION
There was issue in adding worklog, user field is not working in original code, so I have updated add_worklog jira rest request input parameter.
With this author and updateAuthor fields are in working state