### PR TITLE
no-check -> nocheck

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -349,7 +349,7 @@ class JIRA(object):
             # 'Accept': 'application/json',  # default for REST
             # 'Pragma': 'no-cache',
             # 'Expires': 'Thu, 01 Jan 1970 00:00:00 GMT'
-            'X-Atlassian-Token': 'no-check'}}
+            'X-Atlassian-Token': 'nocheck'}}
 
     checked_version = False
 


### PR DESCRIPTION
Prevents warnings on the server:

```
Use of the 'nocheck' value for X-Atlassian-Token has been deprecated since rest 3.0.0. Please use a value of 'no-check' instead.
```