### PR TITLE
Allow setting page_size with unlimited paging

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -322,6 +322,7 @@ class JIRA(object):
         "async_workers": 5,
         "client_cert": None,
         "check_update": False,
+        "page_size": None,
         # amount of seconds to wait for loading a resource after updating it
         # used to avoid server side caching issues, used to be 4 seconds.
         "delay_reload": 0,
@@ -636,6 +637,9 @@ class JIRA(object):
             page_params["startAt"] = startAt
         if maxResults:
             page_params["maxResults"] = maxResults
+        elif self._options["page_size"]:
+            # Set initial page size guess.
+            page_params["maxResults"] = self._options["page_size"]
 
         resource = self._get_json(request_path, params=page_params, base=base)
         next_items_page = self._get_items_from_page(item_type, items_key, resource)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1724,16 +1724,20 @@ class SearchTests(unittest.TestCase):
 
     def test_search_issues_async(self):
         original_val = self.jira._options["async"]
+        original_page_size = self.jira._options["page_size"]
         try:
             self.jira._options["async"] = True
+            self.jira._options["page_size"] = 100
             issues = self.jira.search_issues(
                 "project=%s" % self.project_b, maxResults=False
             )
             self.assertEqual(len(issues), issues.total)
             for issue in issues:
                 self.assertTrue(issue.key.startswith(self.project_b))
+            self.assertEqual(issues.max_results_from_response, 100)
         finally:
             self.jira._options["async"] = original_val
+            self.jira._options["page_size"] = original_page_size
 
     def test_search_issues_maxresults(self):
         issues = self.jira.search_issues("project=%s" % self.project_b, maxResults=10)


### PR DESCRIPTION
By default, it will use the whatever the first maxResults that server returns.
This can be far less than what the server is capable of, and fetching in small batch is very inefficient.