### PR TITLE
Document that when searching, by default all fields are included

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2060,7 +2060,8 @@ class JIRA(object):
         :param maxResults: maximum number of issues to return. Total number of results
             is available in the ``total`` attribute of the returned :class:`~jira.client.ResultList`.
             If maxResults evaluates as False, it will try to get all issues in batches.
-        :param fields: comma-separated string of issue fields to include in the results
+        :param fields: comma-separated string of issue fields to include in the results.
+            Default is to include all fields.
         :param expand: extra information to fetch inside each resource
         :param json_result: JSON response will be returned when this parameter is set to True.
                 Otherwise, :class:`~jira.client.ResultList` will be returned.


### PR DESCRIPTION
With a default value of `fields=None` and a description of "comma-separated string of issue fields to include in the results" it sounds like the default is to return no fields. In reality is it the opposite, and all fields are returned. This is just a simple change to the documentation to (hopefully) make that clearer.