### PR TITLE
Fix create_board failure

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -3754,10 +3754,8 @@ class JIRA(object):
             for p in project_ids.split(','):
                 ids.append(self.project(p).id)
             project_ids = ','.join(ids)
-       
         if location_id is not None:
             location_id = self.project(location_id).id
-
         payload['name'] = name
         if isinstance(project_ids, string_types):
             project_ids = project_ids.split(',')

--- a/jira/client.py
+++ b/jira/client.py
@@ -3754,9 +3754,10 @@ class JIRA(object):
             for p in project_ids.split(','):
                 ids.append(self.project(p).id)
             project_ids = ','.join(ids)
-        
-        location_id = self.project(location_id).id
-        
+       
+        if location_id != None:
+            location_id = self.project(location_id).id
+                
         payload['name'] = name
         if isinstance(project_ids, string_types):
             project_ids = project_ids.split(',')

--- a/jira/client.py
+++ b/jira/client.py
@@ -3754,7 +3754,9 @@ class JIRA(object):
             for p in project_ids.split(','):
                 ids.append(self.project(p).id)
             project_ids = ','.join(ids)
-
+        
+        location_id = self.project(location_id).id
+        
         payload['name'] = name
         if isinstance(project_ids, string_types):
             project_ids = project_ids.split(',')

--- a/jira/client.py
+++ b/jira/client.py
@@ -3755,9 +3755,9 @@ class JIRA(object):
                 ids.append(self.project(p).id)
             project_ids = ','.join(ids)
        
-        if location_id != None:
+        if location_id is not None:
             location_id = self.project(location_id).id
-                
+
         payload['name'] = name
         if isinstance(project_ids, string_types):
             project_ids = project_ids.split(',')


### PR DESCRIPTION
location_id (project key) was not translated into into the database ID (number).
Tested using the following script:

```
#Initiate connection to JIRA.
print "Authenticating with server..."
authed_jira = JIRA(options, basic_auth=(username, password))
print "Ok."

#Read project name
project = authed_jira.project(prjkey)
prjname = project.name

#Create board for everything

#First create filter for the board
fltrjql = "project = " + prjkey + " ORDER BY RANK"
filter = authed_jira.create_filter(prjname, "Board for all the issues of the project", fltrjql)

#Create board using filter
boardname = prjname + " Issues"
authed_jira.create_board(boardname, prjkey, preset='scrum', location_type='project', location_id=prjkey)
