### PR TITLE
Improved support for passing list of fields to search_issues

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2355,9 +2355,9 @@ class JIRA(object):
         :type maxResults: int
         :param validate_query: Whether or not the query should be validated. (Default: True)
         :type validate_query: bool
-        :param fields: comma-separated string of issue fields to include in the results.
+        :param fields: comma-separated string or list of issue fields to include in the results.
             Default is to include all fields.
-        :type fields: Optional[str]
+        :type fields: Optional[str or list]
         :param expand: extra information to fetch inside each resource
         :type expand: Optional[str]
         :param json_result: JSON response will be returned when this parameter is set to True.
@@ -2367,12 +2367,10 @@ class JIRA(object):
         :rtype: dict or :class:`~jira.client.ResultList`
 
         """
-        if fields is None:
-            fields = []
-        elif isinstance(fields, list):
-            fields = fields.copy()
-        elif isinstance(fields, string_types):
+        if isinstance(fields, string_types):
             fields = fields.split(",")
+        else:
+            fields = list(fields or [])
 
         # this will translate JQL field names to REST API Name
         # most people do know the JQL names so this will help them use the API easier


### PR DESCRIPTION
The public docs for pycontribs don't acknowledge `list` as a supported type for passing fields via `search_issues`, however support for it is implemented.

This fixes a bug introduced by [this](https://github.com/pycontribs/jira/pull/625#) PR, where list copying was implemented using functionality only present in Python 3. This PR uses more universally supported method of copying lists, and also adds `list` as a supported input type in the documentation.

I've intentionally implemented this to work with other iterables (sets, tuples, etc) however that should again be considered an internal implementation detail.