### PR TITLE
[Fix CI] style(travis): split long command over multiple lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,9 @@ before_install:
 # Install this repository, as we will need it in the next step
   - pip install .
 # Attempt to create the test user, as the empty JIRA instance isn't provisioned with one
-  - (python -c "from jira import JIRA; JIRA('$CI_JIRA_URL', basic_auth=('$CI_JIRA_ADMIN', '$CI_JIRA_ADMIN_PASSWORD')).add_user('$CI_JIRA_USER', 'user@example.com', password='$CI_JIRA_USER_PASSWORD')" && echo "Created user '$CI_JIRA_USER'") || (echo "Failed creating user '$CI_JIRA_USER'" && docker logs --tail 500 jira)
+  - >-
+    (python -c "from jira import JIRA; JIRA('$CI_JIRA_URL', basic_auth=('$CI_JIRA_ADMIN', '$CI_JIRA_ADMIN_PASSWORD')).add_user('$CI_JIRA_USER', 'user@example.com', password='$CI_JIRA_USER_PASSWORD')" && echo "Created user '$CI_JIRA_USER'")
+    || (echo "Failed creating user '$CI_JIRA_USER'" && docker logs --tail 500 jira)
 notifications:
   email:
     - pycontribs@googlegroups.com


### PR DESCRIPTION
The linter is complaining about one of the lines I added being too long. Using a multiline in YAML to split it.