### PR TITLE
Fix requirement conflicts via oathlib<3.0.0

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -159,7 +159,8 @@
         "xscs",
         "xsrf",
         "yanc",
-        "ztravisdeb"
+        "ztravisdeb",
+        "LGPL"
     ],
     "flagWords": [],
     "allowCompoundWords": true,

--- a/cspell.json
+++ b/cspell.json
@@ -146,6 +146,7 @@
         "undoc",
         "unstaged",
         "untranslate",
+        "venv",
         "virtualenv",
         "virtualenvs",
         "websudo",

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -312,19 +312,19 @@ class Resource(object):
                 data['fields'][
                     'summary'] = self.fields.summary.replace("/n", "")
             for error in error_list:
-                if re.search(u"^User '(.*)' was not found in the system\.", error, re.U):
+                if re.search(r"^User '(.*)' was not found in the system\.", error, re.U):
                     m = re.search(
-                        u"^User '(.*)' was not found in the system\.", error, re.U)
+                        r"^User '(.*)' was not found in the system\.", error, re.U)
                     if m:
                         user = m.groups()[0]
                     else:
-                        raise NotImplemented()
-                if re.search("^User '(.*)' does not exist\.", error):
-                    m = re.search("^User '(.*)' does not exist\.", error)
+                        raise NotImplementedError()
+                if re.search(r"^User '(.*)' does not exist\.", error):
+                    m = re.search(r"^User '(.*)' does not exist\.", error)
                     if m:
                         user = m.groups()[0]
                     else:
-                        raise NotImplemented()
+                        raise NotImplementedError()
 
             if user:
                 logging.warning(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,21 +6,21 @@ hacking>=0.13
 MarkupSafe>=0.23
 mock; python_version<'3.3'
 oauthlib
-pre-commit
+pre-commit  # MIT
 py >= 1.4
 pytest-cache
 pytest-cov
 pytest-instafail
 pytest-timeout>=1.3.1
 pytest-xdist>=1.14
-pytest>=2.9.1
-PyYAML>=3.13
-requests_mock
-requires.io
-tenacity
-tox-pyenv
-tox>=2.3.1
-unittest2; python_version<'3.1'
-wheel>=0.24.0
-xmlrunner>=1.7.7
-yanc>=0.3.3
+pytest>=2.9.1,<5.0  # MIT
+PyYAML>=3.13  # MIT
+requests_mock  # Apache-2
+requires.io  # UNKNOWN!!!
+tenacity  # Apache-2
+tox-pyenv  # Apache-2
+tox>=2.3.1  # MIT
+unittest2; python_version<'3.1'  # BSD
+wheel>=0.24.0  # MIT
+xmlrunner>=1.7.7  # LGPL
+yanc>=0.3.3  # GPL

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 argparse; python_version<'2.7'
 defusedxml
 functools32; python_version<'3.2'  # PSF license
-oauthlib[signedtoken]>=1.0.0  # dep of requests-oauthlib, to avoid pycrypto. See: https://github.com/pycontribs/jira/issues/619
+oauthlib[signedtoken]>=1.0.0,<3.0.0  # dep of requests-oauthlib, to avoid pycrypto. See: https://github.com/pycontribs/jira/issues/619
 pbr>=3.0.0
-requests-oauthlib>=0.6.1
+requests-oauthlib>=1.1.0
 requests>=2.10.0
 requests_toolbelt
 setuptools>=20.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 argparse; python_version<'2.7'
 defusedxml
 functools32; python_version<'3.2'  # PSF license
-oauthlib[signedtoken]>=1.0.0,<3.0.0  # dep of requests-oauthlib, to avoid pycrypto. See: https://github.com/pycontribs/jira/issues/619
 pbr>=3.0.0
 requests-oauthlib>=1.1.0
 requests>=2.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,8 +79,8 @@ upload-dir = docs/build/html
 max-line-length=160
 exclude=build,.eggs,.tox
 statistics=yes
-ignore =
-# TODO(ssbarnea): remove ignored flake8 rules one by one by fixing them.
+ignore = W504
+# W504: causes too many false positives and unreliable between far flake8 versions
 
 [pep8]
 exclude=build,lib,.tox,third,*.egg,docs,packages,.eggs,node_modules

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -475,7 +475,8 @@ class AttachmentTests(unittest.TestCase):
     def test_0_attachment_meta(self):
         meta = self.jira.attachment_meta()
         self.assertTrue(meta['enabled'])
-        self.assertEqual(meta['uploadLimit'], 10485760)
+        # we have no control over server side upload limit
+        self.assertIn('uploadLimit', meta)
 
     def test_1_add_remove_attachment(self):
         issue = self.jira.issue(self.issue_1)

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,8 @@ commands=
     python -m pytest {posargs}
 setenv =
     PIP_LOG={envdir}/pip.log
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
 passenv =
     CI
     CI_JIRA_*

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,13 @@
 [tox]
-minversion = 2.3.1
+minversion = 3.2.1
 envlist = lint,py27,py37,py36,py35,py34,docs
 skip_missing_interpreters = true
+
+# workaround for https://github.com/tox-dev/tox/issues/149
+# require =
+#    tox-pip-extensions>=1.4.2
+# tox_pip_extensions_ext_venv_update = true
+# ^ disabled due to https://github.com/Yelp/venv-update/pull/215
 
 [testenv:docs]
 basepython=python
@@ -17,13 +23,14 @@ usedevelop = True
 # avoid using deps= due to https://github.com/tox-dev/tox/issues/149
 # hide deps from stdout https://github.com/tox-dev/tox/issues/601
 list_dependencies_command=echo
-
+deps =
+    -rrequirements.txt
+    -rrequirements-dev.txt
 extras =
     cli
     opt
 sitepackages=False
 commands=
-    pip install -q -rrequirements.txt -rrequirements-dev.txt
     bash -c 'find . | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf'
     python -m pip check
     python -m pytest {posargs}
@@ -49,6 +56,5 @@ whitelist_externals =
 
 [testenv:lint]
 commands=
-    pip install -q -rrequirements.txt -rrequirements-dev.txt
     bash -c "npm install && npm run spell"
     python -m pre_commit run --all


### PR DESCRIPTION
Temporary disable use of tox-pip-extensions due to lingering bugs in venv-update.

Adds oathlib<3.0.0 because is not supported by requests-oauth-lib.
As soon this conflict will be sorted upstream we will update it.