### PR TITLE
GDPR Strict Mode Fix

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2833,7 +2833,7 @@ class JIRA(object):
         :rtype: ResultList
         """
         params = {
-            "username": user,
+            "query": user,
             "includeActive": includeActive,
             "includeInactive": includeInactive,
         }


### PR DESCRIPTION
Atlassian has changed their rest API and removed the `username` parameter. They have replaced it with `query` which takes a display name or an email address. In the future they might remove support for email addresses and only accept display names.

More info [HERE](https://community.atlassian.com/t5/Jira-questions/The-query-parameter-username-is-not-supported-in-GDPR-strict/qaq-p/1345106)