### PR TITLE
Add expand to JIRA.project and JIRA.projects

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2156,24 +2156,31 @@ class JIRA(object):
 
     # Projects
 
-    def projects(self):
+    def projects(self, expand=None):
         """Get a list of project Resources from the server visible to the current authenticated user.
 
+        :param expand: Extra information to fetch inside each resource
+        :type expand: Optional[str]
         :rtype: List[Project]
 
         """
-        r_json = self._get_json('project')
+        params = {}
+        if expand:
+            params['expand'] = expand
+        r_json = self._get_json('project', params=params)
         projects = [Project(
             self._options, self._session, raw_project_json) for raw_project_json in r_json]
         return projects
 
-    def project(self, id):
+    def project(self, id, expand=None):
         """Get a project Resource from the server.
 
         :param id: ID or key of the project to get
+        :param expand: Extra information to fetch inside each resource
+        :type expand: Optional[str]
         :rtype: Project
         """
-        return self._find_for_resource(Project, id)
+        return self._find_for_resource(Project, id, expand=expand)
 
     # non-resource
     @translate_resource_args

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1427,9 +1427,19 @@ class ProjectTests(unittest.TestCase):
         projects = self.jira.projects()
         self.assertGreaterEqual(len(projects), 2)
 
+    def test_projects_expand(self):
+        project = self.jira.projects(expand='description')[0]
+        self.assertTrue(hasattr(project, 'description'))
+        self.assertFalse(hasattr(project, 'lead'))
+
     def test_project(self):
         project = self.jira.project(self.project_b)
         self.assertEqual(project.key, self.project_b)
+
+    def test_project_expand(self):
+        project = self.jira.project(self.project_b, expand='description')
+        self.assertTrue(hasattr(project, 'description'))
+        self.assertFalse(hasattr(project, 'lead'))
 
     # I have no idea what avatars['custom'] is and I get different results every time
     #    def test_project_avatars(self):


### PR DESCRIPTION
Expand can be provided to projects to include additional information: https://developer.atlassian.com/cloud/jira/platform/rest/v3/?utm_source=%2Fcloud%2Fjira%2Fplatform%2Frest%2F&utm_medium=302#api-rest-api-3-project-get

It currently isn't possible to get at these extra fields, which this changeset addresses.