### PR TITLE
Feat: allow saving password in OS keychain/keyring

### DIFF
--- a/jira/jirashell.py
+++ b/jira/jirashell.py
@@ -7,25 +7,26 @@ over HTTP BASIC or Kerberos.
 """
 
 from __future__ import print_function
+
+import argparse
+import os
+import sys
+import webbrowser
+from getpass import getpass
+
+import requests
+from oauthlib.oauth1 import SIGNATURE_RSA
+from requests_oauthlib import OAuth1
+from six.moves import input
+from six.moves.urllib.parse import parse_qsl
+
+from jira import JIRA, __version__
+
 try:
     import configparser
 except ImportError:
     from six.moves import configparser
 
-from six.moves import input
-from six.moves.urllib.parse import parse_qsl
-
-import argparse
-from getpass import getpass
-from jira import __version__
-from jira import JIRA
-from oauthlib.oauth1 import SIGNATURE_RSA
-import os
-import requests
-from requests_oauthlib import OAuth1
-import sys
-
-import webbrowser
 
 CONFIG_PATH = os.path.join(
     os.path.expanduser('~'), '.jira-python', 'jirashell.ini')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 argparse; python_version<'2.7'
 defusedxml
 functools32; python_version<'3.2'  # PSF license
+keyring<19  # to support python 2.7 and 3.4
 pbr>=3.0.0
 requests-oauthlib>=1.1.0
 requests>=2.10.0

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,20 +1,26 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import pytest  # noqa
+import io
 import requests  # noqa
 import sys
 
 try:
     # python 3.4+ should use builtin unittest.mock not mock package
-    from unittest.mock import patch
+    from unittest.mock import patch, MagicMock
 except ImportError:
-    from mock import patch
+    from mock import patch, MagicMock
 
 from jira import Role, Issue, JIRA, JIRAError, Project  # noqa
 import jira.jirashell as jirashell
 
 
-def test_unicode(requests_mock, capsys):
+@pytest.fixture
+def testargs():
+    return ["jirashell", "-s", "http://localhost"]
+
+
+def test_unicode(requests_mock, capsys, testargs):
     """This functions tests that CLI tool does not throw an UnicodeDecodeError
     when it attempts to display some Unicode error message, which can happen
     when printing exceptions received from the remote HTTP server.
@@ -23,9 +29,77 @@ def test_unicode(requests_mock, capsys):
     Likely not needed for Py3 versions.
     """
     requests_mock.register_uri('GET', 'http://localhost/rest/api/2/serverInfo', text='Δεν βρέθηκε', status_code=404)
-    testargs = ["jirashell", "-s", "http://localhost"]
+
     with patch.object(sys, 'argv', testargs):
         jirashell.main()
     captured = capsys.readouterr()
     assert captured.err.startswith("JiraError HTTP 404")
     assert captured.out == ""
+
+
+@pytest.fixture
+def mock_keyring():
+    _keyring = {}
+
+    def mock_set_password(server, username, password):
+        _keyring[(server, username)] = password
+
+    def mock_get_password(server, username):
+        return _keyring.get((server, username), '')
+
+    mock_kr = MagicMock(
+        set_password=MagicMock(side_effect=mock_set_password),
+        get_password=MagicMock(side_effect=mock_get_password),
+        _keyring=_keyring,
+    )
+    mocked_module = patch.object(jirashell, 'keyring', new=mock_kr)
+    yield mocked_module.start()
+    mocked_module.stop()
+
+
+@pytest.mark.timeout(4)
+def test_no_password_try_keyring(requests_mock, capsys, testargs, mock_keyring, monkeypatch):
+    requests_mock.register_uri('GET', 'http://localhost/rest/api/2/serverInfo', status_code=200)
+
+    # no password provided
+    args = testargs + ['-u', 'test@user']
+    with patch.object(sys, 'argv', args):
+        jirashell.main()
+
+        assert len(requests_mock.request_history) == 0
+        captured = capsys.readouterr()
+        assert captured.err == "No password provided!\nassert ''\n"
+        assert "Getting password from keyring..." == captured.out.strip()
+        assert mock_keyring._keyring == {}
+
+    # password provided, don't save
+    monkeypatch.setattr('sys.stdin', io.StringIO('n'))
+    args = args + ['-p', 'pass123']
+    with patch.object(sys, 'argv', args):
+        jirashell.main()
+
+        assert len(requests_mock.request_history) == 4
+        captured = capsys.readouterr()
+        assert captured.out.strip() == "Would you like to remember password in OS keyring? (y/n)"
+        assert mock_keyring._keyring == {}
+
+    # password provided, save
+    monkeypatch.setattr('sys.stdin', io.StringIO('y'))
+    args = args + ['-p', 'pass123']
+    with patch.object(sys, 'argv', args):
+        jirashell.main()
+
+        assert len(requests_mock.request_history) == 8
+        captured = capsys.readouterr()
+        assert captured.out.strip() == "Would you like to remember password in OS keyring? (y/n)"
+        assert mock_keyring._keyring == {('http://localhost', 'test@user'): 'pass123'}
+
+    # user stored password
+    args = testargs + ['-u', 'test@user']
+    with patch.object(sys, 'argv', args):
+        jirashell.main()
+
+        assert len(requests_mock.request_history) == 12
+        captured = capsys.readouterr()
+        assert "Getting password from keyring..." == captured.out.strip()
+        assert mock_keyring._keyring == {('http://localhost', 'test@user'): 'pass123'}


### PR DESCRIPTION
resolves #784

Considering one thing we could change, is to move the keyring lookup logic inside the JIRA class, so that it's available to library users as well as shell users ...

@ssbarnea how do you feel about this?