### PR TITLE
 group_members should return sorted user keys

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -991,9 +991,11 @@ class JIRA(object):
 
         result = {}
         for user in r['users']['items']:
-            result[user['name']] = {'fullname': user['displayName'], 'email': user.get('emailAddress', 'hidden'),
-                                    'active': user['active']}
-        return result
+            result[user['key']] = {'name': user['name'],
+                                   'fullname': user['displayName'],
+                                   'email': user.get('emailAddress', 'hidden'),
+                                   'active': user['active']}
+        return OrderedDict(sorted(result.items(), key=lambda t: t[0]))
 
     def add_group(self, groupname):
         """Create a new group in JIRA.


### PR DESCRIPTION
Updates group_mebers() to return a sorted dictionary
of users where user key is used instead of name attribute
which can be a duplicate.

Fixes: #281
Signed-off-by: Sorin Sbarnea <sorin.sbarnea@gmail.com>