### PR TITLE
Improve feedback for oauth errors.

### DIFF
--- a/jira/jirashell.py
+++ b/jira/jirashell.py
@@ -22,6 +22,7 @@ from requests_oauthlib import OAuth1
 from jira import JIRA, __version__
 
 CONFIG_PATH = os.path.join(os.path.expanduser("~"), ".jira-python", "jirashell.ini")
+SENTINEL = object()
 
 
 def oauth_dance(server, consumer_key, key_cert_data, print_tokens=False, verify=None):
@@ -34,8 +35,16 @@ def oauth_dance(server, consumer_key, key_cert_data, print_tokens=False, verify=
         server + "/plugins/servlet/oauth/request-token", verify=verify, auth=oauth
     )
     request = dict(parse_qsl(r.text))
-    request_token = request["oauth_token"]
-    request_token_secret = request["oauth_token_secret"]
+    request_token = request.get("oauth_token", SENTINEL)
+    request_token_secret = request.get("oauth_token_secret", SENTINEL)
+    if request_token is SENTINEL or request_token_secret is SENTINEL:
+        problem = request.get("oauth_problem")
+        if problem is not None:
+            message = "OAuth error: {}".format(problem)
+        else:
+            message = " ".join(f"{key}:{value}" for key, value in request.items())
+        exit(message)
+
     if print_tokens:
         print("Request tokens received.")
         print("    Request token:        {}".format(request_token))


### PR DESCRIPTION
This is a minor improvement with the feedback during the OAuth dance errors.  
I got bitten by it twice, a few months apart and spent some time debugging what's going on. In my case, I got just the `KeyError` exception that the `oauth_token` key does not exist. In my case, the response dict content was as below:
```json
{"oauth_problem": "consumer_key_unknown"}
```

This PR should cause the OAuth dance to return a bit more meaningful error messages during that stage.