### PR TITLE
ResilientSession: do not log request data on ConnectionError

### DIFF
--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -94,6 +94,7 @@ class ResilientSession(Session):
 
     def __init__(self, timeout=None):
         self.max_retries = 3
+        self.max_retry_delay = 60
         self.timeout = timeout
         super(ResilientSession, self).__init__()
 
@@ -129,7 +130,7 @@ class ResilientSession(Session):
                 msg = "Atlassian's bug https://jira.atlassian.com/browse/JRA-41559"
 
         # Exponential backoff with full jitter.
-        delay = min(60, 10 * 2 ** counter) * random.random()
+        delay = min(self.max_retry_delay, 10 * 2 ** counter) * random.random()
         logging.warning(
             "Got recoverable error from %s %s, will retry [%s/%s] in %ss. Err: %s"
             % (request, url, counter, self.max_retries, delay, msg)

--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -167,7 +167,8 @@ class ResilientSession(Session):
                 if response.status_code >= 200 and response.status_code <= 299:
                     return response
             except ConnectionError as e:
-                logging.warning(f"{e} while doing {verb.upper()} {url} [{kwargs}]")
+                logging.warning(f"{e} while doing {verb.upper()} {url}")
+
                 exception = e
             retry_number += 1
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -19,6 +19,7 @@ import requests
 from flaky import flaky
 
 import jira  # noqa
+import jira.resilientsession
 from jira import JIRA, Issue, JIRAError, Project, Role  # noqa
 from jira.resources import Group, Resource, UnknownResource, cls_for_resource  # noqa
 
@@ -2170,6 +2171,57 @@ class SessionTests(unittest.TestCase):
             )
             return
         self.assertTrue(False, "Instantiation of invalid JIRA instance succeeded.")
+
+
+class ListLoggingHandler(logging.Handler):
+    """A logging handler that records all events in a list."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+    def reset(self):
+        self.records = []
+
+
+class ResilientSessionLoggingConfidentialityTests(unittest.TestCase):
+    """No sensitive data shall be written to the log."""
+
+    def setUp(self):
+        self.loggingHandler = ListLoggingHandler()
+        jira.resilientsession.logging.getLogger().addHandler(self.loggingHandler)
+
+    def test_logging_with_connection_error(self):
+        """No sensitive data shall be written to the log in case of a connection error."""
+        witness = "etwhpxbhfniqnbbjoqvw"  # random string; hopefully unique
+        for max_retries in (0, 1):
+            for verb in ("get", "post", "put", "delete", "head", "patch", "options"):
+                with self.subTest(max_retries=max_retries, verb=verb):
+                    with jira.resilientsession.ResilientSession() as session:
+                        session.max_retries = max_retries
+                        session.max_retry_delay = 0
+                        try:
+                            getattr(session, verb)(
+                                "http://127.0.0.1:9",
+                                headers={"sensitive_header": witness},
+                                data={"sensitive_data": witness},
+                            )
+                        except jira.resilientsession.ConnectionError:
+                            pass
+                    # check that `witness` does not appear in log
+                    for record in self.loggingHandler.records:
+                        self.assertNotIn(witness, record.msg)
+                        for arg in record.args:
+                            self.assertNotIn(witness, str(arg))
+                        self.assertNotIn(witness, str(record))
+                    self.loggingHandler.reset()
+
+    def tearDown(self):
+        jira.resilientsession.logging.getLogger().removeHandler(self.loggingHandler)
+        del self.loggingHandler
 
 
 class AsyncTests(unittest.TestCase):


### PR DESCRIPTION
The request data may contain secrets, e.g., a plaintext password when using basic auth. Therefore the request data shall not be logged.

In version 2.0.0, the basic auth login credentials were logged when a ConnectionError was triggered by an invalid SSL certificate. With current master this is not the case anymore, however, the problem might still occur under other circumstances.