### PR TITLE
Print statements converted to functions (py3)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,9 +59,9 @@ Feeling impatient? I like your style.
         jira = JIRA('https://jira.atlassian.com')
 
         issue = jira.issue('JRA-9')
-        print issue.fields.project.key             # 'JRA'
-        print issue.fields.issuetype.name          # 'New Feature'
-        print issue.fields.reporter.displayName    # 'Mike Cannon-Brookes [Atlassian]'
+        print(issue.fields.project.key)            # 'JRA'
+        print(issue.fields.issuetype.name)         # 'New Feature'
+        print(issue.fields.reporter.displayName)   # 'Mike Cannon-Brookes [Atlassian]'
 
 
 Installation


### PR DESCRIPTION
I tried running the README example and it won't run on my python 3. I converted the three print statements, and this should now work equally on python 2 and 3. (The parentheses are simply redundant in python 2.)