### PR TITLE
Fix flake

### DIFF
--- a/jira/jirashell.py
+++ b/jira/jirashell.py
@@ -265,7 +265,7 @@ def main():
         # would report utf-8
         # see: https://stackoverflow.com/a/23847316/99834
         stdin, stdout, stderr = sys.stdin, sys.stdout, sys.stderr
-        reload(sys)
+        reload(sys)  # noqa
         sys.stdin, sys.stdout, sys.stderr = stdin, stdout, stderr
         sys.setdefaultencoding(os.environ.get('PYTHONIOENCODING', 'utf-8'))
 

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -318,13 +318,13 @@ class Resource(object):
                     if m:
                         user = m.groups()[0]
                     else:
-                        raise NotImplemented()
+                        raise NotImplementedError()
                 if re.search("^User '(.*)' does not exist\.", error):
                     m = re.search("^User '(.*)' does not exist\.", error)
                     if m:
                         user = m.groups()[0]
                     else:
-                        raise NotImplemented()
+                        raise NotImplementedError()
 
             if user:
                 logging.warning(

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from __future__ import print_function
+
 """
 This module implements the Resource classes that translate JSON from JIRA REST resources
 into usable objects.
@@ -9,6 +10,7 @@ into usable objects.
 import logging
 import re
 import time
+
 try:  # Python 2.7+
     from logging import NullHandler
 except ImportError:
@@ -202,6 +204,7 @@ class Resource(object):
                 return self.raw[item]
             else:
                 raise AttributeError("%r object has no attribute %r (%s)" % (self.__class__, item, e))
+
     # def __getstate__(self):
     #     """
     #     Pickling the resource; using the raw dict
@@ -312,15 +315,15 @@ class Resource(object):
                 data['fields'][
                     'summary'] = self.fields.summary.replace("/n", "")
             for error in error_list:
-                if re.search(u"^User '(.*)' was not found in the system\.", error, re.U):
+                if re.search(u"^User '(.*)' was not found in the system[.]", error, re.U):
                     m = re.search(
-                        u"^User '(.*)' was not found in the system\.", error, re.U)
+                        u"^User '(.*)' was not found in the system[.]", error, re.U)
                     if m:
                         user = m.groups()[0]
                     else:
                         raise NotImplementedError()
-                if re.search("^User '(.*)' does not exist\.", error):
-                    m = re.search("^User '(.*)' does not exist\.", error)
+                if re.search("^User '(.*)' does not exist[.]", error):
+                    m = re.search("^User '(.*)' does not exist[.]", error)
                     if m:
                         user = m.groups()[0]
                     else:
@@ -988,6 +991,7 @@ class RequestType(Resource):
         Resource.__init__(self, 'servicedesk/{0}/requesttype', options, session, '{server}/rest/servicedeskapi/{path}')
         if raw:
             self._parse_raw(raw)
+
 
 # Utilities
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,8 @@ upload-dir = docs/build/html
 max-line-length=160
 exclude=build,.eggs,.tox
 statistics=yes
-ignore =
+ignore=W504
+# W504 or W503 you get one or the other every time. Choose W504 because of https://github.com/PyCQA/pycodestyle/issues/498
 # TODO(ssbarnea): remove ignored flake8 rules one by one by fixing them.
 
 [pep8]

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -259,7 +259,7 @@ class JiraTestManager(object):
                     try:
                         self.jira_admin.delete_project(self.project_a)
                     except Exception as e:
-                        pass
+                        logging.warning(e)
 
                 try:
                     self.jira_admin.project(self.project_b)
@@ -270,7 +270,7 @@ class JiraTestManager(object):
                     try:
                         self.jira_admin.delete_project(self.project_b)
                     except Exception as e:
-                        pass
+                        logging.warning(e)
 
                 # wait for the project to be deleted
                 for i in range(1, 20):
@@ -341,8 +341,7 @@ class JiraTestManager(object):
                 sleep(1)
                 counter += 1
                 if counter > 60:
-                    logging.fatal("Something is clearly not right with " +
-                                  "initialization, killing the tests to prevent a " +
+                    logging.fatal("Something is clearly not right with initialization, killing the tests to prevent a "
                                   "deadlock.")
                     sys.exit(3)
 
@@ -2081,9 +2080,7 @@ class UserAdministrationTests(unittest.TestCase):
                     'permission to modify users.')
 
     def _should_skip_for_pycontribs_instance(self):
-        return self.test_manager.CI_JIRA_ADMIN == 'ci-admin' and (
-            self.test_manager.CI_JIRA_URL ==
-            "https://pycontribs.atlassian.net")
+        return self.test_manager.CI_JIRA_ADMIN == 'ci-admin' and (self.test_manager.CI_JIRA_URL == "https://pycontribs.atlassian.net")
 
     def test_add_and_remove_user(self):
         if self._should_skip_for_pycontribs_instance():


### PR DESCRIPTION
Fixes so that lintian hopefully works again.
Had to ignore W504 as W503 and W504 are mutually exclusive . W504 seems to be the accepted as the better solution. (https://github.com/PyCQA/pycodestyle/issues/792)
reload(sys) will always fail in newer python versions and there seems to be no solution that works for new and old. (The if clause around it seems to be there for a reason)
To fix W605 I had to replace escaping the dot with putting it into a character class expression. (https://stackoverflow.com/questions/13989640/regular-expression-to-match-a-dot) 