### PR TITLE
Support assigning issue by accountId

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1569,13 +1569,15 @@ class JIRA(object):
 
     # non-resource
     @translate_resource_args
-    def assign_issue(self, issue, assignee):
+    def assign_issue(self, issue, assignee=None, *, account_id=None):
         """Assign an issue to a user. None will set it to unassigned. -1 will set it to Automatic.
 
         :param issue: the issue ID or key to assign
         :type issue: int or str
         :param assignee: the user to assign the issue to
         :type assignee: str
+        :param account_id: the accountId to assign the issue to, ignoring assignee
+        :type account_id: str
 
         :rtype: bool
         """
@@ -1585,7 +1587,11 @@ class JIRA(object):
             + str(issue)
             + "/assignee"
         )
-        payload = {"accountId": self._get_user_accountid(assignee)}
+
+        if account_id is not None:
+            payload = {"accountId": account_id}
+        else:
+            payload = {"accountId": self._get_user_accountid(assignee)}
         # 'key' and 'name' are deprecated in favor of accountId
         r = self._session.put(url, data=json.dumps(payload))
         raise_on_error(r)


### PR DESCRIPTION
In strict GDPR mode the[ `_get_user_accountid`](https://github.com/pycontribs/jira/blob/5c27f6ddafffc6110be1db4749fa67025852bcb6/jira/client.py#L1562) function will not work. For [`assign_user`](https://github.com/pycontribs/jira/blob/5c27f6ddafffc6110be1db4749fa67025852bcb6/jira/client.py#L1572) to work, we have to be able to pass the `accountId` directly.

This PR adds `account_id` as an optional named parameter, replacing the unnamed username parameter.