### PR TITLE
Export resource_class_map and fix bug in Role.add_user()

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -42,6 +42,7 @@ __all__ = (
     "Customer",
     "ServiceDesk",
     "RequestType",
+    "resource_class_map",
 )
 
 logging.getLogger("jira").addHandler(logging.NullHandler())
@@ -799,7 +800,7 @@ class Role(Resource):
         if groups is not None and isinstance(groups, str):
             groups = (groups,)
 
-        data = {"user": users}
+        data = {"user": users, "group": groups}
         self._session.post(self.self, data=json.dumps(data))
 
 


### PR DESCRIPTION
The reason for exporting `resource_class_map` is to allow an external module to support additional resource types without the need to edit resources.py (I had edited it previously but this became a maintenance nightmare).

The `Role.add_user()` bug is (I hope) an obvious one: the `groups` argument was ignored.

---

Some of my local extensions conflict with more recent extensions in `master`. For example, I supported notification schemes and permission schemes, but I took a different approach: I also added new resource types, and the methods return resources rather than dictionaries. For example:

Master:

```python
    @lru_cache(maxsize=None)
    def notificationschemes(self):
        # TODO(ssbarnea): implement pagination support
        url = self._options["server"] + "/rest/api/3/notificationscheme"

        r = self._session.get(url)
        data = json_loads(r)
        return data["values"]
```

Mine:

```python
    def notificationschemes(self) -> List[NotificationScheme]:
        """Get a list of notificationscheme Resources."""
        r_json = self._get_json('notificationscheme')
        notificationschemes = [
            NotificationScheme(self._options, self._session, raw_res_json) for
            raw_res_json in r_json['values']]
        return notificationschemes
```

There was already some level of `Role` support, and I took this approach to extending the interface (this is in a wrapper class that calls methods from the existing master class when it can):

```python
    @translate_resource_args
    def project_roles(self, project: IDorName, *, as_list: bool = False,
                      as_resources: bool = False):
        assert self._mode == 'online'
        # this returns a Dict[str, Dict[str, Any]]
        roles = self._jira.project_roles(project)
        # add a 'name' key (needed if will return a list)
        roles = {name: {**value, 'name': name} for name, value in
                 roles.items()}
        # if requested, convert to Dict[str, ProjectRole]
        if as_resources:
            roles = {name: ProjectRole(self._options, self._session, value) for
                     name, value in roles.items()}
        # if requested, convert to List[]
        if as_list:
            roles = list(roles.values())
        return roles
```

Please let me know if you'd like me to contribute any of these extensions.