### PR TITLE
Use proxies for deactivate_user in cloud endpoint

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -3109,7 +3109,8 @@ class JIRA(object):
             url = self._options['server'] + '/admin/rest/um/1/user/deactivate?username=%s' % (username)
             # We can't use our existing session here - this endpoint is fragile and objects to extra headers
             try:
-                r = requests.post(url, headers={'Cookie': self.authCookie, 'Content-Type': 'application/json'}, data={})
+                r = requests.post(url, headers={'Cookie': self.authCookie, 'Content-Type': 'application/json'}, 
+                                  proxies=self._session.proxies, data={})
                 if r.status_code == 200:
                     return True
                 else:

--- a/jira/client.py
+++ b/jira/client.py
@@ -3109,7 +3109,7 @@ class JIRA(object):
             url = self._options['server'] + '/admin/rest/um/1/user/deactivate?username=%s' % (username)
             # We can't use our existing session here - this endpoint is fragile and objects to extra headers
             try:
-                r = requests.post(url, headers={'Cookie': self.authCookie, 'Content-Type': 'application/json'}, 
+                r = requests.post(url, headers={'Cookie': self.authCookie, 'Content-Type': 'application/json'},
                                   proxies=self._session.proxies, data={})
                 if r.status_code == 200:
                     return True


### PR DESCRIPTION
Reuse proxies stored in the `_session` object.

this should fix #667 - which was already fixed but did lack of proxy support (which is a requirement for some environments like mine ... ).