### PR TITLE
Decrease maximum version for external argparse

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-argparse; python_version<'3.2'
+argparse; python_version<'2.7'
 defusedxml
 ordereddict; python_version<'3.1'
 pbr>=3.0.0


### PR DESCRIPTION
While packaging jira for NixOS, I came across errors regarding "argparse not found". Turns out that argparse is available in Python >= 3.2 _and_ Python >= 2.7, see also:

https://docs.python.org/2/library/argparse.html

Note that this specification cannot be expressed in full generality: we have no logical "OR" in the pip requirements language, apparently.