### PR TITLE
Update assign_issue call to allow use of accountId

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1508,19 +1508,22 @@ class JIRA(object):
 
     # non-resource
     @translate_resource_args
-    def assign_issue(self, issue, assignee):
+    def assign_issue(self, issue, assignee, use_accountId=False):
         """Assign an issue to a user. None will set it to unassigned. -1 will set it to Automatic.
 
         :param issue: the issue ID or key to assign
         :type issue: int or str
-        :param assignee: the user to assign the issue to
+        :param assignee: name or accountId of the user to assign the issue to
         :type assignee: str
+        :param use_accountId: whether to use accountId instead of name
+        :type use_accountId: bool
 
         :rtype: bool
         """
         url = self._options['server'] + \
             '/rest/api/latest/issue/' + str(issue) + '/assignee'
-        payload = {'name': assignee}
+        key = 'accountId' if use_accountId else 'name'
+        payload = {key: assignee}
         r = self._session.put(
             url, data=json.dumps(payload))
         raise_on_error(r)


### PR DESCRIPTION
Assigning by user name was deprecated 2018-10-01 and disabled entirely
2019-04-29. See the deprecation notice:

https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/

See also current api docs:

https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-rest-api-3-issue-issueIdOrKey-assignee-put

Following these changes, `assign_issue` uses the `accountId` of the target
user rather than the `name`. Toward that end this commit adds a flag to
allow the call to `use_accountId` which will default to `False` in case
backward compatibility is an issue.

Attempting to assign by name results in the following `JIRAError` response:

```'accountId' must be the only user identifying query parameter in GDPR strict mode.```

Didn't make any attempt to add tests but extant tests for `assign_issue` should pass.