### PR TITLE
Fix warnings

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -514,16 +514,15 @@ class JIRA(object):
     def close(self):
         session = getattr(self, "_session", None)
         if session is not None:
+            try:
+                session.close()
+            except TypeError:
+                # TypeError: "'NoneType' object is not callable"
+                # Could still happen here because other references are also
+                # in the process to be torn down, see warning section in
+                # https://docs.python.org/2/reference/datamodel.html#object.__del__
+                pass
             self._session = None
-            if self.sys_version_info < (3, 4, 0):  # workaround for https://github.com/kennethreitz/requests/issues/2303
-                try:
-                    session.close()
-                except TypeError:
-                    # TypeError: "'NoneType' object is not callable"
-                    # Could still happen here because other references are also
-                    # in the process to be torn down, see warning section in
-                    # https://docs.python.org/2/reference/datamodel.html#object.__del__
-                    pass
 
     def _check_for_html_error(self, content):
         # JIRA has the bad habit of returning errors in pages with 200 and

--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -83,7 +83,7 @@ class ResilientSession(Session):
     def __recoverable(self, response, url, request, counter=1):
         msg = response
         if isinstance(response, ConnectionError):
-            logging.warning("Got ConnectionError [%s] errno:%s on %s %s\n%s\%s" % (
+            logging.warning("Got ConnectionError [%s] errno:%s on %s %s\n%s\n%s" % (
                 response, response.errno, request, url, vars(response), response.__dict__))
         if hasattr(response, 'status_code'):
             if response.status_code in [502, 503, 504, 401]:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -479,17 +479,17 @@ class AttachmentTests(unittest.TestCase):
 
     def test_1_add_remove_attachment(self):
         issue = self.jira.issue(self.issue_1)
-        attachment = self.jira.add_attachment(issue,
-                                              open(TEST_ATTACH_PATH, 'rb'),
-                                              "new test attachment")
-        new_attachment = self.jira.attachment(attachment.id)
-        msg = "attachment %s of issue %s" % (new_attachment.__dict__, issue)
-        self.assertEqual(
-            new_attachment.filename, 'new test attachment', msg=msg)
-        self.assertEqual(
-            new_attachment.size, os.path.getsize(TEST_ATTACH_PATH), msg=msg)
-        # JIRA returns a HTTP 204 upon successful deletion
-        self.assertEqual(attachment.delete().status_code, 204)
+        with open(TEST_ATTACH_PATH, 'rb') as f:
+            attachment = self.jira.add_attachment(
+                issue, f, "new test attachment")
+            new_attachment = self.jira.attachment(attachment.id)
+            msg = "attachment %s of issue %s" % (new_attachment.__dict__, issue)
+            self.assertEqual(
+                new_attachment.filename, 'new test attachment', msg=msg)
+            self.assertEqual(
+                new_attachment.size, os.path.getsize(TEST_ATTACH_PATH), msg=msg)
+            # JIRA returns a HTTP 204 upon successful deletion
+            self.assertEqual(attachment.delete().status_code, 204)
 
 
 @flaky

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1285,7 +1285,7 @@ class IssueTests(unittest.TestCase):
         serialised_sprint = getattr(updated_issue_1.fields, sprint_customfield)[0]
 
         # Too hard to serialise the sprint object. Performing simple regex match instead.
-        assert re.search('\[id=' + str(s.id) + ',', serialised_sprint)
+        assert re.search(r'\[id=' + str(s.id) + ',', serialised_sprint)
 
         # self.jira.add_issues_to_sprint(s.id, self.issue_2)
 
@@ -1734,7 +1734,7 @@ class UserTests(unittest.TestCase):
     def test_user(self):
         user = self.jira.user(self.test_manager.CI_JIRA_ADMIN)
         self.assertEqual(user.name, self.test_manager.CI_JIRA_ADMIN)
-        self.assertRegex(user.emailAddress, '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$')
+        self.assertRegex(user.emailAddress, r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$')
 
     @pytest.mark.xfail(reason='query returns empty list')
     def test_search_assignable_users_for_projects(self):


### PR DESCRIPTION
Fix several warnings:
```python
test: AttachmentTests.test_1_add_remove_attachment
tests/tests.py:484 unclosed file <_io.BufferedReader name='.../tests/tests.py'>

test: SessionTests.test_session_with_no_logged_in_user_raises
resilientsession.py:86 invalid escape sequence \\%'
tests/tests.py:1289 invalid escape sequence \\[
tests/tests.py:1738 invalid escape sequence \\.
```
Also fix an unclosed socket (showed by the test `OtherTests.test_session_invalid_login`):
```python
client.py:512 unclosed <ssl.SSLSocket fd=13, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('192.168.0.14', 44314), raddr=('104.192.139.50', 443)>
```