### PR TITLE
Example of the email address and API token initialization.

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -61,6 +61,11 @@ Pass a tuple of (username, password) to the ``basic_auth`` constructor argument:
 
     auth_jira = JIRA(basic_auth=('username', 'password'))
 
+Or pass a tuple of (email, api_token) to the ``basic_auth`` constructor argument (JIRA cloud)::
+
+    auth_jira = JIRA(basic_auth=('email', 'API token'))
+
+
 OAuth
 ^^^^^
 


### PR DESCRIPTION
Added a sample of using tuple ('email', 'API token') as initialization of JIRA client, as tuple ('user', 'password') does not work for JIRA cloud.