### PR TITLE
adds allow_no_value to ConfigParser options in findfile function

### DIFF
--- a/jira/config.py
+++ b/jira/config.py
@@ -60,7 +60,7 @@ def get_jira(profile=None, url="http://localhost:2990", username="admin", passwo
                 return possible
         return None
     config = configparser.ConfigParser(defaults={'user': None, 'pass': None, 'appid': appid, 'autofix': autofix,
-                                                 'verify': 'yes' if verify else 'no'})
+                                                 'verify': 'yes' if verify else 'no'}, allow_no_value=True)
 
     config_file = findfile('config.ini')
     if config_file:


### PR DESCRIPTION
I ran into an issue when trying to port some custom jira scripts from python2 -> python3 and found the below link which also resolved my issue.

https://github.com/ralphbean/bugwarrior/pull/600/commits/da9221ea673b32fe3f9732b13c818604cf657230