### PR TITLE
Prevent mutation of original fields list JIRA.search_issues

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2064,6 +2064,9 @@ class JIRA(object):
         if fields is None:
             fields = []
 
+        if isinstance(fields, list):
+            fields = fields.copy()
+
         if isinstance(fields, string_types):
             fields = fields.split(",")
 

--- a/jira/client.py
+++ b/jira/client.py
@@ -2063,11 +2063,9 @@ class JIRA(object):
         """
         if fields is None:
             fields = []
-
-        if isinstance(fields, list):
+        elif isinstance(fields, list):
             fields = fields.copy()
-
-        if isinstance(fields, string_types):
+        elif isinstance(fields, string_types):
             fields = fields.split(",")
 
         # this will translate JQL field names to REST API Name


### PR DESCRIPTION
This is to fix #418 , where JIRA.search_issues can be seen to mutate the original list of fields passed to it.

To avoid this behaviour, this change simply checks if `fields` is a list and creates a copy of it. 