### PR TITLE
fix dictionary keys changed during iteration error seen in utils when using py3.8

### DIFF
--- a/jira/utils/__init__.py
+++ b/jira/utils/__init__.py
@@ -36,18 +36,14 @@ class CaseInsensitiveDict(dict):
     def __init__(self, *args, **kw):
         super(CaseInsensitiveDict, self).__init__(*args, **kw)
 
-#        self.itemlist = {}
-#        for key, value in super(CaseInsensitiveDict, self).items():
-#            if key != key.lower():
-#                self[key.lower()] = value
-#                self.pop(key, None)
+        upper_keys_list = []
+        for key in super(CaseInsensitiveDict, self).keys():
+            if key != key.lower():
+                upper_keys_list.append(key)
 
-        # self.itemlist[key.lower()] = value
-        itemlist = {}
-        for key, value in super(CaseInsensitiveDict, self).items():
-            itemlist[key.lower()] = value
-        self = itemlist
-
+        for upper_key in upper_keys_list:
+            self[upper_key.lower()] = self[upper_key]
+            self.pop(upper_key, None)
 
     def __setitem__(self, key, value):
         """Overwrite [] implementation."""

--- a/jira/utils/__init__.py
+++ b/jira/utils/__init__.py
@@ -36,13 +36,18 @@ class CaseInsensitiveDict(dict):
     def __init__(self, *args, **kw):
         super(CaseInsensitiveDict, self).__init__(*args, **kw)
 
-        self.itemlist = {}
-        for key, value in super(CaseInsensitiveDict, self).items():
-            if key != key.lower():
-                self[key.lower()] = value
-                self.pop(key, None)
+#        self.itemlist = {}
+#        for key, value in super(CaseInsensitiveDict, self).items():
+#            if key != key.lower():
+#                self[key.lower()] = value
+#                self.pop(key, None)
 
         # self.itemlist[key.lower()] = value
+        itemlist = {}
+        for key, value in super(CaseInsensitiveDict, self).items():
+            itemlist[key.lower()] = value
+        self = itemlist
+
 
     def __setitem__(self, key, value):
         """Overwrite [] implementation."""


### PR DESCRIPTION
noticed this error when trying to upload a file in jira while using python 3.8 on MacOS 10.14.6:
```
Python 3.8.0 (default, Nov 25 2019, 19:38:49) 
[Clang 10.0.1 (clang-1001.0.46.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from jira import JIRA
>>> jira = JIRA(server='http://localhost:8080', basic_auth=('myuser', 'mypass'))
>>> attached = jira.add_attachment(issue='CSTREQ-1', attachment='file_with_text.log')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/myuser/.pyenv/versions/venv/lib/python3.8/site-packages/jira/client.py", line 126, in wrapper
    result = func(*arg_list, **kwargs)
  File "/Users/myuser/.pyenv/versions/venv/lib/python3.8/site-packages/jira/client.py", line 787, in add_attachment
    url, data=m, headers=CaseInsensitiveDict({'content-type': m.content_type, 'X-Atlassian-Token': 'nocheck'}), retry_data=file_stream)
  File "/Users/myuser/.pyenv/versions/venv/lib/python3.8/site-packages/jira/utils/__init__.py", line 41, in __init__
    for key, value in super(CaseInsensitiveDict, self).items():
RuntimeError: dictionary keys changed during iteration
```
Tested the fix below and there seems to not be any issues. File uploaded fine, no other errors:
```
>>> attached = jira.add_attachment(issue='CSTREQ-1', attachment='file_with_text.log')
>>> attached
<JIRA Attachment: filename='file_with_text.log', id='10000', mimeType='text/plain'>
```