### PR TITLE
Add ability to get tickets completed within a sprint

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -4084,6 +4084,20 @@ class JIRA(object):
 
         return issues
 
+    def completed_issues(self, board_id, sprint_id):
+        """Return the completed issues for the sprint."""
+        r_json = self._get_json(
+            "rapid/charts/sprintreport?rapidViewId=%s&sprintId=%s"
+            % (board_id, sprint_id),
+            base=self.AGILE_BASE_URL,
+        )
+        issues = [
+            Issue(self._options, self._session, raw_issues_json)
+            for raw_issues_json in r_json["contents"]["completedIssues"]
+        ]
+
+        return issues
+
     def removedIssuesEstimateSum(self, board_id, sprint_id):
         """Return the total incompleted points this sprint."""
         return self._get_json(

--- a/jira/client.py
+++ b/jira/client.py
@@ -4071,7 +4071,7 @@ class JIRA(object):
         )["contents"]["incompletedIssuesEstimateSum"]["value"]
 
     def removed_issues(self, board_id, sprint_id):
-        """Return the completed issues for the sprint."""
+        """Return the removed issues for the sprint."""
         r_json = self._get_json(
             "rapid/charts/sprintreport?rapidViewId=%s&sprintId=%s"
             % (board_id, sprint_id),


### PR DESCRIPTION
I've added the ability to get a list of issues completed within a particular sprint. It works the same way `removed_issues()` does. I found `completedIssues` in the JSON which is used in the Sprint Report's 'Completed Issues' section.

While I was here, I fixed the misleading docstring which I stumbled across whilst trying to find the method to return the list of items I wanted (completed ones).