### PR TITLE
Pin flake8 version when using with pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v1.3.0
+    rev: v2.1.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -11,18 +11,20 @@ repos:
       - id: check-merge-conflict
       - id: check-symlinks
       - id: check-vcs-permalinks
-      - id: flake8
       - id: debug-statements
       - id: requirements-txt-fixer
       - id: check-yaml
         files: .*\.(yaml|yml)$
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.11.1
+    rev: v1.15.0
     hooks:
       - id: yamllint
         files: \.(yaml|yml)$
-
   - repo: https://github.com/openstack-dev/bashate.git
     rev: 0.6.0
     hooks:
       - id: bashate
+  - repo: https://github.com/PyCQA/flake8
+    rev: 3.7.7
+    hooks:
+      - id: flake8

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,6 @@ package:
 req:
 	@$(PREFIX)requires.io update-site -t ac3bbcca32ae03237a6aae2b02eb9411045489bb -r $(PACKAGE_NAME)
 
-hooks:
-	@$(PREFIX)python -m flake8 --install-hook 2>/dev/null || true
-
 install: prepare
 	$(PREFIX)pip install .
 

--- a/jira/jirashell.py
+++ b/jira/jirashell.py
@@ -265,7 +265,7 @@ def main():
         # would report utf-8
         # see: https://stackoverflow.com/a/23847316/99834
         stdin, stdout, stderr = sys.stdin, sys.stdout, sys.stderr
-        reload(sys)
+        reload(sys)  # noqa
         sys.stdin, sys.stdout, sys.stderr = stdin, stdout, stderr
         sys.setdefaultencoding(os.environ.get('PYTHONIOENCODING', 'utf-8'))
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -258,7 +258,7 @@ class JiraTestManager(object):
                 else:
                     try:
                         self.jira_admin.delete_project(self.project_a)
-                    except Exception as e:
+                    except Exception as e:  # noqa
                         pass
 
                 try:
@@ -269,7 +269,7 @@ class JiraTestManager(object):
                 else:
                     try:
                         self.jira_admin.delete_project(self.project_b)
-                    except Exception as e:
+                    except Exception as e:  # noqa
                         pass
 
                 # wait for the project to be deleted


### PR DESCRIPTION
Avoids errors caused by flake8 updates by pinning its version.
Use `pre-commit autoupdate` to bump linters.