### PR TITLE
[POC] support the plugin REST API

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -62,6 +62,7 @@ from jira.resources import Issue
 from jira.resources import IssueLink
 from jira.resources import IssueLinkType
 from jira.resources import IssueType
+from jira.resources import Plugin
 from jira.resources import Priority
 from jira.resources import Project
 from jira.resources import RemoteLink
@@ -78,6 +79,8 @@ from jira.resources import Version
 from jira.resources import Votes
 from jira.resources import Watchers
 from jira.resources import Worklog
+
+from jira.resources import get_plugin_resource
 
 from jira import __version__
 from jira.utils import CaseInsensitiveDict
@@ -3373,6 +3376,19 @@ class JIRA(object):
         else:
             raise NotImplementedError('No API for moving issues to backlog for agile_rest_path="%s"' %
                                       self._options['agile_rest_path'])
+
+    def plugins(self):
+        r_json = get_plugin_resource(self)
+        return [
+            Plugin(self._options, self._session, raw_plugin_json)
+            for raw_plugin_json in r_json['plugins']
+        ]
+
+    def plugin(self, key):
+        if not key.endswith('-key'):
+            key = key + '-key'
+        r_json = get_plugin_resource(self, key)
+        return Plugin(self._options, self._session, r_json)
 
 
 class GreenHopper(JIRA):

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -6,6 +6,7 @@ This module implements the Resource classes that translate JSON from JIRA REST r
 into usable objects.
 """
 
+import datetime
 import logging
 import re
 import time
@@ -19,6 +20,7 @@ except ImportError:
 import json
 
 from six import iteritems
+from six.moves.urllib.parse import urljoin
 from six import string_types
 from six import text_type
 
@@ -888,6 +890,43 @@ class RequestType(Resource):
         if raw:
             self._parse_raw(raw)
 
+
+# Plugins
+
+
+# FIXME this is not a real resource
+class _PluginResource(Resource):
+    def __init__(self, options, session, raw=None):
+        Resource.__init__(self, 'invalid', options, session)
+        if raw:
+            self._parse_raw(raw)
+
+
+class PluginLicense(_PluginResource):
+    # We need to use __getattribute__ instead of __getattr__ as for __getattr__
+    # the parent implementation is preferred
+    def __getattribute__(self, item):
+        val = super(_PluginResource, self).__getattribute__(item)
+
+        # convert date integers to datetime objects
+        if item.endswith('Date') and isinstance(val, int):
+            seconds, milliseconds = divmod(val, 1000)
+            return \
+                datetime.datetime.fromtimestamp(seconds) \
+                + datetime.timedelta(milliseconds=milliseconds)
+        else:
+            return val
+
+
+class Plugin(_PluginResource):
+    def resolve(self):
+        r_json = get_plugin_resource(self, None, self.raw['links']['self'])
+        return type(self)(self._options, self._session, r_json)
+
+    def license(self):
+        r_json = get_plugin_resource(self, None, self.raw['links']['self'] + '/license')
+        return PluginLicense(self._options, self._session, r_json)
+
 # Utilities
 
 
@@ -966,3 +1005,13 @@ def cls_for_resource(resource_literal):
     else:
         # Generic Resource without specialized update/delete behavior
         return Resource
+
+
+def get_plugin_resource(self, path='', link=None):
+    server = self._options['server']
+    if link is None:
+        url = server + '/rest/plugins/1.0/' + path
+    else:
+        url = urljoin(server, link)
+    r = self._session.get(url, headers={'Accept': '*'})
+    return r.json()


### PR DESCRIPTION
The plugin API is behind websudo, so other authentication mechanism than
basic will probably need extra logic.

Usage example, check for plugin license expiry:

```py
for plugin in jira.plugins():
    if plugin.usesLicensing:
        license = plugin.license()
        for attr in ['expiryDate', 'maintenanceExpiryDate']:
            date = getattr(license, attr, None)
            if date is not None:
                print('{}: {}'.format(plugin.name, date))
                break
```

Supercedes: #367 