### PR TITLE
Fixes #791. If username is not available in headers, get username from account ID.

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -847,6 +847,12 @@ class User(Resource):
         """Comparison."""
         return str(self.name) == str(other.name)
 
+    def find_by_account_id(self, account_id, params=None):
+        orig_resource = self._resource
+        self._resource = 'user?accountId={0}'
+        self.find(account_id, params=params)
+        self._resource = orig_resource
+
 
 class Group(Resource):
     """A JIRA user group."""


### PR DESCRIPTION
See https://github.com/pycontribs/jira/issues/791 for bug explanation.

Appears that Atlassian may have removed username header from API response headers. This Jira lib relies on that header to automatically fill in project "lead" username when creating a new project.