### PR TITLE
Add posargs to tox.ini.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ sitepackages=False
 commands=
     python -m pip check
     python -m flake8
-    python -m pytest
+    python -m pytest {posargs}
 passenv =
     CI
     CI_JIRA_*


### PR DESCRIPTION
- The purpose of this is to allow someone to test an individual test
  or set of tests while doing development.