### PR TITLE
Add expand to JIRA.project and JIRA.projects

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2401,30 +2401,39 @@ class JIRA(object):
 
     # Projects
 
-    def projects(self) -> List[Project]:
+    def projects(self, expand: Optional[str] = None) -> List[Project]:
         """Get a list of project Resources from the server visible to the current authenticated user.
+
+        Args:
+            expand (Optional[str]): extra information to fetch for each project
+                                    such as projectKeys and description.
 
         Returns:
             List[Project]
 
         """
-        r_json = self._get_json("project")
+        params = {}
+        if expand is not None:
+            params["expand"] = expand
+        r_json = self._get_json("project", params=params)
         projects = [
             Project(self._options, self._session, raw_project_json)
             for raw_project_json in r_json
         ]
         return projects
 
-    def project(self, id: str) -> Project:
+    def project(self, id: str, expand: Optional[str] = None) -> Project:
         """Get a project Resource from the server.
 
         Args:
             id (str): ID or key of the project to get
+            expand (Optional[str]): extra information to fetch for the project
+                                    such as projectKeys and description.
 
         Returns:
             Project
         """
-        return self._find_for_resource(Project, id)
+        return self._find_for_resource(Project, id, expand=expand)
 
     # non-resource
     @translate_resource_args

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1548,9 +1548,23 @@ class ProjectTests(unittest.TestCase):
         projects = self.jira.projects()
         self.assertGreaterEqual(len(projects), 2)
 
+    def test_projects_expand(self):
+        projects = self.jira.projects()
+        for project in projects:
+            self.assertFalse(hasattr(project, "projectKeys"))
+        projects = self.jira.projects(expand="projectKeys")
+        for project in projects:
+            self.assertTrue(hasattr(project, "projectKeys"))
+
     def test_project(self):
         project = self.jira.project(self.project_b)
         self.assertEqual(project.key, self.project_b)
+
+    def test_project_expand(self):
+        project = self.jira.project(self.project_b)
+        self.assertFalse(hasattr(project, "projectKeys"))
+        project = self.jira.project(self.project_b, expand="projectKeys")
+        self.assertTrue(hasattr(project, "projectKeys"))
 
     # I have no idea what avatars['custom'] is and I get different results every time
     #    def test_project_avatars(self):


### PR DESCRIPTION
This is a rebase of #837 

> Expand can be provided to projects to include additional information: https://developer.atlassian.com/cloud/jira/platform/rest/v3/?utm_source=%2Fcloud%2Fjira%2Fplatform%2Frest%2F&utm_medium=302#api-rest-api-3-project-get
>
> It currently isn't possible to get at these extra fields, which this changeset addresses.