### PR TITLE
avoid pycrypto dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 argparse; python_version<'2.7'
 defusedxml
+oauthlib[signedtoken]>=1.0.0  # dep of requests-oauthlib, to avoid pycrypto. See: https://github.com/pycontribs/jira/issues/619
 pbr>=3.0.0
 requests-oauthlib>=0.6.1
 requests>=2.10.0


### PR DESCRIPTION
Bumps oathlib version in order to avoid case where
pycrypto may endup as a dependecy. This makes
jira library more portable as pycrypto is deprecated
and does not build on many systems.
