### PR TITLE
chore(github): adds jira instance type to bug-report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,6 +26,9 @@ A code block with the any trace messages.
 
 
 **Version Information**
+Type of Jira instance:
+- [ ] Jira Cloud (Hosted by Atlassian)
+- [ ] Jira Server (Self-hosted)
 Python Interpreter: <VERSION>
 jira-python: <VERSION>
 OS: <OPERATING SYSTEM>
@@ -35,3 +38,4 @@ Other Dependencies:
 
 **Additional context**
 Add any other context about the problem here.
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,7 +28,7 @@ A code block with the any trace messages.
 **Version Information**
 Type of Jira instance:
 - [ ] Jira Cloud (Hosted by Atlassian)
-- [ ] Jira Server (Self-hosted)
+- [ ] Jira Server or Data Center (Self-hosted)
 Python Interpreter: <VERSION>
 jira-python: <VERSION>
 OS: <OPERATING SYSTEM>
@@ -38,4 +38,3 @@ Other Dependencies:
 
 **Additional context**
 Add any other context about the problem here.
-


### PR DESCRIPTION
Self-hosted and Atlassian's cloud hosted versions of Jira start to have diverging APIs. Hence, it is relevant to know for a bug report on what type of JIRA instance this error occurred, such that later we can more effectively triage issues (or know which issues to ignore if we decide to drop support for either of them).