### PR TITLE
fix: group_members

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1211,11 +1211,14 @@ class JIRA(object):
 
         result = {}
         for user in r["users"]["items"]:
-            result[user["key"]] = {
-                "name": user["name"],
-                "fullname": user["displayName"],
-                "email": user.get("emailAddress", "hidden"),
-                "active": user["active"],
+            result[user['id']] = {
+                'name': user.get('name'),
+                'id': user.get('id'),
+                'accountId': user.get('accountId'),
+                'fullname': user.get('displayName'),
+                'email': user.get('emailAddress', 'hidden'),
+                'active': user.get('active'),
+                'timezone': user.get('timezone')
             }
         return OrderedDict(sorted(result.items(), key=lambda t: t[0]))
 

--- a/jira/client.py
+++ b/jira/client.py
@@ -1211,14 +1211,14 @@ class JIRA(object):
 
         result = {}
         for user in r["users"]["items"]:
-            result[user['id']] = {
-                'name': user.get('name'),
-                'id': user.get('id'),
-                'accountId': user.get('accountId'),
-                'fullname': user.get('displayName'),
-                'email': user.get('emailAddress', 'hidden'),
-                'active': user.get('active'),
-                'timezone': user.get('timezone')
+            result[user["id"]] = {
+                "name": user.get("name"),
+                "id": user.get("id"),
+                "accountId": user.get("accountId"),
+                "fullname": user.get("displayName"),
+                "email": user.get("emailAddress", "hidden"),
+                "active": user.get("active"),
+                "timezone": user.get("timezone"),
             }
         return OrderedDict(sorted(result.items(), key=lambda t: t[0]))
 


### PR DESCRIPTION
Some attributes have become obsolete with the latest GDPR developments.
Avoid client crashes trying to retrieve the members of a group.

Without the patch
```
In [9]: client.group_members("jira-admins")
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-9-1f19d7928eeb> in <module>
----> 1 client.group_members("engineering")

~/dev/gitbot/venv/lib/python3.7/site-packages/jira/client.py in group_members(self, group)
   1010         for user in r['users']['items']:
   1011             logging.exception(user)
-> 1012             result[user['key']] = {'name': user['name'],
   1013                                   'id': user['id'],

KeyError: 'name'  
```
With the patch
```
In [10]: client.group_members("jira-admins")
[omissis - a list of users]
```