### PR TITLE
Make Kerberos option mutual_authentication configurable

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2483,6 +2483,13 @@ class JIRA(object):
         from requests_kerberos import HTTPKerberosAuth
         from requests_kerberos import OPTIONAL
 
+        mutual_authentication = OPTIONAL
+        if kerberos_options.get('mutual_authentication') == 'DISABLED':
+            mutual_authentication = DISABLED
+        else:
+            raise ValueError("Unknown value for mutual_authentication: %s" %
+                             kerberos_options['mutual_authentication'])
+
         if kerberos_options.get('mutual_authentication', 'OPTIONAL') == 'OPTIONAL':
             mutual_authentication = OPTIONAL
         elif kerberos_options.get('mutual_authentication') == 'DISABLED':


### PR DESCRIPTION
Cherry-picked from #473 (by @pbabinca):

    Before this change mutual_authentication was set to requests_kerberos.OPTIONAL.
    This option value doesn't change.

(the original PR is closed for being out-of-date and the author seems somewhat inactive.)