### PR TITLE
Fix Issue comparsion with None

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -590,7 +590,7 @@ class Issue(Resource):
 
     def __eq__(self, other):
         """Comparison method."""
-        return self.id == other.id
+        return other is not None and self.id == other.id
 
 
 class Comment(Resource):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -709,6 +709,7 @@ class IssueTests(unittest.TestCase):
         issue1 = self.jira.issue(self.issue_1)
         issue2 = self.jira.issue(self.issue_2)
         issues = self.jira.search_issues('key=%s' % self.issue_1)
+        self.assertTrue(issue1 != None)
         self.assertTrue(issue1 == issues[0])
         self.assertFalse(issue2 == issues[0])
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -709,7 +709,7 @@ class IssueTests(unittest.TestCase):
         issue1 = self.jira.issue(self.issue_1)
         issue2 = self.jira.issue(self.issue_2)
         issues = self.jira.search_issues('key=%s' % self.issue_1)
-        self.assertTrue(issue1 != None)
+        self.assertTrue(issue1 is not None)
         self.assertTrue(issue1 == issues[0])
         self.assertFalse(issue2 == issues[0])
 


### PR DESCRIPTION
When you try to compare an issue with `None` code blows up and tells that `None` doesn't have a `.id` attribute.

This simple short circuits the comparison so that if `other` is `None` it doesn't tries to access a non existing field.