### PR TITLE
Start/end sprint fix

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -3158,7 +3158,7 @@ class JIRA(object):
         if endDate:
             payload['endDate'] = endDate
         if state:
-            if self._options['agile_rest_path'] != GreenHopperResource.GREENHOPPER_REST_PATH:
+            if self._options['agile_rest_path'] == GreenHopperResource.GREENHOPPER_REST_PATH:
                 raise NotImplementedError('Public JIRA API does not support state update')
             payload['state'] = state
 


### PR DESCRIPTION
If you change the agile_rest_path from 'greenhopper' to 'agile' at the connection
moment to the JIRA instance, then you can update the sprint state, eg:
- start the sprint - state 'active'
- complete the sprint - state 'closed'

In order to change the sprint state you must always provide also
the following parameters: sprintId, name, startDate, endDate.
Reference: https://docs.atlassian.com/jira-software/REST/7.3.1/#agile/1.0/sprint-updateSprint

This is fixing 2 issues:
- Ability to complete/end/finish a sprint #305
- Ability to change Sprint state #123

Signed-off-by: Mihai Catalin Stefan <mihaics3@gmail.com>