### PR TITLE
Add access to resources.py for users.

### DIFF
--- a/jira/__init__.py
+++ b/jira/__init__.py
@@ -18,6 +18,7 @@ from jira.client import Watchers  # noqa: E402
 from jira.client import Worklog  # noqa: E402
 from jira.config import get_jira  # noqa: E402
 from jira.exceptions import JIRAError  # noqa: E402
+from jira import resources # noqa: E402
 
 __all__ = (
     'Comment',

--- a/jira/__init__.py
+++ b/jira/__init__.py
@@ -18,7 +18,7 @@ from jira.client import Watchers  # noqa: E402
 from jira.client import Worklog  # noqa: E402
 from jira.config import get_jira  # noqa: E402
 from jira.exceptions import JIRAError  # noqa: E402
-from jira import resources # noqa: E402
+from jira import resources  # noqa: E402,E401
 
 __all__ = (
     'Comment',
@@ -28,6 +28,7 @@ __all__ = (
     'JIRAError',
     'Priority',
     'Project',
+    'resources',
     'Role',
     'User',
     'version_info',


### PR DESCRIPTION
Users don't have access to resources, but they should.
For example (Checking types):
```
if isinstance(o, jira.resources.IssueType):
                return {}
```