### PR TITLE
Retry timeout

### DIFF
--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -76,7 +76,10 @@ class ResilientSession(Session):
 
     def __init__(self, timeout=None):
         self.max_retries = 3
+        # HTTP call timeout
         self.timeout = timeout
+        # base timeout for retry delay
+        self.retry_delay = timeout if timeout else 10
         super(ResilientSession, self).__init__()
 
         # Indicate our preference for JSON to avoid https://bitbucket.org/bspeakmon/jira-python/issue/46 and https://jira.atlassian.com/browse/JRA-38551
@@ -113,7 +116,7 @@ class ResilientSession(Session):
                 msg = "Atlassian's bug https://jira.atlassian.com/browse/JRA-41559"
 
         # Exponential backoff with full jitter.
-        delay = min(60, 10 * 2 ** counter) * random.random()
+        delay = min(60, self.retry_delay * 2 ** counter) * random.random()
         logging.warning(
             "Got recoverable error from %s %s, will retry [%s/%s] in %ss. Err: %s"
             % (request, url, counter, self.max_retries, delay, msg)

--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -100,6 +100,8 @@ class ResilientSession(Session):
                 )
             )
         if hasattr(response, "status_code"):
+            logging.debug("response.headers: %s", response.headers)
+            logging.debug("response.body: %s", response.content)
             if response.status_code in [502, 503, 504, 401]:
                 # 401 UNAUTHORIZED still randomly returned by Atlassian Cloud as of 2017-01-16
                 msg = "%s %s" % (response.status_code, response.reason)
@@ -121,8 +123,6 @@ class ResilientSession(Session):
             "Got recoverable error from %s %s, will retry [%s/%s] in %ss. Err: %s"
             % (request, url, counter, self.max_retries, delay, msg)
         )
-        logging.debug("response.headers: %s", response.headers)
-        logging.debug("response.body: %s", response.content)
         time.sleep(delay)
         return True
 


### PR DESCRIPTION
Two things here:

- A small bug fix when the JIRA API endpoint is unavaiable and an exception is raised
- A feature change to set the exponential retry delay to be based off the timeout value. I think it’s reasonable that if users want a low timeout, they will also want a low retry time. (I was waiting multiple minutes for Jira client to decide the API is unavailable).