### PR TITLE
Fix worklog timezone handling

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -139,6 +139,7 @@
         "trw",
         "twz",
         "txcwsb",
+        "tzinfo",
         "ucfirst",
         "ul",
         "uname",

--- a/jira/client.py
+++ b/jira/client.py
@@ -1918,7 +1918,10 @@ class JIRA(object):
 
         if started is not None:
             # based on REST Browser it needs: "2014-06-03T08:21:01.273+0000"
-            data['started'] = started.strftime("%Y-%m-%dT%H:%M:%S.000+0000%z")
+            if started.tzinfo is None:
+                data['started'] = started.strftime("%Y-%m-%dT%H:%M:%S.000+0000")
+            else:
+                data['started'] = started.strftime("%Y-%m-%dT%H:%M:%S.000%z")
         if user is not None:
             data['author'] = {"name": user,
                               'self': self.JIRA_BASE_URL + '/rest/api/latest/user?username=' + user,


### PR DESCRIPTION
Fix time string formatting in worklog creation, to allow for both naive and timezone aware datetime objects