### PR TITLE
Documentation: HTTP Basic with remote server

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -104,7 +104,7 @@ To enable Kerberos auth, set ``kerberos=True``::
 To pass additional options to Kerberos auth use dict ``kerberos_options``, e.g.::
 
     auth_jira = JIRA(kerberos=True, kerberos_options={'mutual_authentication': 'DISABLED'})
-    
+
 .. _jirashell-label:
 
 Issues

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -34,7 +34,11 @@ default address for a JIRA instance started from the Atlassian Plugin SDK.
 
 You can manually set the JIRA server to use::
 
-    jac = JIRA('https://jira.atlassian.com')
+    jira = JIRA('https://jira.atlassian.com')
+    
+You may also pass multiple arguments to initialize the JIRA object. For example, to log into a remote Jira server with basic authentication:
+
+    jira = JIRA('https://jira.atlassian.com', basic_auth('username', 'password'))
 
 Authentication
 --------------

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -35,10 +35,6 @@ default address for a JIRA instance started from the Atlassian Plugin SDK.
 You can manually set the JIRA server to use::
 
     jira = JIRA('https://jira.atlassian.com')
-    
-You may also pass multiple arguments to initialize the JIRA object. For example, to log into a remote Jira server with basic authentication:
-
-    jira = JIRA('https://jira.atlassian.com', basic_auth('username', 'password'))
 
 Authentication
 --------------
@@ -105,6 +101,13 @@ To pass additional options to Kerberos auth use dict ``kerberos_options``, e.g.:
 
     auth_jira = JIRA(kerberos=True, kerberos_options={'mutual_authentication': 'DISABLED'})
 
+Authenticating on a remote server
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You may also pass multiple arguments to initialize the JIRA object. For example, to log into a remote Jira server with basic authentication::
+
+   jira = JIRA('https://jira.atlassian.com', basic_auth('username', 'password'))
+    
 .. _jirashell-label:
 
 Issues

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -63,7 +63,7 @@ Pass a tuple of (username, password) to the ``basic_auth`` constructor argument:
     
 To log into a remote Jira server with basic authentication::
 
-   jira = JIRA('https://jira.atlassian.com', basic_auth('username', 'password'))
+   jira = JIRA('https://jira.atlassian.com', basic_auth=('username', 'password'))
 
 OAuth
 ^^^^^

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -60,6 +60,10 @@ HTTP BASIC
 Pass a tuple of (username, password) to the ``basic_auth`` constructor argument::
 
     auth_jira = JIRA(basic_auth=('username', 'password'))
+    
+To log into a remote Jira server with basic authentication::
+
+   jira = JIRA('https://jira.atlassian.com', basic_auth('username', 'password'))
 
 OAuth
 ^^^^^
@@ -100,13 +104,6 @@ To enable Kerberos auth, set ``kerberos=True``::
 To pass additional options to Kerberos auth use dict ``kerberos_options``, e.g.::
 
     auth_jira = JIRA(kerberos=True, kerberos_options={'mutual_authentication': 'DISABLED'})
-
-Authenticating on a remote server
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-You may also pass multiple arguments to initialize the JIRA object. For example, to log into a remote Jira server with basic authentication::
-
-   jira = JIRA('https://jira.atlassian.com', basic_auth('username', 'password'))
     
 .. _jirashell-label:
 


### PR DESCRIPTION
The documentation was not clear on how to pass authentication info during the initialization of the JIRA object. Adding an example for a particular use case.