### PR TITLE
Fix bug when updating reporter

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -549,7 +549,7 @@ class Issue(Resource):
             # apply some heuristics to make certain changes easier
             if isinstance(value, str):
                 if field == "assignee" or field == "reporter":
-                    fields_dict["assignee"] = {"name": value}
+                    fields_dict[field] = {"name": value}
                 elif field == "comment":
                     if "comment" not in update_dict:
                         update_dict["comment"] = []


### PR DESCRIPTION
When updating a ticket `reporter` the `assignee` will be changed instead:
```py
>>> jira_client = JIRA(...)
>>> issue = jira_client.issue("...")
>>> issue.update(reporter="bored-engineer")
```