### PR TITLE
Close the file descriptor for add_attachment

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -853,6 +853,7 @@ class JIRA(object):
         close_attachment = False
         if isinstance(attachment, str):
             attachment: BufferedReader = open(attachment, "rb")  # type: ignore
+            attachment = cast(BufferedReader, attachment)
             close_attachment = True
         elif isinstance(attachment, BufferedReader) and attachment.mode != "rb":
             self.log.warning(
@@ -878,7 +879,7 @@ class JIRA(object):
                 )
             finally:
                 if close_attachment:
-                    cast(BufferedReader, attachment).close()
+                    attachment.close()
         else:
             method = "MultipartEncoder"
 
@@ -900,7 +901,7 @@ class JIRA(object):
                 )
             finally:
                 if close_attachment:
-                    cast(BufferedReader, attachment).close()
+                    attachment.close()
 
         js: Union[Dict[str, Any], List[Dict[str, Any]]] = json_loads(r)
         if not js or not isinstance(js, Iterable):

--- a/jira/client.py
+++ b/jira/client.py
@@ -35,6 +35,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    cast,
     no_type_check,
 )
 from urllib.parse import urlparse
@@ -877,7 +878,7 @@ class JIRA(object):
                 )
             finally:
                 if close_attachment:
-                    attachment.close()
+                    cast(BufferedReader, attachment).close()
         else:
             method = "MultipartEncoder"
 
@@ -899,7 +900,7 @@ class JIRA(object):
                 )
             finally:
                 if close_attachment:
-                    attachment.close()
+                    cast(BufferedReader, attachment).close()
 
         js: Union[Dict[str, Any], List[Dict[str, Any]]] = json_loads(r)
         if not js or not isinstance(js, Iterable):

--- a/jira/client.py
+++ b/jira/client.py
@@ -895,7 +895,10 @@ class JIRA(object):
                     url,
                     data=m,
                     headers=CaseInsensitiveDict(
-                        {"content-type": m.content_type, "X-Atlassian-Token": "no-check"}
+                        {
+                            "content-type": m.content_type,
+                            "X-Atlassian-Token": "no-check",
+                        }
                     ),
                     retry_data=file_stream,
                 )


### PR DESCRIPTION
If the attachment argument is string, the add_attachment function creates a file descriptor then forget to close it. The patch closes the file descriptor after the post action.