### PR TITLE
add_attachment() and delete_attachment() no notification support.

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -919,13 +919,21 @@ class JIRA(object):
             )
         return attachment
 
-    def delete_attachment(self, id):
+    def delete_attachment(self, id, notify=True):
         """Delete attachment by id.
 
         :param id: ID of the attachment to delete
         :type id: str
+        :param notify: query parameter notifyUsers. If true send the email with notification that the issue was updated to users that watch it.
+                       Admin or project admin permissions are required to disable the notification.
+        :type notify: bool
         """
-        url = self._get_url("attachment/" + str(id))
+        if not notify:
+            querystring = "?notifyUsers=false"
+        else:
+            querystring = ""
+
+        url = self._get_url("attachment/{id}{query}".format(id=str(id), query=querystring))
         return self._session.delete(url)
 
     # Components

--- a/jira/client.py
+++ b/jira/client.py
@@ -843,7 +843,7 @@ class JIRA(object):
         return self._get_json("attachment/meta")
 
     @translate_resource_args
-    def add_attachment(self, issue, attachment, filename=None):
+    def add_attachment(self, issue, attachment, filename=None, notify=True):
         """Attach an attachment to an issue and returns a Resource for it.
 
         The client will *not* attempt to open or validate the attachment; it expects a file-like object to be ready
@@ -857,6 +857,9 @@ class JIRA(object):
             is used. If you acquired the file-like object by any other method than ``open()``, make sure
             that a name is specified in one way or the other.
         :type filename: str
+        :param notify: query parameter notifyUsers. If true send the email with notification that the issue was updated to users that watch it.
+                       Admin or project admin permissions are required to disable the notification.
+        :type notify: bool
         :rtype: Attachment
         """
         if isinstance(attachment, str):
@@ -871,7 +874,12 @@ class JIRA(object):
                 % attachment.name
             )
 
-        url = self._get_url("issue/" + str(issue) + "/attachments")
+        if not notify:
+            querystring = "?notifyUsers=false"
+        else:
+            querystring = ""
+
+        url = self._get_url("issue/{issue}/attachments{query}".format(issue=str(issue), query=querystring))
 
         fname = filename
         if not fname:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -492,7 +492,7 @@ class AttachmentTests(unittest.TestCase):
     def test_1_add_remove_attachment(self):
         issue = self.jira.issue(self.issue_1)
         with open(TEST_ATTACH_PATH, "rb") as f:
-            attachment = self.jira.add_attachment(issue, f, "new test attachment")
+            attachment = self.jira.add_attachment(issue, f, "new test attachment", notify=False)
             new_attachment = self.jira.attachment(attachment.id)
             msg = "attachment %s of issue %s" % (new_attachment.__dict__, issue)
             self.assertEqual(new_attachment.filename, "new test attachment", msg=msg)


### PR DESCRIPTION
Added flags for both add_attachment() and delete_attachment() functions for disabling notifications.

As stated in issue #937 