### PR TITLE
make Jira issues hashable

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -599,6 +599,10 @@ class Issue(Resource):
         """Comparison method."""
         return other is not None and self.id == other.id
 
+    def __hash__(self):
+        """Allow using Issue in sets and as key for dictionaries."""
+        return hash(self.id)
+
 
 class Comment(Resource):
     """An issue comment."""


### PR DESCRIPTION
This allows them to be used in sets or as dictionary keys.

I did not add this to the Resource class as that is inherited by multiple other classes
with differend __eq__ implementations.