### PR TITLE
Update JIRA -> Jira branding and use https for links

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# EditorConfig is awesome: http://EditorConfig.org
+# EditorConfig is awesome: https://editorconfig.org/
 
 # top-most EditorConfig file
 root = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# See http://stackoverflow.com/questions/5533050/gitignore-exclude-folder-but-include-specific-subfolder
+# See https://stackoverflow.com/questions/5533050/gitignore-exclude-folder-but-include-specific-subfolder
 # to understand pattern used to include .idea/codeStyleSettings.xml but not the rest of .idea/
 !.idea/
 .idea/*

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ===================
-JIRA Python Library
+Jira Python Library
 ===================
 
 .. image:: https://img.shields.io/pypi/v/jira.svg
@@ -40,7 +40,7 @@ JIRA Python Library
         :alt: Requirements Status
 
 
-This library eases the use of the JIRA REST API from Python and it has been used in production for years.
+This library eases the use of the Jira REST API from Python and it has been used in production for years.
 
 As this is an open-source project that is community maintained, do not be surprised if some bugs or features are not implemented quickly enough. You are always welcomed to use BountySource_ to motivate others to help.
 
@@ -102,7 +102,7 @@ Setup
 * Fork_ repo
 * Keep it sync_'ed while you are developing
 * Install pyenv_
-* Install `Atlassian JIRA Server`_ for testing
+* Install `Atlassian Jira Server`_ for testing
   - make install-sdk
 * pip install jira[test]
 * Start up Jira Server
@@ -113,7 +113,7 @@ Setup
 .. _Fork: https://help.github.com/articles/fork-a-repo/
 .. _sync: https://help.github.com/articles/syncing-a-fork/
 .. _pyenv: https://amaral.northwestern.edu/resources/guides/pyenv-tutorial
-.. _`Atlassian JIRA Server`: https://www.atlassian.com/software/jira/download
+.. _`Atlassian Jira Server`: https://www.atlassian.com/software/jira/download
 
 
 Credits
@@ -121,13 +121,13 @@ Credits
 
 In addition to all the contributors we would like to thank to these companies:
 
-* Atlassian_ for developing such a powerful issue tracker and for providing a free on-demand JIRA_ instance that we can use for continuous integration testing.
+* Atlassian_ for developing such a powerful issue tracker and for providing a free on-demand Jira_ instance that we can use for continuous integration testing.
 * JetBrains_ for providing us with free licenses of PyCharm_
 * Travis_ for hosting our continuous integration
 * Navicat_ for providing us free licenses of their powerful database client GUI tools.
 
 .. _Atlassian: https://www.atlassian.com/
-.. _JIRA: https://pycontribs.atlassian.net
+.. _Jira: https://pycontribs.atlassian.net
 .. _JetBrains: http://www.jetbrains.com
 .. _PyCharm: http://www.jetbrains.com/pycharm/
 .. _Travis: https://travis-ci.org/

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Jira Python Library
 ------------
 
 .. image:: https://readthedocs.org/projects/jira/badge/?version=master
-        :target: http://jira.readthedocs.io
+        :target: https://jira.readthedocs.io/
 
 .. image:: https://travis-ci.com/pycontribs/jira.svg?branch=master
         :target: https://travis-ci.com/pycontribs/jira
@@ -77,7 +77,7 @@ By default only the basic library dependencies are installed, so if you want
 to use the ``cli`` tool or other optional dependencies do perform a full
 installation using ``pip install jira[opt,cli,test]``
 
-.. _virtualenv: http://www.virtualenv.org/en/latest/index.html
+.. _virtualenv: https://virtualenv.pypa.io/
 
 
 Usage
@@ -85,7 +85,7 @@ Usage
 
 See the documentation_ for full details.
 
-.. _documentation: http://jira.readthedocs.org/en/latest/
+.. _documentation: https://jira.readthedocs.org/en/latest/
 
 
 Development
@@ -128,16 +128,16 @@ In addition to all the contributors we would like to thank to these companies:
 
 .. _Atlassian: https://www.atlassian.com/
 .. _Jira: https://pycontribs.atlassian.net
-.. _JetBrains: http://www.jetbrains.com
-.. _PyCharm: http://www.jetbrains.com/pycharm/
+.. _JetBrains: https://www.jetbrains.com/
+.. _PyCharm: https://www.jetbrains.com/pycharm/
 .. _Travis: https://travis-ci.org/
 .. _navicat: https://www.navicat.com/
 
 .. image:: https://raw.githubusercontent.com/pycontribs/resources/master/logos/x32/logo-atlassian.png
-   :target: http://www.atlassian.com
+   :target: https://www.atlassian.com/
 
 .. image:: https://raw.githubusercontent.com/pycontribs/resources/master/logos/x32/logo-pycharm.png
-    :target: http://www.jetbrains.com/
+    :target: https://www.jetbrains.com/
 
 .. image:: https://raw.githubusercontent.com/pycontribs/resources/master/logos/x32/logo-navicat.png
-    :target: http://www.navicat.com/
+    :target: https://www.navicat.com/

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -4,10 +4,10 @@ Advanced
 Resource Objects and Properties
 ===============================
 
-The library distinguishes between two kinds of data in the JIRA REST API: *resources* and *properties*.
+The library distinguishes between two kinds of data in the Jira REST API: *resources* and *properties*.
 
 A *resource* is a REST entity that represents the current state of something that the server owns; for example,
-the issue called "ABC-123" is a concept managed by JIRA which can be viewed as a resource obtainable at the URL
+the issue called "ABC-123" is a concept managed by Jira which can be viewed as a resource obtainable at the URL
 *http://jira-server/rest/api/latest/issue/ABC-123*. All resources have a *self link*: a root-level property called *self*
 which contains the URL the resource originated from. In jira-python, resources are instances of the *Resource* object
 (or one of its subclasses) and can only be obtained from the server using the ``find()`` method. Resources may be
@@ -20,10 +20,10 @@ connected to other resources: the issue *Resource* is connected to a user *Resou
     user *Resource* object. Whenever a resource contains other resources, the client will attempt to convert them
     to the proper subclass of *Resource*.
 
-A *properties object* is a collection of values returned by JIRA in response to some query from the REST API. Their
+A *properties object* is a collection of values returned by Jira in response to some query from the REST API. Their
 structure is freeform and modeled as a Python dict. Client methods return this structure for calls that do not
 produce resources. For example, the properties returned from the URL *http://jira-server/rest/api/latest/issue/createmeta*
 are designed to inform users what fields (and what values for those fields) are required to successfully create
-issues in the server's projects. Since these properties are determined by JIRA's configuration, they are not resources.
+issues in the server's projects. Since these properties are determined by Jira's configuration, they are not resources.
 
-The JIRA client's methods document whether they will return a *Resource* or a properties object.
+The Jira client's methods document whether they will return a *Resource* or a properties object.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# JIRA Python Client documentation build configuration file, created by
+# Jira Python Client documentation build configuration file, created by
 # sphinx-quickstart on Thu May  3 17:01:50 2012.
 #
 # This file is execfile()d with the current directory set to its containing dir.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -8,7 +8,7 @@ Here's a quick usage example:
 
 .. literalinclude:: ../examples/basic_use.py
 
-Another example shows how to authenticate with your JIRA username and password:
+Another example shows how to authenticate with your Jira username and password:
 
 .. literalinclude:: ../examples/basic_auth.py
 
@@ -23,16 +23,16 @@ Quickstart
 Initialization
 --------------
 
-Everything goes through the JIRA object, so make one::
+Everything goes through the ``JIRA`` object, so make one::
 
     from jira import JIRA
 
     jira = JIRA()
 
-This connects to a JIRA started on your local machine at http://localhost:2990/jira, which not coincidentally is the
-default address for a JIRA instance started from the Atlassian Plugin SDK.
+This connects to a Jira started on your local machine at http://localhost:2990/jira, which not coincidentally is the
+default address for a Jira instance started from the Atlassian Plugin SDK.
 
-You can manually set the JIRA server to use::
+You can manually set the Jira server to use::
 
     jac = JIRA('https://jira.atlassian.com')
 
@@ -40,7 +40,7 @@ Authentication
 --------------
 
 At initialization time, jira-python can optionally create an HTTP BASIC or use OAuth 1.0a access tokens for user
-authentication. These sessions will apply to all subsequent calls to the JIRA object.
+authentication. These sessions will apply to all subsequent calls to the ``JIRA`` object.
 
 The library is able to load the credentials from inside the ~/.netrc file, so put them there instead of keeping them in your source code.
 
@@ -84,11 +84,11 @@ Pass a dict of OAuth properties to the ``oauth`` constructor argument::
     interactive use, ``jirashell`` can perform the dance with you if you don't already have valid tokens.
 
 * The access token and token secret uniquely identify the user.
-* The consumer key must match the OAuth provider configured on the JIRA server.
-* The key cert data must be the private key that matches the public key configured on the JIRA server's OAuth provider.
+* The consumer key must match the OAuth provider configured on the Jira server.
+* The key cert data must be the private key that matches the public key configured on the Jira server's OAuth provider.
 
 See https://confluence.atlassian.com/display/JIRA/Configuring+OAuth+Authentication+for+an+Application+Link for details
-on configuring an OAuth provider for JIRA.
+on configuring an OAuth provider for Jira.
 
 Kerberos
 ^^^^^^^^
@@ -106,7 +106,7 @@ To pass additional options to Kerberos auth use dict ``kerberos_options``, e.g.:
 Issues
 ------
 
-Issues are objects. You get hold of them through the JIRA object::
+Issues are objects. You get hold of them through the ``JIRA`` object::
 
     issue = jira.issue('JRA-1330')
 
@@ -164,7 +164,7 @@ You can even bulk create multiple issues::
     issues = jira.create_issues(field_list=issue_list)
 
 .. note::
-    Project, summary, description and issue type are always required when creating issues. Your JIRA may require
+    Project, summary, description and issue type are always required when creating issues. Your Jira may require
     additional fields for creating issues; see the ``jira.createmeta`` method for getting access to that information.
 
 .. note::
@@ -241,7 +241,7 @@ to quickly find the issues you want::
 Comments
 --------
 
-Comments, like issues, are objects. Get at issue comments through the parent Issue object or the JIRA object's
+Comments, like issues, are objects. Get at issue comments through the parent Issue object or the ``JIRA`` object's
 dedicated method::
 
     comments_a = issue.fields.comment.comments

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,9 +4,9 @@
    contain the root `toctree` directive.
 
 
-Python JIRA
+Python Jira
 ###########
-Python library to work with JIRA APIs
+Python library to work with Jira APIs
 
 .. toctree::
     :numbered:
@@ -19,7 +19,7 @@ Python library to work with JIRA APIs
     api
 
 This documents the ``jira`` python package (version |release|), a Python library designed to ease the use of the
-JIRA REST API. Some basic support for the GreenHopper REST API also exists.
+Jira REST API. Some basic support for the GreenHopper REST API also exists.
 
 Documentation is also available in
 `Dash

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,13 +4,13 @@ Installation
 .. contents:: Contents
    :local:
 
-The easiest (and best) way to install jira-python is through `pip <http://www.pip-installer.org/>`_::
+The easiest (and best) way to install jira-python is through `pip <https://pip.pypa.io/>`_::
 
     $ pip install jira
 
 This will handle the client itself as well as the requirements.
 
-If you're going to run the client standalone, we strongly recommend using a `virtualenv <http://www.virtualenv.org/>`_,
+If you're going to run the client standalone, we strongly recommend using a `virtualenv <https://virtualenv.pypa.io/>`_,
 which pip can also set up for you::
 
     $ pip -E jira_python install jira
@@ -30,10 +30,10 @@ Dependencies
 
 Python 3.5+ is required.
 
-- :py:mod:`requests` - `python-requests <http://docs.python-requests.org>`_ library handles the HTTP business. Usually, the latest version available at time of release is the minimum version required; at this writing, that version is 1.2.0, but any version >= 1.0.0 should work.
+- :py:mod:`requests` - `python-requests <https://pypi.org/project/requests/>`_ library handles the HTTP business. Usually, the latest version available at time of release is the minimum version required; at this writing, that version is 1.2.0, but any version >= 1.0.0 should work.
 - :py:mod:`requests-oauthlib` - Used to implement OAuth. The latest version as of this writing is 0.3.3.
 - :py:mod:`requests-kerberos` - Used to implement Kerberos.
-- :py:mod:`ipython` - The `IPython enhanced Python interpreter <http://ipython.org>`_ provides the fancy chrome used by :ref:`jirashell-label`.
+- :py:mod:`ipython` - The `IPython enhanced Python interpreter <https://ipython.org>`_ provides the fancy chrome used by :ref:`jirashell-label`.
 - :py:mod:`filemagic` - This library handles content-type autodetection for things like image uploads. This will only work on a system that provides libmagic; Mac and Unix will almost always have it preinstalled, but Windows users will have to use Cygwin or compile it natively. If your system doesn't have libmagic, you'll have to manually specify the ``contentType`` parameter on methods that take an image object, such as project and user avatar creation.
 
 Installing through :py:mod:`pip` takes care of these dependencies for you.

--- a/docs/jirashell.rst
+++ b/docs/jirashell.rst
@@ -8,14 +8,14 @@ it, and bang your elbows -- trial and error. A REST design is especially well-su
 Run it from the command line::
 
     $ jirashell -s http://jira.atlassian.com
-    <JIRA Shell (http://jira.atlassian.com)>
+    <Jira Shell (http://jira.atlassian.com)>
 
-    *** JIRA shell active; client is in 'jira'. Press Ctrl-D to exit.
+    *** Jira shell active; client is in 'jira'. Press Ctrl-D to exit.
 
     In [1]:
 
-This is a specialized Python interpreter (built on IPython) that lets you explore JIRA as a service. Any legal
-Python code is acceptable input. The shell builds a JIRA client object for you (based on the launch parameters) and
+This is a specialized Python interpreter (built on IPython) that lets you explore Jira as a service. Any legal
+Python code is acceptable input. The shell builds a ``JIRA`` client object for you (based on the launch parameters) and
 stores it in the ``jira`` object.
 
 Try getting an issue::

--- a/docs/jirashell.rst
+++ b/docs/jirashell.rst
@@ -7,8 +7,8 @@ it, and bang your elbows -- trial and error. A REST design is especially well-su
 
 Run it from the command line::
 
-    $ jirashell -s http://jira.atlassian.com
-    <Jira Shell (http://jira.atlassian.com)>
+    $ jirashell -s https://jira.atlassian.com
+    <Jira Shell (https://jira.atlassian.com)>
 
     *** Jira shell active; client is in 'jira'. Press Ctrl-D to exit.
 

--- a/examples/basic_auth.py
+++ b/examples/basic_auth.py
@@ -1,10 +1,10 @@
-# This script shows how to connect to a JIRA instance with a
+# This script shows how to connect to a Jira instance with a
 # username and password over HTTP BASIC authentication.
 
 from collections import Counter
 from jira import JIRA
 
-# By default, the client will connect to a JIRA instance started from the Atlassian Plugin SDK.
+# By default, the client will connect to a Jira instance started from the Atlassian Plugin SDK.
 # See
 # https://developer.atlassian.com/display/DOCS/Installing+the+Atlassian+Plugin+SDK
 # for details.

--- a/examples/basic_use.py
+++ b/examples/basic_use.py
@@ -3,7 +3,7 @@
 from jira import JIRA
 import re
 
-# By default, the client will connect to a JIRA instance started from the Atlassian Plugin SDK
+# By default, the client will connect to a Jira instance started from the Atlassian Plugin SDK
 # (see https://developer.atlassian.com/display/DOCS/Installing+the+Atlassian+Plugin+SDK for details).
 # Override this with the options parameter.
 options = {"server": "https://jira.atlassian.com"}

--- a/examples/cookie_auth.py
+++ b/examples/cookie_auth.py
@@ -1,10 +1,10 @@
-# This script shows how to connect to a JIRA instance with a
+# This script shows how to connect to a Jira instance with a
 # username and password over HTTP BASIC authentication.
 
 from collections import Counter
 from jira import JIRA
 
-# By default, the client will connect to a JIRA instance started from the Atlassian Plugin SDK.
+# By default, the client will connect to a Jira instance started from the Atlassian Plugin SDK.
 # See
 # https://developer.atlassian.com/display/DOCS/Installing+the+Atlassian+Plugin+SDK
 # for details.

--- a/examples/greenhopper.py
+++ b/examples/greenhopper.py
@@ -2,10 +2,10 @@
 # against jira.atlassian.com.
 from jira.client import GreenHopper
 
-# By default, the client will connect to a JIRA instance started from the Atlassian Plugin SDK
+# By default, the client will connect to a Jira instance started from the Atlassian Plugin SDK
 # (see https://developer.atlassian.com/display/DOCS/Installing+the+Atlassian+Plugin+SDK for details).
 # Override this with the options parameter.
-# GreenHopper is a plugin in a JIRA instance
+# GreenHopper is a plugin in a Jira instance
 options = {"server": "https://jira.atlassian.com"}
 gh = GreenHopper(options)
 

--- a/jira/client.py
+++ b/jira/client.py
@@ -4,7 +4,7 @@ from requests.auth import AuthBase
 
 """
 This module implements a friendly (well, friendlier) interface between the raw JSON
-responses from JIRA and the Resource/dict abstractions provided by this library. Users
+responses from Jira and the Resource/dict abstractions provided by this library. Users
 will construct a JIRA object as described below. Full API documentation can be found
 at: https://jira.readthedocs.io/en/latest/
 """
@@ -39,7 +39,7 @@ from jira.exceptions import JIRAError
 from jira.resilientsession import raise_on_error
 from jira.resilientsession import ResilientSession
 
-# JIRA specific resources
+# Jira-specific resources
 from jira.resources import Attachment
 from jira.resources import Board
 from jira.resources import Comment
@@ -238,22 +238,22 @@ class JiraCookieAuth(AuthBase):
 
 
 class JIRA(object):
-    """User interface to JIRA.
+    """User interface to Jira.
 
-    Clients interact with JIRA by constructing an instance of this object and calling its methods. For addressable
-    resources in JIRA -- those with "self" links -- an appropriate subclass of :py:class:`Resource` will be returned
+    Clients interact with Jira by constructing an instance of this object and calling its methods. For addressable
+    resources in Jira -- those with "self" links -- an appropriate subclass of :py:class:`Resource` will be returned
     with customized ``update()`` and ``delete()`` methods, along with attribute access to fields. This means that calls
     of the form ``issue.fields.summary`` will be resolved into the proper lookups to return the JSON value at that
     mapping. Methods that do not return resources will return a dict constructed from the JSON response or a scalar
     value; see each method's documentation for details on what that method returns.
 
-    Without any arguments, this client will connect anonymously to the JIRA instance
+    Without any arguments, this client will connect anonymously to the Jira instance
     started by the Atlassian Plugin SDK from one of the 'atlas-run', ``atlas-debug``,
     or ``atlas-run-standalone`` commands. By default, this instance runs at
-    ``http://localhost:2990/jira``. The ``options`` argument can be used to set the JIRA instance to use.
+    ``http://localhost:2990/jira``. The ``options`` argument can be used to set the Jira instance to use.
 
     Authentication is handled with the ``basic_auth`` argument. If authentication is supplied (and is
-    accepted by JIRA), the client will remember it for subsequent requests.
+    accepted by Jira), the client will remember it for subsequent requests.
 
     For quick command line access to a server, see the ``jirashell`` script included with this distribution.
 
@@ -263,9 +263,9 @@ class JIRA(object):
         of the following properties:
 
         * server -- the server address and context path to use. Defaults to ``http://localhost:2990/jira``.
-        * rest_path -- the root REST path to use. Defaults to ``api``, where the JIRA REST resources live.
+        * rest_path -- the root REST path to use. Defaults to ``api``, where the Jira REST resources live.
         * rest_api_version -- the version of the REST resources under rest_path to use. Defaults to ``2``.
-        * agile_rest_path - the REST path to use for JIRA Agile requests. Defaults to ``greenhopper`` (old, private
+        * agile_rest_path - the REST path to use for Jira Agile requests. Defaults to ``greenhopper`` (old, private
                 API). Check `GreenHopperResource` for other supported values.
         * verify -- Verify SSL certs. Defaults to ``True``.
         * client_cert -- a tuple of (cert,key) for the requests library for client side SSL
@@ -278,9 +278,9 @@ class JIRA(object):
 
         * access_token -- OAuth access token for the user
         * access_token_secret -- OAuth access token secret to sign with the key
-        * consumer_key -- key of the OAuth application link defined in JIRA
+        * consumer_key -- key of the OAuth application link defined in Jira
         * key_cert -- private key file to sign requests with (should be the pair of the public key supplied to
-          JIRA in the OAuth application link)
+          Jira in the OAuth application link)
 
     :param kerberos: If true it will enable Kerberos authentication.
     :param kerberos_options: A dict of properties for Kerberos authentication. The following properties are possible:
@@ -298,13 +298,13 @@ class JIRA(object):
 
         Example jwt structure: ``{'secret': SHARED_SECRET, 'payload': {'iss': PLUGIN_KEY}}``
 
-    :param validate: If true it will validate your credentials first. Remember that if you are accessing JIRA
+    :param validate: If true it will validate your credentials first. Remember that if you are accessing Jira
         as anonymous it will fail to instantiate.
     :param get_server_info: If true it will fetch server version info first to determine if some API calls
         are available.
     :param async_: To enable asynchronous requests for those actions where we implemented it, like issue update() or delete().
     :param async_workers: Set the number of worker threads for async operations.
-    :param timeout: Set a read/connect timeout for the underlying calls to JIRA (default: None)
+    :param timeout: Set a read/connect timeout for the underlying calls to Jira (default: None)
         Obviously this means that you cannot rely on the return code when this is enabled.
     """
 
@@ -361,15 +361,15 @@ class JIRA(object):
         timeout=None,
         auth=None,
     ):
-        """Construct a JIRA client instance.
+        """Construct a Jira client instance.
 
-        Without any arguments, this client will connect anonymously to the JIRA instance
+        Without any arguments, this client will connect anonymously to the Jira instance
         started by the Atlassian Plugin SDK from one of the 'atlas-run', ``atlas-debug``,
         or ``atlas-run-standalone`` commands. By default, this instance runs at
-        ``http://localhost:2990/jira``. The ``options`` argument can be used to set the JIRA instance to use.
+        ``http://localhost:2990/jira``. The ``options`` argument can be used to set the Jira instance to use.
 
         Authentication is handled with the ``basic_auth`` argument. If authentication is supplied (and is
-        accepted by JIRA), the client will remember it for subsequent requests.
+        accepted by Jira), the client will remember it for subsequent requests.
 
         For quick command line access to a server, see the ``jirashell`` script included with this distribution.
 
@@ -379,9 +379,9 @@ class JIRA(object):
         :param options: Specify the server and properties this client will use. Use a dict with any
             of the following properties:
             * server -- the server address and context path to use. Defaults to ``http://localhost:2990/jira``.
-            * rest_path -- the root REST path to use. Defaults to ``api``, where the JIRA REST resources live.
+            * rest_path -- the root REST path to use. Defaults to ``api``, where the Jira REST resources live.
             * rest_api_version -- the version of the REST resources under rest_path to use. Defaults to ``2``.
-            * agile_rest_path - the REST path to use for JIRA Agile requests. Defaults to ``greenhopper`` (old, private
+            * agile_rest_path - the REST path to use for Jira Agile requests. Defaults to ``greenhopper`` (old, private
                API). Check `GreenHopperResource` for other supported values.
             * verify -- Verify SSL certs. Defaults to ``True``.
             * client_cert -- a tuple of (cert,key) for the requests library for client side SSL
@@ -393,9 +393,9 @@ class JIRA(object):
         :param oauth: A dict of properties for OAuth authentication. The following properties are required:
             * access_token -- OAuth access token for the user
             * access_token_secret -- OAuth access token secret to sign with the key
-            * consumer_key -- key of the OAuth application link defined in JIRA
+            * consumer_key -- key of the OAuth application link defined in Jira
             * key_cert -- private key file to sign requests with (should be the pair of the public key supplied to
-            JIRA in the OAuth application link)
+            Jira in the OAuth application link)
         :type oauth: Optional[Any]
         :param kerberos: If true it will enable Kerberos authentication.
         :type kerberos: bool
@@ -410,7 +410,7 @@ class JIRA(object):
             * payload -- dict of fields to be inserted in the JWT payload, e.g. 'iss'
             Example jwt structure: ``{'secret': SHARED_SECRET, 'payload': {'iss': PLUGIN_KEY}}``
         :type jwt: Optional[Any]
-        :param validate: If true it will validate your credentials first. Remember that if you are accessing JIRA
+        :param validate: If true it will validate your credentials first. Remember that if you are accessing Jira
             as anonymous it will fail to instantiate.
         :type validate: bool
         :param get_server_info: If true it will fetch server version info first to determine if some API calls
@@ -420,7 +420,7 @@ class JIRA(object):
         :type async_: bool
         :param async_workers: Set the number of worker threads for async operations.
         :type async_workers: int
-        :param timeout: Set a read/connect timeout for the underlying calls to JIRA (default: None)
+        :param timeout: Set a read/connect timeout for the underlying calls to Jira (default: None)
         :type timeout: Optional[Any]
         Obviously this means that you cannot rely on the return code when this is enabled.
         :param max_retries: Sets the amount Retries for the HTTP sessions initiated by the client. (Default: 3)
@@ -548,7 +548,7 @@ class JIRA(object):
             released_version = data["info"]["version"]
             if parse_version(released_version) > parse_version(__version__):
                 warnings.warn(
-                    "You are running an outdated version of JIRA Python %s. Current version is %s. Do not file any bugs against older versions."
+                    "You are running an outdated version of Jira Python %s. Current version is %s. Do not file any bugs against older versions."
                     % (__version__, released_version)
                 )
         except requests.RequestException:
@@ -574,7 +574,7 @@ class JIRA(object):
             self._session = None
 
     def _check_for_html_error(self, content):
-        # JIRA has the bad habit of returning errors in pages with 200 and
+        # Jira has the bad habit of returning errors in pages with 200 and
         # embedding the error in a huge webpage.
         if "<!-- SecurityTokenMissing -->" in content:
             logging.warning("Got SecurityTokenMissing")
@@ -645,7 +645,7 @@ class JIRA(object):
 
             if isinstance(resource, dict):
                 total = resource.get("total")
-                # 'isLast' is the optional key added to responses in JIRA Agile 6.7.6. So far not used in basic JIRA API.
+                # 'isLast' is the optional key added to responses in Jira Agile 6.7.6. So far not used in basic Jira API.
                 is_last = resource.get("isLast", False)
                 start_at_from_response = resource.get("startAt", 0)
                 max_results_from_response = resource.get("maxResults", 1)
@@ -741,7 +741,7 @@ class JIRA(object):
     def find(self, resource_format, ids=None):
         """Find Resource object for any addressable resource on the server.
 
-        This method is a universal resource locator for any REST-ful resource in JIRA. The
+        This method is a universal resource locator for any REST-ful resource in Jira. The
         argument ``resource_format`` is a string of the form ``resource``, ``resource/{0}``,
         ``resource/{0}/sub``, ``resource/{0}/sub/{1}``, etc. The format placeholders will be
         populated from the ``ids`` argument if present. The existing authentication session
@@ -1179,14 +1179,14 @@ class JIRA(object):
         return sorted(groups)
 
     def group_members(self, group):
-        """Return a hash or users with their information. Requires JIRA 6.0 or will raise NotImplemented.
+        """Return a hash or users with their information. Requires Jira 6.0 or will raise NotImplemented.
 
         :param group: Name of the group.
         :type group: str
         """
         if self._version < (6, 0, 0):
             raise NotImplementedError(
-                "Group members is not implemented in JIRA before version 6.0, upgrade the instance, if possible."
+                "Group members is not implemented in Jira before version 6.0, upgrade the instance, if possible."
             )
 
         params = {"groupname": group, "expand": "users"}
@@ -1216,7 +1216,7 @@ class JIRA(object):
         return OrderedDict(sorted(result.items(), key=lambda t: t[0]))
 
     def add_group(self, groupname):
-        """Create a new group in JIRA.
+        """Create a new group in Jira.
 
         :param groupname: The name of the group you wish to create.
         :type groupname: str
@@ -1239,9 +1239,9 @@ class JIRA(object):
         return True
 
     def remove_group(self, groupname):
-        """Delete a group from the JIRA instance.
+        """Delete a group from the Jira instance.
 
-        :param groupname: The group to be deleted from the JIRA instance.
+        :param groupname: The group to be deleted from the Jira instance.
         :type groupname: str
         :return: Boolean. Returns True on success.
         :rtype: bool
@@ -1290,7 +1290,7 @@ class JIRA(object):
         By default, the client will immediately reload the issue Resource created by this method in order to return
         a complete Issue object to the caller; this behavior can be controlled through the 'prefetch' argument.
 
-        JIRA projects may contain many different issue types. Some issue screens have different requirements for
+        Jira projects may contain many different issue types. Some issue screens have different requirements for
         fields in a new issue. This information is available through the 'createmeta' method. Further examples are
         available here: https://developer.atlassian.com/display/JIRADEV/JIRA+REST+API+Example+-+Create+Issue
 
@@ -1399,7 +1399,7 @@ class JIRA(object):
         return issue_list
 
     def supports_service_desk(self):
-        """Returns whether or not the JIRA instance supports service desk.
+        """Returns whether or not the Jira instance supports service desk.
 
         :rtype: bool
         """
@@ -1471,7 +1471,7 @@ class JIRA(object):
         By default, the client will immediately reload the issue Resource created by this method in order to return
         a complete Issue object to the caller; this behavior can be controlled through the 'prefetch' argument.
 
-        JIRA projects may contain many different issue types. Some issue screens have different requirements for
+        Jira projects may contain many different issue types. Some issue screens have different requirements for
         fields in a new issue. This information is available through the 'createmeta' method. Further examples are
         available here: https://developer.atlassian.com/display/JIRADEV/JIRA+REST+API+Example+-+Create+Issue
 
@@ -1627,7 +1627,7 @@ class JIRA(object):
         :param body: Text of the comment to add
         :type body: str
         :param visibility: a dict containing two entries: "type" and "value".
-            "type" is 'role' (or 'group' if the JIRA server has configured
+            "type" is 'role' (or 'group' if the Jira server has configured
             comment visibility for groups) and 'value' is the name of the role
             (or group) to which viewing of this comment will be restricted.
         :type visibility: Optional[Dict[str, str]]
@@ -1697,7 +1697,7 @@ class JIRA(object):
         """Add a remote link from an issue to an external application and returns a remote link Resource for it.
 
         ``destination`` should be a dict containing at least ``url`` to the linked external URL and
-        ``title`` to display for the link inside JIRA.
+        ``title`` to display for the link inside Jira.
 
         For definitions of the allowable fields for ``object`` and the keyword arguments ``globalId``, ``application``
         and ``relationship``, see https://developer.atlassian.com/display/JIRADEV/JIRA+REST+API+for+Remote+Issue+Links.
@@ -1778,7 +1778,7 @@ class JIRA(object):
             requiring more complex ``application`` data.
 
         ``object`` should be a dict containing at least ``url`` to the
-            linked external URL and ``title`` to display for the link inside JIRA.
+            linked external URL and ``title`` to display for the link inside Jira.
 
         For definitions of the allowable fields for ``object`` , see https://developer.atlassian.com/display/JIRADEV/JIRA+REST+API+for+Remote+Issue+Links.
 
@@ -2038,7 +2038,7 @@ class JIRA(object):
             a dict containing ``body`` and ``visibility`` fields: ``body`` being
             the text of the comment and ``visibility`` being a dict containing
             two entries: ``type`` and ``value``. ``type`` is ``role`` (or
-            ``group`` if the JIRA server has configured comment visibility for
+            ``group`` if the Jira server has configured comment visibility for
             groups) and ``value`` is the name of the role (or group) to which
             viewing of this comment will be restricted.
         :type comment: Optional[Dict[str, Any]]
@@ -2270,12 +2270,12 @@ class JIRA(object):
         Avatar images are specified by a filename, size, and file object. By default, the client will attempt to
             autodetect the picture's content type: this mechanism relies on libmagic and will not work out of the box
             on Windows systems (see http://filemagic.readthedocs.org/en/latest/guide.html for details on how to install
-            support). The ``contentType`` argument can be used to explicitly set the value (note that JIRA will reject any
+            support). The ``contentType`` argument can be used to explicitly set the value (note that Jira will reject any
             type other than the well-known ones for images, e.g. ``image/jpg``, ``image/png``, etc.)
 
         This method returns a dict of properties that can be used to crop a subarea of a larger image for use. This
             dict should be saved and passed to :py:meth:`confirm_project_avatar` to finish the avatar creation process. If
-            you want to cut out the middleman and confirm the avatar with JIRA's default cropping, pass the 'auto_confirm'
+            you want to cut out the middleman and confirm the avatar with Jira's default cropping, pass the 'auto_confirm'
             argument with a truthy value and :py:meth:`confirm_project_avatar` will be called for you before this method
             returns.
 
@@ -2552,7 +2552,7 @@ class JIRA(object):
 
     # non-resource
     def server_info(self):
-        """Get a dict of server information for this JIRA instance.
+        """Get a dict of server information for this Jira instance.
         :rtype: Dict[str, Any]
         """
         retry = 0
@@ -2566,7 +2566,7 @@ class JIRA(object):
         return j
 
     def myself(self):
-        """Get a dict of server information for this JIRA instance."""
+        """Get a dict of server information for this Jira instance."""
         return self._get_json("myself")
 
     # Status
@@ -2725,12 +2725,12 @@ class JIRA(object):
         Avatar images are specified by a filename, size, and file object. By default, the client will attempt to
         autodetect the picture's content type: this mechanism relies on ``libmagic`` and will not work out of the box
         on Windows systems (see http://filemagic.readthedocs.org/en/latest/guide.html for details on how to install
-        support). The ``contentType`` argument can be used to explicitly set the value (note that JIRA will reject any
+        support). The ``contentType`` argument can be used to explicitly set the value (note that Jira will reject any
         type other than the well-known ones for images, e.g. ``image/jpg``, ``image/png``, etc.)
 
         This method returns a dict of properties that can be used to crop a subarea of a larger image for use. This
         dict should be saved and passed to :py:meth:`confirm_user_avatar` to finish the avatar creation process. If you
-        want to cut out the middleman and confirm the avatar with JIRA's default cropping, pass the ``auto_confirm``
+        want to cut out the middleman and confirm the avatar with Jira's default cropping, pass the ``auto_confirm``
         argument with a truthy value and :py:meth:`confirm_user_avatar` will be called for you before this method
         returns.
 
@@ -3097,7 +3097,7 @@ class JIRA(object):
         return self._session.put(url, params=params, data=json.dumps(data))
 
     def _get_url(self, path, base=JIRA_BASE_URL):
-        """ Returns the full url based on JIRA base url and the path provided
+        """ Returns the full url based on Jira base url and the path provided
 
         :param path: The subpath desired.
         :type path: str
@@ -3119,7 +3119,7 @@ class JIRA(object):
         :type path: str
         :param params: Parameters to filter the json query.
         :type params: Optional[Dict[str, Any]]
-        :param base: The Base JIRA URL, defaults to the instance base.
+        :param base: The Base Jira URL, defaults to the instance base.
         :type base: Optional[str]
 
         :rtype: Union[Dict[str, Any], List[Dict[str, str]]]
@@ -3186,7 +3186,7 @@ class JIRA(object):
                 return None
 
     def rename_user(self, old_user, new_user):
-        """Rename a JIRA user.
+        """Rename a Jira user.
 
         :param old_user: Old username login
         :type old_user: str
@@ -3210,7 +3210,7 @@ class JIRA(object):
             )
 
     def delete_user(self, username):
-        """Deletes a JIRA User.
+        """Deletes a Jira User.
 
         :param username: Username to delete
         :type username: str
@@ -3305,9 +3305,9 @@ class JIRA(object):
     def reindex(self, force=False, background=True):
         """Start jira re-indexing. Returns True if reindexing is in progress or not needed, or False.
 
-        If you call reindex() without any parameters it will perform a background reindex only if JIRA thinks it should do it.
+        If you call reindex() without any parameters it will perform a background reindex only if Jira thinks it should do it.
 
-        :param force: reindex even if JIRA doesn't say this is needed, False by default.
+        :param force: reindex even if Jira doesn't say this is needed, False by default.
         :param background: reindex in background, slower but does not impact the users, defaults to True.
         """
         # /secure/admin/IndexAdmin.jspa
@@ -3321,7 +3321,7 @@ class JIRA(object):
 
         r = self._session.get(url, headers=self._options["headers"])
         if r.status_code == 503:
-            # logging.warning("JIRA returned 503, this could mean that a full reindex is in progress.")
+            # logging.warning("Jira returned 503, this could mean that a full reindex is in progress.")
             return 503
 
         if (
@@ -3331,7 +3331,7 @@ class JIRA(object):
             return True
 
         if r.text.find("All issues are being re-indexed"):
-            logging.warning("JIRA re-indexing is already running.")
+            logging.warning("Jira re-indexing is already running.")
             return True  # still reindexing is considered still a success
 
         if r.text.find("To perform the re-index now, please go to the") or force:
@@ -3457,7 +3457,7 @@ class JIRA(object):
     def delete_project(self, pid):
         """Delete project from Jira.
 
-        :param pid: JIRA projectID or Project or slug
+        :param pid: Jira projectID or Project or slug
         :type pid: str
         :return: True if project was deleted
         :rtype: bool
@@ -3627,7 +3627,7 @@ class JIRA(object):
     ):
         """Create a project with the specified parameters.
 
-        :param key: Mandatory. Must match JIRA project key requirements, usually only 2-10 uppercase characters.
+        :param key: Mandatory. Must match Jira project key requirements, usually only 2-10 uppercase characters.
         :type: str
         :param name: If not specified it will use the key value.
         :type name: Optional[str]
@@ -3677,7 +3677,7 @@ class JIRA(object):
             if not projectCategory and ps_list:
                 projectCategory = ps_list[0]["id"]
         # <beep> Atlassian for failing to provide an API to get projectTemplateKey values
-        #  Possible values are just hardcoded and obviously depending on JIRA version.
+        #  Possible values are just hardcoded and obviously depending on Jira version.
         # https://developer.atlassian.com/cloud/jira/platform/rest/v3/?_ga=2.88310429.766596084.1562439833-992274574.1559129176#api-rest-api-3-project-post
         # https://jira.atlassian.com/browse/JRASERVER-59658
         # preference list for picking a default template
@@ -3775,7 +3775,7 @@ class JIRA(object):
         ignore_existing=False,
         application_keys=None,
     ):
-        """Create a new JIRA user.
+        """Create a new Jira user.
 
         :param username: the username of the new user
         :type username: str
@@ -3873,7 +3873,7 @@ class JIRA(object):
         return True
 
     def role(self):
-        """Return JIRA role information.
+        """Return Jira role information.
 
         :return: List of current user roles
         :rtype: Iterable
@@ -3965,7 +3965,7 @@ class JIRA(object):
         :param board_id: the board to get sprints from
         :param extended: Used only by old GreenHopper API to fetch additional information like
             startDate, endDate, completeDate, much slower because it requires an additional requests for each sprint.
-            New JIRA Agile API always returns this information without a need for additional requests.
+            New Jira Agile API always returns this information without a need for additional requests.
         :param startAt: the index of the first sprint to return (0 based)
         :param maxResults: the maximum number of sprints to return
         :param state: Filters results to sprints in specified states. Valid values: `future`, `active`, `closed`.
@@ -4053,7 +4053,7 @@ class JIRA(object):
                 == GreenHopperResource.GREENHOPPER_REST_PATH
             ):
                 raise NotImplementedError(
-                    "Public JIRA API does not support state update"
+                    "Public Jira API does not support state update"
                 )
             payload["state"] = state
 
@@ -4147,7 +4147,7 @@ class JIRA(object):
             != GreenHopperResource.GREENHOPPER_REST_PATH
         ):
             raise NotImplementedError(
-                "JIRA Agile Public API does not support this request"
+                "Jira Agile Public API does not support this request"
             )
 
         payload = {}
@@ -4253,7 +4253,7 @@ class JIRA(object):
             except JIRAError as e:
                 if e.status_code == 404:
                     warnings.warn(
-                        "Status code 404 may mean, that too old JIRA Agile version is installed."
+                        "Status code 404 may mean, that too old Jira Agile version is installed."
                         " At least version 6.7.10 is required."
                     )
                 raise
@@ -4298,7 +4298,7 @@ class JIRA(object):
         ):
             # TODO(ssbarnea): simulate functionality using issue.update()?
             raise NotImplementedError(
-                "JIRA Agile Public API does not support this request"
+                "Jira Agile Public API does not support this request"
             )
 
         data = {}
@@ -4307,7 +4307,7 @@ class JIRA(object):
         url = self._get_url("epics/%s/add" % epic_id, base=self.AGILE_BASE_URL)
         return self._session.put(url, data=json.dumps(data))
 
-    # TODO(ssbarnea): Both GreenHopper and new JIRA Agile API support moving more than one issue.
+    # TODO(ssbarnea): Both GreenHopper and new Jira Agile API support moving more than one issue.
     def rank(self, issue, next_issue):
         """Rank an issue before another using the default Ranking field, the one named 'Rank'.
 
@@ -4327,7 +4327,7 @@ class JIRA(object):
                         field["schema"]["custom"]
                         == "com.pyxis.greenhopper.jira:gh-global-rank"
                     ):
-                        # Obsolete since JIRA v6.3.13.1
+                        # Obsolete since Jira v6.3.13.1
                         self._rank = field["schema"]["customId"]
 
         if self._options["agile_rest_path"] == GreenHopperResource.AGILE_BASE_REST_PATH:
@@ -4342,7 +4342,7 @@ class JIRA(object):
             except JIRAError as e:
                 if e.status_code == 404:
                     warnings.warn(
-                        "Status code 404 may mean, that too old JIRA Agile version is installed."
+                        "Status code 404 may mean, that too old Jira Agile version is installed."
                         " At least version 6.7.10 is required."
                     )
                 raise
@@ -4379,7 +4379,7 @@ class JIRA(object):
             except JIRAError as e:
                 if e.status_code == 404:
                     warnings.warn(
-                        "Status code 404 may mean, that too old JIRA Agile version is installed."
+                        "Status code 404 may mean, that too old Jira Agile version is installed."
                         " At least version 6.7.10 is required."
                     )
                 raise

--- a/jira/client.py
+++ b/jira/client.py
@@ -2269,7 +2269,7 @@ class JIRA(object):
 
         Avatar images are specified by a filename, size, and file object. By default, the client will attempt to
             autodetect the picture's content type: this mechanism relies on libmagic and will not work out of the box
-            on Windows systems (see http://filemagic.readthedocs.org/en/latest/guide.html for details on how to install
+            on Windows systems (see https://filemagic.readthedocs.io/en/latest/guide.html for details on how to install
             support). The ``contentType`` argument can be used to explicitly set the value (note that Jira will reject any
             type other than the well-known ones for images, e.g. ``image/jpg``, ``image/png``, etc.)
 

--- a/jira/jirashell.py
+++ b/jira/jirashell.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""Starts an interactive JIRA session in an ipython terminal.
+"""Starts an interactive Jira session in an ipython terminal.
 
 Script arguments support changing the server and a persistent authentication
 over HTTP BASIC or Kerberos.
@@ -144,13 +144,13 @@ def process_config():
 
 def process_command_line():
     parser = argparse.ArgumentParser(
-        description="Start an interactive JIRA shell with the REST API."
+        description="Start an interactive Jira shell with the REST API."
     )
-    jira_group = parser.add_argument_group("JIRA server connection options")
+    jira_group = parser.add_argument_group("Jira server connection options")
     jira_group.add_argument(
         "-s",
         "--server",
-        help="The JIRA instance to connect to, including context path.",
+        help="The Jira instance to connect to, including context path.",
     )
     jira_group.add_argument(
         "-r", "--rest-path", help="The root path of the REST API to use."
@@ -168,7 +168,7 @@ def process_command_line():
 
     basic_auth_group = parser.add_argument_group("BASIC auth options")
     basic_auth_group.add_argument(
-        "-u", "--username", help="The username to connect to this JIRA instance with."
+        "-u", "--username", help="The username to connect to this Jira instance with."
     )
     basic_auth_group.add_argument(
         "-p", "--password", help="The password associated with this user."
@@ -185,14 +185,14 @@ def process_command_line():
         "-od",
         "--oauth-dance",
         action="store_true",
-        help="Start a 3-legged OAuth authentication dance with JIRA.",
+        help="Start a 3-legged OAuth authentication dance with Jira.",
     )
     oauth_group.add_argument("-ck", "--consumer-key", help="OAuth consumer key.")
     oauth_group.add_argument(
         "-k",
         "--key-cert",
         help="Private key to sign OAuth requests with (should be the pair of the public key\
-                                   configured in the JIRA application link)",
+                                   configured in the Jira application link)",
     )
     oauth_group.add_argument(
         "-pt",
@@ -362,9 +362,9 @@ def main():
             from IPython.frontend.terminal.embed import InteractiveShellEmbed
 
         ip_shell = InteractiveShellEmbed(
-            banner1="<JIRA Shell " + __version__ + " (" + jira.client_info() + ")>"
+            banner1="<Jira Shell " + __version__ + " (" + jira.client_info() + ")>"
         )
-        ip_shell("*** JIRA shell active; client is in 'jira'." " Press Ctrl-D to exit.")
+        ip_shell("*** Jira shell active; client is in 'jira'." " Press Ctrl-D to exit.")
     except Exception as e:
         print(e, file=sys.stderr)
         return 2

--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -28,10 +28,10 @@ def raise_on_error(r, verb="???", **kwargs):
             try:
                 response = json.loads(r.text)
                 if "message" in response:
-                    # JIRA 5.1 errors
+                    # Jira 5.1 errors
                     error = response["message"]
                 elif "errorMessages" in response and len(response["errorMessages"]) > 0:
-                    # JIRA 5.0.x error messages sometimes come wrapped in this array
+                    # Jira 5.0.x error messages sometimes come wrapped in this array
                     # Sometimes this is present but empty
                     errorMessages = response["errorMessages"]
                     if isinstance(errorMessages, (list, tuple)):
@@ -44,7 +44,7 @@ def raise_on_error(r, verb="???", **kwargs):
                     and len(response["errors"]) > 0
                     and isinstance(response["errors"], dict)
                 ):
-                    # JIRA 6.x error messages are found in this array.
+                    # Jira 6.x error messages are found in this array.
                     error_list = response["errors"].values()
                     error = ", ".join(error_list)
                 else:

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-This module implements the Resource classes that translate JSON from JIRA REST resources
+This module implements the Resource classes that translate JSON from Jira REST resources
 into usable objects.
 """
 
@@ -56,10 +56,10 @@ def get_error_list(r):
             try:
                 response = json_loads(r)
                 if "message" in response:
-                    # JIRA 5.1 errors
+                    # Jira 5.1 errors
                     error_list = [response["message"]]
                 elif "errorMessages" in response and len(response["errorMessages"]) > 0:
-                    # JIRA 5.0.x error messages sometimes come wrapped in this array
+                    # Jira 5.0.x error messages sometimes come wrapped in this array
                     # Sometimes this is present but empty
                     errorMessages = response["errorMessages"]
                     if isinstance(errorMessages, (list, tuple)):
@@ -67,7 +67,7 @@ def get_error_list(r):
                     else:
                         error_list = [errorMessages]
                 elif "errors" in response and len(response["errors"]) > 0:
-                    # JIRA 6.x error messages are found in this array.
+                    # Jira 6.x error messages are found in this array.
                     error_list = response["errors"].values()
                 else:
                     error_list = [r.text]
@@ -77,7 +77,7 @@ def get_error_list(r):
 
 
 class Resource(object):
-    """Models a URL-addressable resource in the JIRA REST API.
+    """Models a URL-addressable resource in the Jira REST API.
 
     All Resource objects provide the following:
     ``find()`` -- get a resource from the server and load it into the current object
@@ -126,7 +126,7 @@ class Resource(object):
         :type options: Dict[str,str]
         :param session: Session used for the resource.
         :type session: ResilientSession
-        :param base_url: The Base JIRA url.
+        :param base_url: The Base Jira url.
         :type base_url: Optional[str]
 
         """
@@ -257,7 +257,7 @@ class Resource(object):
         :type fields: Optional[Dict[str, Any]]
         :param async_: If true the request will be added to the queue so it can be executed later using async_run()
         :type async_: bool
-        :param jira: Instance of JIRA Client
+        :param jira: Instance of Jira Client
         :type jira: jira.JIRA
         :param notify: Whether or not to notify users about the update. (Default: True)
         :type notify: bool
@@ -462,7 +462,7 @@ class CustomFieldOption(Resource):
 
 
 class Dashboard(Resource):
-    """A JIRA dashboard."""
+    """A Jira dashboard."""
 
     def __init__(self, options, session, raw=None):
         Resource.__init__(self, "dashboard/{0}", options, session)
@@ -480,7 +480,7 @@ class Filter(Resource):
 
 
 class Issue(Resource):
-    """A JIRA issue."""
+    """A Jira issue."""
 
     class _IssueFields(object):
         def __init__(self):
@@ -518,7 +518,7 @@ class Issue(Resource):
         is treated as the intended value for that field -- if the fields argument is used, all other keyword arguments
         will be ignored.
 
-        JIRA projects may contain many different issue types. Some issue screens have different requirements for
+        Jira projects may contain many different issue types. Some issue screens have different requirements for
         fields in an issue. This information is available through the :py:meth:`.JIRA.editmeta` method. Further examples
         are available here: https://developer.atlassian.com/display/JIRADEV/JIRA+REST+API+Example+-+Edit+issues
 
@@ -743,7 +743,7 @@ class Priority(Resource):
 
 
 class Project(Resource):
-    """A JIRA project."""
+    """A Jira project."""
 
     def __init__(self, options, session, raw=None):
         Resource.__init__(self, "project/{0}", options, session)
@@ -840,7 +840,7 @@ class StatusCategory(Resource):
 
 
 class User(Resource):
-    """A JIRA user."""
+    """A Jira user."""
 
     def __init__(self, options, session, raw=None):
         Resource.__init__(self, "user?username={0}", options, session)
@@ -857,7 +857,7 @@ class User(Resource):
 
 
 class Group(Resource):
-    """A JIRA user group."""
+    """A Jira user group."""
 
     def __init__(self, options, session, raw=None):
         Resource.__init__(self, "group?groupname={0}", options, session)
@@ -923,11 +923,11 @@ class GreenHopperResource(Resource):
     AGILE_BASE_URL = "{server}/rest/{agile_rest_path}/{agile_rest_api_version}/{path}"
 
     GREENHOPPER_REST_PATH = "greenhopper"
-    """ Old, private API. Deprecated and will be removed from JIRA on the 1st February 2016. """
+    """ Old, private API. Deprecated and will be removed from Jira on the 1st February 2016. """
     AGILE_EXPERIMENTAL_REST_PATH = "greenhopper/experimental-api"
-    """ Experimental API available in JIRA Agile 6.7.3 - 6.7.6, basically the same as Public API """
+    """ Experimental API available in Jira Agile 6.7.3 - 6.7.6, basically the same as Public API """
     AGILE_BASE_REST_PATH = "agile"
-    """ Public API introduced in JIRA Agile 6.7.7. """
+    """ Public API introduced in Jira Agile 6.7.7. """
 
     def __init__(self, path, options, session, raw):
         self.self = None
@@ -975,7 +975,7 @@ class Board(GreenHopperResource):
             != GreenHopperResource.GREENHOPPER_REST_PATH
         ):
             raise NotImplementedError(
-                "JIRA Agile Public API does not support Board removal"
+                "Jira Agile Public API does not support Board removal"
             )
 
         Resource.delete(self, params)
@@ -1071,7 +1071,7 @@ def dict2resource(raw, top=None, options=None, session=None):
 
 
 resource_class_map = {
-    # JIRA specific resources
+    # Jira-specific resources
     r"attachment/[^/]+$": Attachment,
     r"component/[^/]+$": Component,
     r"customFieldOption/[^/]+$": CustomFieldOption,
@@ -1102,7 +1102,7 @@ resource_class_map = {
 
 
 class UnknownResource(Resource):
-    """A Resource from JIRA that is not (yet) supported."""
+    """A Resource from Jira that is not (yet) supported."""
 
     def __init__(self, options, session, raw=None):
         Resource.__init__(self, "unknown{0}", options, session)

--- a/jira/utils/__init__.py
+++ b/jira/utils/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""JIRA utils used internally."""
+"""Jira utils used internally."""
 import threading
 
 from jira.resilientsession import raise_on_error

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ author = Ben Speakmon
 author-email = ben.speakmon@gmail.com
 maintainer = Sorin Sbarnea
 maintainer-email = sorin.sbarnea@gmail.com
-summary = Python library for interacting with JIRA via REST APIs.
+summary = Python library for interacting with Jira via REST APIs.
 long-description = file: README.rst
 # Do not include ChangeLog in description-file due to multiple reasons:
 # - Unicode chars, see https://github.com/pycontribs/jira/issues/512

--- a/tests/start-jira.sh
+++ b/tests/start-jira.sh
@@ -6,7 +6,7 @@ rm jira.log
 atlas-run-standalone --product jira --http-port 2990 \
     -B -nsu -o --threads 2.0C </dev/zero >jira.log 2>&1 &
 
-printf "Waiting for JIRA to start respinding on $JIRA_URL "
+printf "Waiting for Jira to start respinding on $JIRA_URL "
 until $(curl --output /dev/null --silent --head --fail $JIRA_URL); do
     printf '.'
     sleep 5

--- a/tests/start-jira.sh
+++ b/tests/start-jira.sh
@@ -6,7 +6,7 @@ rm jira.log
 atlas-run-standalone --product jira --http-port 2990 \
     -B -nsu -o --threads 2.0C </dev/zero >jira.log 2>&1 &
 
-printf "Waiting for Jira to start respinding on $JIRA_URL "
+printf "Waiting for Jira to start responding on $JIRA_URL "
 until $(curl --output /dev/null --silent --head --fail $JIRA_URL); do
     printf '.'
     sleep 5

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -42,9 +42,9 @@ except Exception:
 
 if "CI_JIRA_URL" in os.environ:
     not_on_custom_jira_instance = pytest.mark.skipif(
-        True, reason="Not applicable for custom JIRA instance"
+        True, reason="Not applicable for custom Jira instance"
     )
-    logging.info("Picked up custom JIRA engine.")
+    logging.info("Picked up custom Jira engine.")
 else:
 
     def noop(arg):
@@ -77,7 +77,7 @@ def get_unique_project_name():
     user = re.sub("[^A-Z_]", "", getpass.getuser().upper())
     if user == "TRAVIS" and "TRAVIS_JOB_NUMBER" in os.environ:
         # please note that user underline (_) is not supported by
-        # JIRA even if it is documented as supported.
+        # Jira even if it is documented as supported.
         jid = "T" + hashify(user + os.environ["TRAVIS_JOB_NUMBER"])
     else:
         identifier = (
@@ -227,7 +227,7 @@ class JiraTestManager(object):
             executing tests in parallel as we have only one test instance.
 
             jid length must be less than 9 characters because we may append
-            another one and the JIRA Project key length limit is 10.
+            another one and the Jira Project key length limit is 10.
 
             Tests run in parallel:
             * git branches master or developer, git pr or developers running
@@ -305,7 +305,7 @@ class JiraTestManager(object):
             except Exception:
                 # we care only for the project to exist
                 pass
-            sleep(1)  # keep it here as often JIRA will report the
+            sleep(1)  # keep it here as often Jira will report the
             # project as missing even after is created
             self.project_b_issue1_obj = self.jira_admin.create_issue(
                 project=self.project_b,


### PR DESCRIPTION
I'm so used to the new branding now that 'JIRA' sticks out for me; would you be open to this update?

Apply the [branding changes from 2017](https://www.atlassian.com/blog/announcements/our-bold-new-brand) and update 'JIRA' to 'Jira'. This should at least be changed in the front-page link, but this goes all in and updates documentation and comments everywhere

Also, update links to use https: URLs.