### PR TITLE
For cloud basic_auth an API Token is used

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -61,6 +61,8 @@ Pass a tuple of (username, password) to the ``basic_auth`` constructor argument:
 
     auth_jira = JIRA(basic_auth=('username', 'password'))
 
+For cloud basic authentication the password is an API TOKEN, not the password of the user. Please read: https://developer.atlassian.com/cloud/jira/platform/jira-rest-api-basic-authentication 
+
 OAuth
 ^^^^^
 


### PR DESCRIPTION
There is a lot of confusion when using basic_auth for the Jira cloud, I personally lost at least 1h with this... 