### PR TITLE
remove ordereddict requirement

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -85,11 +85,7 @@ from jira.utils import json_loads
 from jira.utils import threaded_requests
 from pkg_resources import parse_version
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    # noinspection PyUnresolvedReferences
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 
 from six import integer_types
 from six import string_types

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 argparse; python_version<'2.7'
 defusedxml
-ordereddict; python_version<'3.1'
 pbr>=3.0.0
 requests-oauthlib>=0.6.1
 requests>=2.10.0


### PR DESCRIPTION
collections.OrderedDict is new from Python 2.7. The requirement ordereddict (package) is for Python 2.6 and below. Since jira does not support Python versions before 2.7 (as per the classifiers in setup.cfg), we don't need this backport any more.