### PR TITLE
Fixes #966 - Use verify parameter in requests

### DIFF
--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -141,7 +141,7 @@ class ResilientSession(Session):
             exception = None
             try:
                 method = getattr(super(ResilientSession, self), verb.lower())
-                response = method(url, timeout=self.timeout, **kwargs)
+                response = method(url, timeout=self.timeout, verify=self.verify, **kwargs)
                 if response.status_code >= 200 and response.status_code <= 299:
                     return response
             except ConnectionError as e:


### PR DESCRIPTION
SSL certificate verification was being done even when `verify` was set to `False`.
Now the parameter is explicitly passed to the request, avoiding this bug.