### PR TITLE
Added X-Atlassian-Force-Acccount-Id header for testing

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -345,6 +345,7 @@ class JIRA(object):
         "delay_reload": 0,
         "headers": {
             'Cache-Control': 'no-cache',
+            'X-Atlassian-Force-Account-Id': 'true',
             # 'Accept': 'application/json;charset=UTF-8',  # default for REST
             'Content-Type': 'application/json',  # ;charset=UTF-8',
             # 'Accept': 'application/json',  # default for REST


### PR DESCRIPTION
See #770 for context.
 This will force API endpoints to use accountId fields. This code _will not_ work with the current system. For example, querying user endpoints fail due to the use of `user?username={0}`, vs `user?accountId={0}`. I would consider this PR mostly just as a way to see which tests fail.