### PR TITLE
Mitigate shadowing of logging module

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -114,6 +114,7 @@ except ImportError:
 #    "which means that there is a big change of having problems. " \
 #    "Possible workaround http://stackoverflow.com/a/17628350/99834" % encoding)
 
+# If this is changed needs to be changed again in JIRA.__init__()
 logging.getLogger('jira').addHandler(NullHandler())
 
 
@@ -369,7 +370,7 @@ class JIRA(object):
                  get_server_info=True,
                  async_=False,
                  async_workers=5,
-                 logging=True,
+                 logging=None,
                  max_retries=3,
                  proxies=None,
                  timeout=None,
@@ -443,8 +444,8 @@ class JIRA(object):
         :type proxies: Optional[Any]
         :param auth: Set a cookie auth token if this is required.
         :type auth: Optional[Tuple[str,str]]
-        :param logging: Determine whether or not logging should be enabled. (Default: True)
-        :type logging: bool
+        :param logging: Determine whether or not logging should be enabled. Deprecated. (Default: None)
+        :type logging: bool, None, logging
         """
         # force a copy of the tuple to be used in __del__() because
         # sys.version_info could have already been deleted in __del__()
@@ -465,7 +466,16 @@ class JIRA(object):
             options['async'] = async_
             options['async_workers'] = async_workers
 
-        self.logging = logging
+        # Breaks https://docs.python.org/3/howto/logging.html#library-config
+        # TODO remove in future version
+        if logging is not None:
+            warnings.warn("Deprecated option. Breaks correct logging.", DeprecationWarning)
+        if logging is None or (isinstance(logging, bool) and not logging):
+            import logging
+            logging.getLogger('jira').addHandler(NullHandler())
+        if isinstance(logging, bool) and logging:
+            import logging
+            logging.getLogger('jira')
 
         self._options = copy.copy(JIRA.DEFAULT_OPTIONS)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1971,7 +1971,7 @@ class OtherTests(unittest.TestCase):
 
     def test_session_invalid_login(self):
         try:
-            JIRA('https://jira.atlassian.com', basic_auth=("xxx", "xxx"), validate=True, )
+            JIRA('https://jira.atlassian.com', basic_auth=("xxx", "xxx"), validate=True)
         except Exception as e:
             self.assertIsInstance(e, JIRAError)
             # 20161010: jira cloud returns 500

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -105,8 +105,8 @@ def get_unique_project_name():
         jid = 'T' + hashify(user + os.environ['TRAVIS_JOB_NUMBER'])
     else:
         identifier = user + \
-            chr(ord('A') + sys.version_info[0]) + \
-            chr(ord('A') + sys.version_info[1])
+                     chr(ord('A') + sys.version_info[0]) + \
+                     chr(ord('A') + sys.version_info[1])
         jid = 'Z' + hashify(identifier)
     return jid
 
@@ -806,7 +806,7 @@ class IssueTests(unittest.TestCase):
                 'summary': 'This issue will not succeed',
                 'description': "Should not be seen.",
                 'priority': {
-                'name': 'Blah'}},
+                    'name': 'Blah'}},
             {'project': {
                 'key': self.project_a},
                 'issuetype': {
@@ -1575,7 +1575,8 @@ class ProjectTests(unittest.TestCase):
         self.assertEqual(test.name, name)
         version.delete()
 
-    @unittest.skip("temporary disabled because roles() return a dictionary of role_name:role_url and we have no call to convert it to proper Role()")
+    @unittest.skip(
+        "temporary disabled because roles() return a dictionary of role_name:role_url and we have no call to convert it to proper Role()")
     def test_project_roles(self):
         project = self.jira.project(self.project_b)
         role_name = 'Developers'
@@ -1944,7 +1945,6 @@ class VersionTests(unittest.TestCase):
 
     @flaky
     def test_update_version(self):
-
         version = self.jira.create_version('new updated version 1',
                                            self.project_b, releaseDate='2015-03-11',
                                            description='new to be updated!')
@@ -1973,10 +1973,7 @@ class OtherTests(unittest.TestCase):
 
     def test_session_invalid_login(self):
         try:
-            JIRA('https://jira.atlassian.com',
-                 basic_auth=("xxx", "xxx"),
-                 validate=True,
-                 logging=False)
+            JIRA('https://jira.atlassian.com', basic_auth=("xxx", "xxx"), validate=True, )
         except Exception as e:
             self.assertIsInstance(e, JIRAError)
             # 20161010: jira cloud returns 500
@@ -1997,14 +1994,14 @@ class SessionTests(unittest.TestCase):
         self.assertIsNotNone(user.raw['session'])
 
     def test_session_with_no_logged_in_user_raises(self):
-        anon_jira = JIRA('https://jira.atlassian.com', logging=False)
+        anon_jira = JIRA('https://jira.atlassian.com')
         self.assertRaises(JIRAError, anon_jira.session)
 
     # @pytest.mark.skipif(platform.python_version() < '3', reason='Does not work with Python 2')
     # @not_on_custom_jira_instance  # takes way too long
     def test_session_server_offline(self):
         try:
-            JIRA('https://127.0.0.1:1', logging=False, max_retries=0)
+            JIRA('https://127.0.0.1:1', max_retries=0)
         except Exception as e:
             self.assertIn(type(e), (JIRAError, requests.exceptions.ConnectionError, AttributeError), e)
             return
@@ -2014,8 +2011,7 @@ class SessionTests(unittest.TestCase):
 class AsyncTests(unittest.TestCase):
 
     def setUp(self):
-        self.jira = JIRA('https://jira.atlassian.com', logging=False,
-                         async_=True, validate=False, get_server_info=False)
+        self.jira = JIRA('https://jira.atlassian.com', async_=True, validate=False, get_server_info=False)
 
     def test_fetch_pages(self):
         """Tests that the JIRA._fetch_pages method works as expected. """
@@ -2100,8 +2096,8 @@ class UserAdministrationTests(unittest.TestCase):
 
     def _should_skip_for_pycontribs_instance(self):
         return self.test_manager.CI_JIRA_ADMIN == 'ci-admin' and (
-            self.test_manager.CI_JIRA_URL ==
-            "https://pycontribs.atlassian.net")
+                self.test_manager.CI_JIRA_URL ==
+                "https://pycontribs.atlassian.net")
 
     def test_add_and_remove_user(self):
         if self._should_skip_for_pycontribs_instance():
@@ -2283,7 +2279,6 @@ class JiraServiceDeskTests(unittest.TestCase):
 
 
 if __name__ == '__main__':
-
     # when running tests we expect various errors and we don't want to display them by default
     logging.getLogger("requests").setLevel(logging.FATAL)
     logging.getLogger("urllib3").setLevel(logging.FATAL)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -104,9 +104,7 @@ def get_unique_project_name():
         # JIRA even if it is documented as supported.
         jid = 'T' + hashify(user + os.environ['TRAVIS_JOB_NUMBER'])
     else:
-        identifier = user + \
-                     chr(ord('A') + sys.version_info[0]) + \
-                     chr(ord('A') + sys.version_info[1])
+        identifier = user + chr(ord('A') + sys.version_info[0]) + chr(ord('A') + sys.version_info[1])
         jid = 'Z' + hashify(identifier)
     return jid
 
@@ -2096,8 +2094,8 @@ class UserAdministrationTests(unittest.TestCase):
 
     def _should_skip_for_pycontribs_instance(self):
         return self.test_manager.CI_JIRA_ADMIN == 'ci-admin' and (
-                self.test_manager.CI_JIRA_URL ==
-                "https://pycontribs.atlassian.net")
+            self.test_manager.CI_JIRA_URL ==
+            "https://pycontribs.atlassian.net")
 
     def test_add_and_remove_user(self):
         if self._should_skip_for_pycontribs_instance():


### PR DESCRIPTION
This relates to and should FIX #755  .
The way I see it it should fix #298 too.
Problem: Because of the shadowing you will get an exception whenever the warning or error would have been printed.
Python Interpreter: 2.7, 3.7
jira-python: 2.0.0 and older
OS: Linux Debian, Linux Ubuntu

Stacktrace:

> Exception AttributeError: "Magic instance has no attribute 'cookie'" in <bound method Magic.__del__ of <magic.Magic instance at 0x7fe763bc4830>> ignored
> WARNING:root:Bug https://jira.atlassian.com/browse/JRA-59676 trying again...
> WARNING:root:Bug https://jira.atlassian.com/browse/JRA-59676 trying again...
> WARNING:root:Bug https://jira.atlassian.com/browse/JRA-59676 trying again...
> Traceback (most recent call last):
>   File "./test.py", line 51, in <module>
> [...]
>   File "/usr/local/lib/python2.7/dist-packages/jira/client.py", line 476, in __init__
>     logging.error("invalid server_info: %s", si)
> AttributeError: 'bool' object has no attribute 'error'
> 

What I did in the pull request:
604e9b1 
* I assumed that you want to follow https://docs.python.org/3/howto/logging.html#library-config
* I changed the Interface for JIRA() so that logging defaults to None. 
* Tried to convey that logging is deprecated
* If the call is JIRA() or JIRA(logging=Null) or JIRA(logging=False) I reimport logging and repeat the line with logging.NullHandler()
* If the call is JIRA(logging=True) I reimport logging but with the default logger.
* I removed one last line that used self.logging and removed the variable 

2caecbe 
* Fixed up tests.py so that JIRA() will no longer be called with the attribute 
* Did some reformatting while at it. 

Testint:
Tox did fail.
[test-result.txt](https://github.com/pycontribs/jira/files/2845249/test-result.txt)

Main reasons where 
* AttachmentTests.test_0_attachment_meta
* JiraShellTests.test_jirashell_command_exists
* pycontribs.atlassian.net does not respond as expected
* sphinx and dependencies were not installed in pip