### PR TITLE
Allow _get_user_accountid to "find" Unassigned and Automatic "users".

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1560,8 +1560,10 @@ class JIRA(object):
         return self._get_json("issue/createmeta", params)
 
     def _get_user_accountid(self, user):
-        """Internal method for translating an user to an accountId."""
+        """Internal method for translating an user to an accountId. Return None and -1 unchanged."""
         try:
+            if user is None or user in (-1, "-1"):
+                return user
             accountId = self.search_users(user, maxResults=1)[0].accountId
         except Exception as e:
             raise JIRAError(e)


### PR DESCRIPTION
Return None, -1, and "-1" back from _get_user_accountid to allow `assign_issue` to do that as well.

This seems related to the work being done to handle Jira's migration away from `key` and to `accountId` everywhere. I'm happy to adjust this if needed or add tests if that would be helpful for this change.