### PR TITLE
Add projectKeyOrID param to JIRA.boards()

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -3061,13 +3061,14 @@ class JIRA(object):
     """
 
     @translate_resource_args
-    def boards(self, startAt=0, maxResults=50, type=None, name=None, projectKeyOrID=projectKeyOrID):
+    def boards(self, startAt=0, maxResults=50, type=None, name=None, projectKeyOrID=None):
         """Get a list of board resources.
 
         :param startAt: The starting index of the returned boards. Base index: 0.
         :param maxResults: The maximum number of boards to return per page. Default: 50
         :param type: Filters results to boards of the specified type. Valid values: scrum, kanban.
         :param name: Filters results to boards that match or partially match the specified name.
+        :param projectKeyOrID: Filters results to boards that match the specified project key or ID.
         :rtype: ResultList[Board]
 
         When old GreenHopper private API is used, paging is not enabled and all parameters are ignored.

--- a/jira/client.py
+++ b/jira/client.py
@@ -3061,7 +3061,7 @@ class JIRA(object):
     """
 
     @translate_resource_args
-    def boards(self, startAt=0, maxResults=50, type=None, name=None):
+    def boards(self, startAt=0, maxResults=50, type=None, name=None, projectKeyOrID=projectKeyOrID):
         """Get a list of board resources.
 
         :param startAt: The starting index of the returned boards. Base index: 0.
@@ -3077,6 +3077,8 @@ class JIRA(object):
             params['type'] = type
         if name:
             params['name'] = name
+        if projectKeyOrID:
+            params['projectKeyOrId'] = projectKeyOrID
 
         if self._options['agile_rest_path'] == GreenHopperResource.GREENHOPPER_REST_PATH:
             # Old, private API did not support pagination, all records were present in response,


### PR DESCRIPTION
JIRA's modern agile REST API supports searching for boards by project key or ID, e.g. https://myjirainstance.com/rest/agile/1.0/board?projectKeyOrId=PROJKEY

I added a param to boards() to allow this on the python side.