### PR TITLE
Fixed tag build trigger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ language: python
 branches:
   only:
     - master
-    - /v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$/
+    - /^\d+\.\d+(\.\d+)?(-\S*)?$/
 
 cache:
   - pip


### PR DESCRIPTION
Our version tags are not using the `v` prrefix, this assures that
when a tag is pushed, we trigger a build.

Deploy stage is already configured to trigger only on tags.

Change-Id: Id495b012bb37312d5fc02e25ed19272e77eaebc2