### PR TITLE
Fix User regular expression to proper identify the User resource.

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -1054,7 +1054,7 @@ resource_class_map = {
     r'securitylevel/[^/]+$': SecurityLevel,
     r'status/[^/]+$': Status,
     r'statuscategory/[^/]+$': StatusCategory,
-    r'user\?accountId.+$': User,
+    r'user\?(username|accountId).+$': User,
     r'group\?groupname.+$': Group,
     r'version/[^/]+$': Version,
     # GreenHopper specific resources

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -1054,7 +1054,7 @@ resource_class_map = {
     r'securitylevel/[^/]+$': SecurityLevel,
     r'status/[^/]+$': Status,
     r'statuscategory/[^/]+$': StatusCategory,
-    r'user\?username.+$': User,
+    r'user\?accountId.+$': User,
     r'group\?groupname.+$': Group,
     r'version/[^/]+$': Version,
     # GreenHopper specific resources


### PR DESCRIPTION
Today (Nov 1st) JIRA API changed the self link.
They start using `accountId` instead of `username`.

This PR is to fix the regular expression (`resource_class_map`) to identify the User resource.