### PR TITLE
Add support for Python 3.8

### DIFF
--- a/jira/utils/__init__.py
+++ b/jira/utils/__init__.py
@@ -37,7 +37,7 @@ class CaseInsensitiveDict(dict):
         super(CaseInsensitiveDict, self).__init__(*args, **kw)
 
         self.itemlist = {}
-        for key, value in super(CaseInsensitiveDict, self).items():
+        for key, value in super(CaseInsensitiveDict, self).copy().items():
             if key != key.lower():
                 self[key.lower()] = value
                 self.pop(key, None)

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ requires =
 envlist =
     lint
     pkg
+    py38
     py37
     py36
     py35


### PR DESCRIPTION
Python 3.8 will thrown an exception if a dict changes while iterating over it,
copy it first.

Fix #890