### PR TITLE
new: add expand option to JIRA.projects

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2228,13 +2228,17 @@ class JIRA(object):
 
     # Projects
 
-    def projects(self):
+    def projects(self, expand=None):
         """Get a list of project Resources from the server visible to the current authenticated user.
 
-        :rtype: List[Project]
+        :param expand: extra information to fetch inside each project
 
+        :type expand: str
         """
-        r_json = self._get_json("project")
+        params = {}
+        if expand is not None:
+            params['expand'] = expand
+        r_json = self._get_json('project', params)
         projects = [
             Project(self._options, self._session, raw_project_json)
             for raw_project_json in r_json

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1503,6 +1503,11 @@ class ProjectTests(unittest.TestCase):
         projects = self.jira.projects()
         self.assertGreaterEqual(len(projects), 2)
 
+    def test_projects_expand(self):
+        projects = self.jira.projects(expand='description')
+        for project in projects:
+            self.assertTrue(hasattr(project, 'description'))
+
     def test_project(self):
         project = self.jira.project(self.project_b)
         self.assertEqual(project.key, self.project_b)


### PR DESCRIPTION
**Issue:** When querying all projects using `JIRA.projects()` there's no option to use the expand feature from the API, for example to be guaranteed to also retrieve the description of a project.

**Solution:** Add an optional parameter to the `JIRA.projects()` which allows specifying an expand parameter, just like e.g. `JIRA.user(id, expand=None)` or `JIRA.group(id, expand=None)`.

**Alternatives:** Earlier I was iterating through all retrieved groups and then individually calling `JIRA.project(project)`, however this invokes an additional API call for every project, which causes major performance degradation when working with large projects.* 

**Changes:** The changed made in this PR are BC and seem too simple to fail - actually it feels too simple so if there's a reason why this wasn't yet implemented then please tell. One concern I have with this PR is that for testing purposes it assumes that the description field is expandable, hence the tests depend on the fact that each project has to have a description, which introduces an implicit dependency.

*In addition, even for this call the same expandable options exist, which seems to me that there's no guarantee that these values are actually present and hence it's more "luck" based.