### PR TITLE
Async improvement: Allow setting the number of worker threads for JIRA._fetch_pages

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -292,6 +292,7 @@ class JIRA(object):
     :param get_server_info: If true it will fetch server version info first to determine if some API calls
         are available.
     :param async_: To enable asynchronous requests for those actions where we implemented it, like issue update() or delete().
+    :param async_workers: Set the number of worker threads for async operations.
     :param timeout: Set a read/connect timeout for the underlying calls to JIRA (default: None)
         Obviously this means that you cannot rely on the return code when this is enabled.
     """
@@ -307,6 +308,7 @@ class JIRA(object):
         "verify": True,
         "resilient": True,
         "async": False,
+        "async_workers": 2,
         "client_cert": None,
         "check_update": False,
         "headers": {
@@ -325,7 +327,7 @@ class JIRA(object):
     AGILE_BASE_URL = GreenHopperResource.AGILE_BASE_URL
 
     def __init__(self, server=None, options=None, basic_auth=None, oauth=None, jwt=None, kerberos=False, kerberos_options=None,
-                 validate=False, get_server_info=True, async_=False, logging=True, max_retries=3, proxies=None,
+                 validate=False, get_server_info=True, async_=False, async_workers=2, logging=True, max_retries=3, proxies=None,
                  timeout=None, auth=None):
         """Construct a JIRA client instance.
 
@@ -374,6 +376,7 @@ class JIRA(object):
         :param get_server_info: If true it will fetch server version info first to determine if some API calls
             are available.
         :param async_: To enable async requests for those actions where we implemented it, like issue update() or delete().
+        :param async_workers: Set the number of worker threads for async operations.
         :param timeout: Set a read/connect timeout for the underlying calls to JIRA (default: None)
         Obviously this means that you cannot rely on the return code when this is enabled.
         :param auth: Set a cookie auth token if this is required.
@@ -395,6 +398,7 @@ class JIRA(object):
             options['server'] = server
         if async_:
             options['async'] = async_
+            options['async_workers'] = async_workers
 
         self.logging = logging
 
@@ -549,6 +553,7 @@ class JIRA(object):
                 async_class = FuturesSession
             except ImportError:
                 pass
+            async_workers = self._options['async_workers']
         page_params = params.copy() if params else {}
         if startAt:
             page_params['startAt'] = startAt
@@ -582,7 +587,7 @@ class JIRA(object):
                 if async_class is not None and not is_last and (
                         total is not None and len(items) < total):
                     async_fetches = []
-                    future_session = async_class(session=self._session)
+                    future_session = async_class(session=self._session, max_workers=async_workers)
                     for start_index in range(page_start, total, page_size):
                         page_params = params.copy()
                         page_params['startAt'] = start_index

--- a/jira/client.py
+++ b/jira/client.py
@@ -308,7 +308,7 @@ class JIRA(object):
         "verify": True,
         "resilient": True,
         "async": False,
-        "async_workers": 2,
+        "async_workers": 5,
         "client_cert": None,
         "check_update": False,
         "headers": {
@@ -327,7 +327,7 @@ class JIRA(object):
     AGILE_BASE_URL = GreenHopperResource.AGILE_BASE_URL
 
     def __init__(self, server=None, options=None, basic_auth=None, oauth=None, jwt=None, kerberos=False, kerberos_options=None,
-                 validate=False, get_server_info=True, async_=False, async_workers=2, logging=True, max_retries=3, proxies=None,
+                 validate=False, get_server_info=True, async_=False, async_workers=5, logging=True, max_retries=3, proxies=None,
                  timeout=None, auth=None):
         """Construct a JIRA client instance.
 


### PR DESCRIPTION
**Summary**
This PR allows users to configure the number of worker threads used when `JIRA._fetch_pages` is run in async mode.

**Background**
Async mode for `JIRA._fetch_pages` is implemented using `requests_futures` module, which itself is a wrapper for using `requests` with `concurrent.futures.ThreadPoolExecutor`. `requests_futures` uses a default of 2 worker threads instead of  `ThreadPoolExecutor`'s default of 5 × # of CPU's. Since `JIRA._fetch_pages` provides no interface for overriding the `requests_futures` default, it results in async mode only using up to 2 threads.

**Performance tests**
Here's the result of some basic tests, running against Apache's public facing Jira instance at https://issues.apache.org/jira:

```
from time import time

from jira import JIRA

JIRA_USER = 'myusername'
JIRA_PASS = 'mypassword'

auth = (JIRA_USER, JIRA_PASS)
jql = 'created>"-5d"'

print('## No async')
jira = JIRA(server='https://issues.apache.org/jira', basic_auth=auth, async_=False)
start = time(); len(jira.search_issues(jql, maxResults=False)); end = time(); print('Time to complete:', end-start)

print('## Async with default of 2 worker threads')
jira = JIRA(server='https://issues.apache.org/jira', basic_auth=auth, async_=True)
start = time(); len(jira.search_issues(jql, maxResults=False)); end = time(); print('Time to complete:', end-start)

print('## Async with 5 worker threads')
jira = JIRA(server='https://issues.apache.org/jira', basic_auth=auth, async_=True, async_workers=5)
start = time(); len(jira.search_issues(jql, maxResults=False)); end = time(); print('Time to complete:', end-start)
```

```
## No async
Time to complete: 52.44412875175476
## Async with default of 2 worker threads
Time to complete: 24.775141954421997
## Async with 5 worker threads
Time to complete: 11.562492847442627
```

**Other considerations**
This library currently has two very different methods of executing async behaviour. `JIRA._fetch_pages`is dependent on `requests_futures` use of `concurrent.futures` library, using 2 worker threads, and other operations such as updating issues depend on `JIRA.async_do` which provides an interface to a manually managed threadpool of up to 10 worker threads. At some point these two approaches should be unified by a common interface, so that the defined number of worker threads apply to all async operations available in this library, and so all async operations share a common model for executing tasks concurrently. That's beyond the scope of the proposed change here however. One step at a time!