### PR TITLE
Fixes add_worklog started time

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1672,7 +1672,7 @@ class JIRA(object):
 
         if started is not None:
             # based on REST Browser it needs: "2014-06-03T08:21:01.273+0000"
-            data['started'] = started.strftime("%Y-%m-%dT%H:%M:%S.000%z")
+            data['started'] = started.strftime("%Y-%m-%dT%H:%M:%S.000+0000%z")
         if user is not None:
             data['author'] = {"name": user,
                               'self': self.JIRA_BASE_URL + '/rest/api/latest/user?username=' + user,


### PR DESCRIPTION
Bug reported through issue #369:
- Added .000+0000%z to the strftime conversion. Tested with my jira
instance and it now creates a worklog fine with the started parameter
set as a datetime object. It does not capture milliseconds, as they are
essentially all gettting rounded down.

Supersedes #514 