### PR TITLE
Make user search GDPR compliant

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2977,7 +2977,7 @@ class JIRA(object):
               If maxResults evaluates as False, it will try to get all items in batches.
             includeActive (bool): If true, then active users are included in the results. (Default: True)
             includeInactive (bool): If true, then inactive users are included in the results. (Default: False)
-            query (optional str): Search term. It can just be the email.
+            query (Optional[str]): Search term. It can just be the email.
 
         Returns:
             ResultList[User]

--- a/jira/client.py
+++ b/jira/client.py
@@ -2987,12 +2987,10 @@ class JIRA(object):
 
         params = {
             "username": user,
+            "query": query,
             "includeActive": includeActive,
             "includeInactive": includeInactive,
         }
-
-        if query:
-            params["query"] = query
 
         return self._fetch_pages(User, None, "user/search", startAt, maxResults, params)
 

--- a/jira/client.py
+++ b/jira/client.py
@@ -2964,8 +2964,11 @@ class JIRA(object):
         maxResults: int = 50,
         includeActive: bool = True,
         includeInactive: bool = False,
+        query: Optional[str] = None,
     ) -> ResultList[User]:
         """Get a list of user Resources that match the specified search string.
+        "username" query parameter is deprecated; the expected parameter now is "query", which can just be the full
+        email again. But the first parameter is kept for backwards compatibility.
 
         Args:
             user (str): a string to match usernames, name or email against.
@@ -2974,15 +2977,25 @@ class JIRA(object):
               If maxResults evaluates as False, it will try to get all items in batches.
             includeActive (bool): If true, then active users are included in the results. (Default: True)
             includeInactive (bool): If true, then inactive users are included in the results. (Default: False)
+            query (optional str): Search term. It can just be the email.
 
         Returns:
             ResultList[User]
         """
+        if not user and not query:
+            raise ValueError("Either 'user' or 'query' arguments must be specified.")
+
         params = {
             "username": user,
             "includeActive": includeActive,
             "includeInactive": includeInactive,
         }
+
+        if user:
+            params["username"] = user
+        else:
+            params["query"] = query
+
         return self._fetch_pages(User, None, "user/search", startAt, maxResults, params)
 
     def search_allowed_users_for_issue(

--- a/jira/client.py
+++ b/jira/client.py
@@ -2991,9 +2991,7 @@ class JIRA(object):
             "includeInactive": includeInactive,
         }
 
-        if user:
-            params["username"] = user
-        else:
+        if query:
             params["query"] = query
 
         return self._fetch_pages(User, None, "user/search", startAt, maxResults, params)

--- a/jira/client.py
+++ b/jira/client.py
@@ -2967,7 +2967,7 @@ class JIRA(object):
         query: Optional[str] = None,
     ) -> ResultList[User]:
         """Get a list of user Resources that match the specified search string.
-        "username" query parameter is deprecated; the expected parameter now is "query", which can just be the full
+        "username" query parameter is deprecated in Jira Cloud; the expected parameter now is "query", which can just be the full
         email again. But the first parameter is kept for backwards compatibility.
 
         Args:

--- a/jira/client.py
+++ b/jira/client.py
@@ -2959,7 +2959,7 @@ class JIRA(object):
 
     def search_users(
         self,
-        user: str,
+        user: Optional[str] = None,
         startAt: int = 0,
         maxResults: int = 50,
         includeActive: bool = True,
@@ -2971,7 +2971,7 @@ class JIRA(object):
         email again. But the first parameter is kept for backwards compatibility.
 
         Args:
-            user (str): a string to match usernames, name or email against.
+            user (optional str): a string to match usernames, name or email against.
             startAt (int): index of the first user to return.
             maxResults (int): maximum number of users to return.
               If maxResults evaluates as False, it will try to get all items in batches.

--- a/jira/client.py
+++ b/jira/client.py
@@ -2971,7 +2971,7 @@ class JIRA(object):
         email again. But the first parameter is kept for backwards compatibility.
 
         Args:
-            user (optional str): a string to match usernames, name or email against.
+            user (Optional[str]): a string to match usernames, name or email against.
             startAt (int): index of the first user to return.
             maxResults (int): maximum number of users to return.
               If maxResults evaluates as False, it will try to get all items in batches.

--- a/jira/client.py
+++ b/jira/client.py
@@ -2968,7 +2968,7 @@ class JIRA(object):
     ) -> ResultList[User]:
         """Get a list of user Resources that match the specified search string.
         "username" query parameter is deprecated in Jira Cloud; the expected parameter now is "query", which can just be the full
-        email again. But the first parameter is kept for backwards compatibility.
+        email again. But the "user" parameter is kept for backwards compatibility, i.e. Jira Server/Data Center.
 
         Args:
             user (Optional[str]): a string to match usernames, name or email against.


### PR DESCRIPTION
The `username` field is deprecated and Jira is gradually removing it
from the cloud instances. This is the second time such changes break
our integrations; until now, our workaround consisted of first searching
for the user based on the email, and then use the account id from the
response for the other requests. But now we cannot search anymore for
users based on the email, and we need to use the `query` field. Even if
we just pass the same exact value we passed to `username`.

I can imagine there're several places in the code that would require of
being changed for being completely GDPR compliant, but I have no time
at the moment to fix all of them :(

Thanks for your work!