### PR TITLE
use 'https://your-domain.atlassian.net' as example URL

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -34,7 +34,7 @@ default address for a JIRA instance started from the Atlassian Plugin SDK.
 
 You can manually set the JIRA server to use::
 
-    jac = JIRA('https://jira.atlassian.com')
+    jac = JIRA('https://your-domain.atlassian.net')
 
 Authentication
 --------------


### PR DESCRIPTION
I could not make basic-auth work with "https://jira.atlassian.com" and I the Jira documentation it uses 'https://your-domain.atlassian.net' for examples. Source: https://developer.atlassian.com/cloud/jira/platform/jira-rest-api-basic-authentication/