### PR TITLE
add typehints and allow google docstrings

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,8 @@
 include LICENSE README.rst
 
+# Include
+include jira/py.typed
+
 # Exclude what is in these folders
 prune tests
 prune .github

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,42 +1,90 @@
 API Documentation
 *****************
 
-.. module:: jira
 
 .. contents:: Contents
    :local:
 
-JIRA
-====
+jira package
+============
 
-.. autoclass:: JIRA
+jira.client module
+------------------
 
-Issue
-========
+.. automodule:: jira.client
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-.. autoclass:: Issue
+jira.config module
+------------------
 
-Priority
-========
+.. automodule:: jira.config
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-.. autoclass:: Priority
+jira.exceptions module
+----------------------
 
-Comment
-=======
+.. automodule:: jira.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-.. autoclass:: Comment
+jira.jirashell module
+---------------------
 
-Worklog
-=======
+.. automodule:: jira.jirashell
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-.. autoclass:: Worklog
+jira.resilientsession module
+----------------------------
 
-Watchers
-========
+.. automodule:: jira.resilientsession
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-.. autoclass:: Watchers
+jira.resources module
+---------------------
 
-JIRAError
-=========
+.. autodata:: jira.client.ResourceType
+   :annotation: = alias of TypeVar(‘ResourceType’, contravariant=True, bound=jira.resources.Resource)
 
-.. autoclass:: JIRAError
+.. automodule:: jira.resources
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members:
+
+.. autoclass:: jira.resources.StatusCategory
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: jira.resources.GreenHopperResource
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: jira.resources.Sprint
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: jira.resources.Board
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+jira.utils module
+-----------------
+
+.. automodule:: jira.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,12 @@ needs_sphinx = "2.2.0"
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode", "sphinx.ext.intersphinx"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.7", None),
@@ -42,9 +47,11 @@ intersphinx_mapping = {
 }
 
 autodoc_default_options = {
+    "member-order": "bysource",
     "members": True,
-    "undoc-members": True,
     "show-inheritance": True,
+    "special-members": "__init__",
+    "undoc-members": True,
 }
 
 nitpick_ignore = [
@@ -286,6 +293,11 @@ man_pages = [
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
+
+# -- Options for Napoleon  -----------------------------------------------------
+
+napoleon_google_docstring = True
+napoleon_numpy_docstring = False  # Explicitly prefer Google style docstring
 
 
 # -- Options for Texinfo output ------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ from jira import __version__  # noqa
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "2.2.0"
+needs_sphinx = "4.0.0"
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
@@ -37,10 +37,8 @@ extensions = [
 ]
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.7", None),
-    # until https://github.com/psf/requests/issues/5212 is addressed
-    # "requests": ("http://docs.python-requests.org/en/latest/", None),
-    "requests": ("https://requests.kennethreitz.org/en/master/", None),
+    "python": ("https://docs.python.org/3.8", None),
+    "requests": ("https://requests.readthedocs.io/en/latest/", None),
     "requests-oauthlib": ("https://requests-oauthlib.readthedocs.io/en/latest/", None),
     "ipython": ("https://ipython.readthedocs.io/en/stable/", None),
     "pip": ("https://pip.readthedocs.io/en/stable/", None),
@@ -53,54 +51,22 @@ autodoc_default_options = {
     "special-members": "__init__",
     "undoc-members": True,
 }
+autodoc_inherit_docstrings = False
+
 
 nitpick_ignore = [
-    ("py:class", "Any"),
-    ("py:class", "Attachment"),
-    ("py:class", "Board"),
-    ("py:class", "BufferedReader"),
-    ("py:class", "Component"),
-    ("py:class", "CustomFieldOption"),
-    ("py:class", "Customer"),
-    ("py:class", "Dashboard"),
-    ("py:class", "Dict"),
-    ("py:class", "Filter"),
-    ("py:class", "Issue._IssueFields"),
-    ("py:class", "IssueLinkType"),
-    ("py:class", "IssueType"),
-    ("py:class", "Iterable"),
-    ("py:class", "List"),
-    ("py:class", "NoReturn"),
-    ("py:class", "Optional"),
-    ("py:class", "Project"),
-    ("py:class", "Resolution"),
-    ("py:class", "Resource"),
-    ("py:class", "Response"),
-    ("py:class", "ResultList"),
-    ("py:class", "ServiceDesk"),
-    ("py:class", "Sprint"),
-    ("py:class", "Status"),
-    ("py:class", "StatusCategory"),
-    ("py:class", "Tuple"),
-    ("py:class", "Union"),
-    ("py:class", "User"),
-    ("py:class", "Version"),
-    ("py:class", "Votes"),
-    ("py:class", "diy"),
-    ("py:class", "integer"),
-    ("py:class", "jira.client.ResultList"),
-    ("py:class", "jira.resources.Resource"),
-    ("py:class", "jira.resources.Sprint"),
-    ("py:class", "jira.resources.Watchers"),
-    ("py:class", "kanban"),
-    ("py:class", "project"),
-    ("py:class", "scrum"),
-    ("py:class", "user"),
-    ("py:meth", "Resource.delete"),
-    ("py:meth", "Resource.update"),
+    ("py:class", "JIRA"),  # in jira.resources we only import this class if type
+    ("py:obj", "typing.ResourceType"),  # only Py36 has a problem with this reference
+    # From other packages
     ("py:mod", "filemagic"),
     ("py:mod", "ipython"),
     ("py:mod", "pip"),
+    ("py:class", "_io.BufferedReader"),
+    ("py:class", "BufferedReader"),
+    ("py:class", "Request"),
+    ("py:class", "requests.models.Response"),
+    ("py:class", "requests.sessions.Session"),
+    ("py:class", "Response"),
     ("py:mod", "requests-kerberos"),
     ("py:mod", "requests-oauthlib"),
 ]
@@ -298,6 +264,7 @@ man_pages = [
 
 napoleon_google_docstring = True
 napoleon_numpy_docstring = False  # Explicitly prefer Google style docstring
+napoleon_use_param = True  # for type hint support
 
 
 # -- Options for Texinfo output ------------------------------------------------

--- a/examples/basic_auth.py
+++ b/examples/basic_auth.py
@@ -19,6 +19,8 @@ jira = JIRA(basic_auth=("admin", "admin"))  # a username/password tuple
 props = jira.application_properties()
 
 # Find all issues reported by the admin
+# Note: we cast() for mypy's benefit, as search_issues can also return the raw json !
+#   This is if the following argument is used: `json_result=True`
 issues = cast(ResultList[Issue], jira.search_issues("assignee=admin"))
 
 # Find the top three projects containing issues reported by admin

--- a/examples/basic_auth.py
+++ b/examples/basic_auth.py
@@ -2,8 +2,11 @@
 # username and password over HTTP BASIC authentication.
 
 from collections import Counter
+from typing import cast
 
 from jira import JIRA
+from jira.client import ResultList
+from jira.resources import Issue
 
 # By default, the client will connect to a Jira instance started from the Atlassian Plugin SDK.
 # See
@@ -16,7 +19,7 @@ jira = JIRA(basic_auth=("admin", "admin"))  # a username/password tuple
 props = jira.application_properties()
 
 # Find all issues reported by the admin
-issues = jira.search_issues("assignee=admin")
+issues = cast(ResultList[Issue], jira.search_issues("assignee=admin"))
 
 # Find the top three projects containing issues reported by admin
 top_three = Counter([issue.fields.project.key for issue in issues]).most_common(3)

--- a/examples/basic_use.py
+++ b/examples/basic_use.py
@@ -16,12 +16,11 @@ keys = sorted([project.key for project in projects])[2:5]
 
 # Get an issue.
 issue = jira.issue("JRA-1330")
-assert issue.fields  # for mypy benefit
 # Find all comments made by Atlassians on this issue.
 atl_comments = [
     comment
-    for comment in issue.fields.comment.comments  # type: ignore # FIXME: .comments?
-    if re.search(r"@atlassian.com$", comment.author.emailAddress)
+    for comment in issue.fields.comment.comments
+    if re.search(r"@atlassian.com$", comment.author.key)
 ]
 
 # Add a comment to the issue.
@@ -40,7 +39,6 @@ issue.update(fields={"labels": ["AAA", "BBB"]})
 
 # Or modify the List of existing labels. The new label is unicode with no
 # spaces
-assert issue.fields.labels  # help mypy
 issue.fields.labels.append(u"new_text")
 issue.update(fields={"labels": issue.fields.labels})
 
@@ -50,4 +48,4 @@ issue.delete()
 # Linking a remote jira issue (needs applinks to be configured to work)
 issue = jira.issue("JRA-1330")
 issue2 = jira.issue("XX-23")  # could also be another instance
-jira.add_remote_link(str(issue.id), issue2)
+jira.add_remote_link(issue.id, issue2)

--- a/examples/basic_use.py
+++ b/examples/basic_use.py
@@ -6,9 +6,7 @@ from jira import JIRA
 
 # By default, the client will connect to a Jira instance started from the Atlassian Plugin SDK
 # (see https://developer.atlassian.com/display/DOCS/Installing+the+Atlassian+Plugin+SDK for details).
-# Override this with the options parameter.
-options = {"server": "https://jira.atlassian.com"}
-jira = JIRA(options)
+jira = JIRA(server="https://jira.atlassian.com")
 
 # Get all projects viewable by anonymous users.
 projects = jira.projects()
@@ -18,11 +16,11 @@ keys = sorted([project.key for project in projects])[2:5]
 
 # Get an issue.
 issue = jira.issue("JRA-1330")
-
+assert issue.fields  # for mypy benefit
 # Find all comments made by Atlassians on this issue.
 atl_comments = [
     comment
-    for comment in issue.fields.comment.comments
+    for comment in issue.fields.comment.comments  # type: ignore # FIXME: .comments?
     if re.search(r"@atlassian.com$", comment.author.emailAddress)
 ]
 
@@ -42,6 +40,7 @@ issue.update(fields={"labels": ["AAA", "BBB"]})
 
 # Or modify the List of existing labels. The new label is unicode with no
 # spaces
+assert issue.fields.labels  # help mypy
 issue.fields.labels.append(u"new_text")
 issue.update(fields={"labels": issue.fields.labels})
 
@@ -51,4 +50,4 @@ issue.delete()
 # Linking a remote jira issue (needs applinks to be configured to work)
 issue = jira.issue("JRA-1330")
 issue2 = jira.issue("XX-23")  # could also be another instance
-jira.add_remote_link(issue, issue2)
+jira.add_remote_link(str(issue.id), issue2)

--- a/examples/cookie_auth.py
+++ b/examples/cookie_auth.py
@@ -2,8 +2,11 @@
 # username and password over HTTP BASIC authentication.
 
 from collections import Counter
+from typing import cast
 
 from jira import JIRA
+from jira.client import ResultList
+from jira.resources import Issue
 
 # By default, the client will connect to a Jira instance started from the Atlassian Plugin SDK.
 # See
@@ -16,11 +19,11 @@ jira = JIRA(auth=("admin", "admin"))  # a username/password tuple for cookie aut
 props = jira.application_properties()
 
 # Find all issues reported by the admin
-issues = jira.search_issues("assignee=admin")
+issues = cast(ResultList[Issue], jira.search_issues("assignee=admin"))
 
 # Find the top three projects containing issues reported by admin
 top_three = Counter([issue.fields.project.key for issue in issues]).most_common(3)
 
 # import time; time.sleep(65)  # Fake cookie expiration
 
-issues = jira.search_issues("assignee=admin")
+issues = cast(ResultList[Issue], jira.search_issues("assignee=admin"))

--- a/jira/client.py
+++ b/jira/client.py
@@ -250,54 +250,6 @@ class JIRA(object):
     For quick command line access to a server, see the ``jirashell`` script included with this distribution.
 
     The easiest way to instantiate is using ``j = JIRA("https://jira.atlassian.com")``
-
-    :param options: Specify the server and properties this client will use. Use a dict with any
-        of the following properties:
-
-        * server -- the server address and context path to use. Defaults to ``http://localhost:2990/jira``.
-        * rest_path -- the root REST path to use. Defaults to ``api``, where the Jira REST resources live.
-        * rest_api_version -- the version of the REST resources under rest_path to use. Defaults to ``2``.
-        * agile_rest_path - the REST path to use for Jira Agile requests. Defaults to ``greenhopper`` (old, private
-                API). Check `GreenHopperResource` for other supported values.
-        * verify -- Verify SSL certs. Defaults to ``True``.
-        * client_cert -- a tuple of (cert,key) for the requests library for client side SSL
-        * check_update -- Check whether using the newest python-jira library version.
-        * cookies -- A dict of custom cookies that are sent in all requests to the server.
-
-    :param basic_auth: A tuple of username and password to use when establishing a session via HTTP BASIC
-        authentication.
-    :param oauth: A dict of properties for OAuth authentication. The following properties are required:
-
-        * access_token -- OAuth access token for the user
-        * access_token_secret -- OAuth access token secret to sign with the key
-        * consumer_key -- key of the OAuth application link defined in Jira
-        * key_cert -- private key file to sign requests with (should be the pair of the public key supplied to
-          Jira in the OAuth application link)
-
-    :param kerberos: If true it will enable Kerberos authentication.
-    :param kerberos_options: A dict of properties for Kerberos authentication. The following properties are possible:
-
-        * mutual_authentication -- string DISABLED or OPTIONAL.
-
-        Example kerberos_options structure: ``{'mutual_authentication': 'DISABLED'}``
-
-    :param jwt: A dict of properties for JWT authentication supported by Atlassian Connect. The following
-        properties are required:
-
-        * secret -- shared secret as delivered during 'installed' lifecycle event
-          (see https://developer.atlassian.com/static/connect/docs/latest/modules/lifecycle.html for details)
-        * payload -- dict of fields to be inserted in the JWT payload, e.g. 'iss'
-
-        Example jwt structure: ``{'secret': SHARED_SECRET, 'payload': {'iss': PLUGIN_KEY}}``
-
-    :param validate: If true it will validate your credentials first. Remember that if you are accessing Jira
-        as anonymous it will fail to instantiate.
-    :param get_server_info: If true it will fetch server version info first to determine if some API calls
-        are available.
-    :param async_: To enable asynchronous requests for those actions where we implemented it, like issue update() or delete().
-    :param async_workers: Set the number of worker threads for async operations.
-    :param timeout: Set a read/connect timeout for the underlying calls to Jira (default: None)
-        Obviously this means that you cannot rely on the return code when this is enabled.
     """
 
     DEFAULT_OPTIONS = {
@@ -365,64 +317,61 @@ class JIRA(object):
 
         For quick command line access to a server, see the ``jirashell`` script included with this distribution.
 
-        The easiest way to instantiate is using j = JIRA("https://jira.atlasian.com")
-        :param server: The server address and context path to use. Defaults to ``http://localhost:2990/jira``.
-        :type server: Optional[str]
-        :param options: Specify the server and properties this client will use. Use a dict with any
-            of the following properties:
-            * server -- the server address and context path to use. Defaults to ``http://localhost:2990/jira``.
-            * rest_path -- the root REST path to use. Defaults to ``api``, where the Jira REST resources live.
-            * rest_api_version -- the version of the REST resources under rest_path to use. Defaults to ``2``.
-            * agile_rest_path - the REST path to use for Jira Agile requests. Defaults to ``greenhopper`` (old, private
-               API). Check `GreenHopperResource` for other supported values.
-            * verify -- Verify SSL certs. Defaults to ``True``.
-            * client_cert -- a tuple of (cert,key) for the requests library for client side SSL
-            * check_update -- Check whether using the newest python-jira library version.
-        :type options: Optional[Dict[str, Any]]
-        :param basic_auth: A tuple of username and password to use when establishing a session via HTTP BASIC
-        authentication.
-        :type basic_auth: Union[Dict, None, Tuple[str, str]]
-        :param oauth: A dict of properties for OAuth authentication. The following properties are required:
-            * access_token -- OAuth access token for the user
-            * access_token_secret -- OAuth access token secret to sign with the key
-            * consumer_key -- key of the OAuth application link defined in Jira
-            * key_cert -- private key file to sign requests with (should be the pair of the public key supplied to
-            Jira in the OAuth application link)
-        :type oauth: Optional[Any]
-        :param kerberos: If true it will enable Kerberos authentication.
-        :type kerberos: bool
-        :param kerberos_options: A dict of properties for Kerberos authentication. The following properties are possible:
-            * mutual_authentication -- string DISABLED or OPTIONAL.
-            Example kerberos_options structure: ``{'mutual_authentication': 'DISABLED'}``
-        :type kerberos_options: Optional[Dict[str,str]]
-        :param jwt: A dict of properties for JWT authentication supported by Atlassian Connect. The following
-            properties are required:
-            * secret -- shared secret as delivered during 'installed' lifecycle event
-            (see https://developer.atlassian.com/static/connect/docs/latest/modules/lifecycle.html for details)
-            * payload -- dict of fields to be inserted in the JWT payload, e.g. 'iss'
-            Example jwt structure: ``{'secret': SHARED_SECRET, 'payload': {'iss': PLUGIN_KEY}}``
-        :type jwt: Optional[Any]
-        :param validate: If true it will validate your credentials first. Remember that if you are accessing Jira
-            as anonymous it will fail to instantiate.
-        :type validate: bool
-        :param get_server_info: If true it will fetch server version info first to determine if some API calls
-            are available.
-        :type get_server_info: bool
-        :param async_: To enable async requests for those actions where we implemented it, like issue update() or delete().
-        :type async_: bool
-        :param async_workers: Set the number of worker threads for async operations.
-        :type async_workers: int
-        :param timeout: Set a read/connect timeout for the underlying calls to Jira (default: None)
-        :type timeout: Optional[Any]
-        Obviously this means that you cannot rely on the return code when this is enabled.
-        :param max_retries: Sets the amount Retries for the HTTP sessions initiated by the client. (Default: 3)
-        :type max_retries: int
-        :param proxies: Sets the proxies for the HTTP session.
-        :type proxies: Optional[Any]
-        :param auth: Set a cookie auth token if this is required.
-        :type auth: Optional[Tuple[str,str]]
-        :param logging: Determine whether or not logging should be enabled. (Default: True)
-        :type logging: bool
+        The easiest way to instantiate is using ``j = JIRA("https://jira.atlasian.com")``
+
+        Args:
+            server (Optional[str]): The server address and context path to use. Defaults to ``http://localhost:2990/jira``.
+            options (Optional[Dict[str, Any]]): Specify the server and properties this client will use.
+              Use a dict with any of the following properties:
+
+                * server -- the server address and context path to use. Defaults to ``http://localhost:2990/jira``.
+                * rest_path -- the root REST path to use. Defaults to ``api``, where the Jira REST resources live.
+                * rest_api_version -- the version of the REST resources under rest_path to use. Defaults to ``2``.
+                * agile_rest_path - the REST path to use for Jira Agile requests. Defaults to ``greenhopper`` (old, private
+                  API). Check :py:class:``GreenHopperResource`` for other supported values.
+                * verify -- Verify SSL certs. Defaults to ``True``.
+                * client_cert -- a tuple of (cert,key) for the requests library for client side SSL
+                * check_update -- Check whether using the newest python-jira library version.
+
+            basic_auth (Union[None, Tuple[str, str]]): A tuple of username and password to use when
+              establishing a session via HTTP BASIC authentication.
+            oauth (Optional[Any]): A dict of properties for OAuth authentication. The following properties are required:
+
+                * access_token -- OAuth access token for the user
+                * access_token_secret -- OAuth access token secret to sign with the key
+                * consumer_key -- key of the OAuth application link defined in Jira
+                * key_cert -- private key file to sign requests with (should be the pair of the public key supplied to
+                  Jira in the OAuth application link)
+
+            kerberos (bool): If true it will enable Kerberos authentication.
+            kerberos_options (Optional[Dict[str,str]]): A dict of properties for Kerberos authentication.
+              The following properties are possible:
+
+                * mutual_authentication -- string DISABLED or OPTIONAL.
+
+                Example kerberos_options structure: ``{'mutual_authentication': 'DISABLED'}``
+
+            jwt (Optional[Any]): A dict of properties for JWT authentication supported by Atlassian Connect.
+              The following properties are required:
+
+                * secret -- shared secret as delivered during 'installed' lifecycle event
+                    (see https://developer.atlassian.com/static/connect/docs/latest/modules/lifecycle.html for details)
+                * payload -- dict of fields to be inserted in the JWT payload, e.g. 'iss'
+
+                Example jwt structure: ``{'secret': SHARED_SECRET, 'payload': {'iss': PLUGIN_KEY}}``
+
+            validate (bool): If true it will validate your credentials first. Remember that if you are accessing Jira
+              as anonymous it will fail to instantiate.
+            get_server_info (bool): If true it will fetch server version info first to determine if some API calls
+              are available.
+            async_ (bool): To enable async requests for those actions where we implemented it, like issue update() or delete().
+            async_workers (int): Set the number of worker threads for async operations.
+            timeout (Optional[Any]): Set a read/connect timeout for the underlying calls to Jira (default: None)
+              Obviously this means that you cannot rely on the return code when this is enabled.
+            max_retries (int): Sets the amount Retries for the HTTP sessions initiated by the client. (Default: 3)
+            proxies (Optional[Any]): Sets the proxies for the HTTP session.
+            auth (Optional[Tuple[str,str]]): Set a cookie auth token if this is required.
+            logging (bool): Determine whether or not logging should be enabled. (Default: True)
         """
         # force a copy of the tuple to be used in __del__() because
         # sys.version_info could have already been deleted in __del__()
@@ -430,13 +379,13 @@ class JIRA(object):
 
         if options is None:
             options = {}
-            if server and hasattr(server, "keys"):
+            if server and isinstance(server, dict):
                 warnings.warn(
                     "Old API usage, use JIRA(url) or JIRA(options={'server': url}, when using dictionary always use named parameters.",
                     DeprecationWarning,
                 )
                 options = server
-                server = None
+                server = ""
 
         if server:
             options["server"] = server
@@ -444,7 +393,8 @@ class JIRA(object):
             options["async"] = async_
             options["async_workers"] = async_workers
 
-        self.logging = logging
+        self.logging = _logging.getLogger("jira")
+        self.logging.setLevel(_logging.INFO if logging else _logging.WARNING)
 
         self._options = copy.copy(JIRA.DEFAULT_OPTIONS)
 
@@ -453,6 +403,7 @@ class JIRA(object):
         self._rank = None
 
         # Rip off trailing slash since all urls depend on that
+        assert isinstance(self._options["server"], str)  # to help mypy
         if self._options["server"].endswith("/"):
             self._options["server"] = self._options["server"][:-1]
 

--- a/jira/client.py
+++ b/jira/client.py
@@ -22,11 +22,26 @@ import warnings
 from collections import OrderedDict
 from collections.abc import Iterable
 from functools import lru_cache, wraps
+from io import BufferedReader
 from numbers import Number
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    no_type_check,
+)
 from urllib.parse import urlparse
 
 import requests
 from pkg_resources import parse_version
+from requests import Response
 from requests.auth import AuthBase
 from requests.utils import get_netrc_auth
 
@@ -88,16 +103,11 @@ LOG = _logging.getLogger("jira")
 LOG.addHandler(_logging.NullHandler())
 
 
-def translate_resource_args(func):
+def translate_resource_args(func: Callable):
     """Decorator that converts Issue and Project resources to their keys when used as arguments."""
 
     @wraps(func)
-    def wrapper(*args, **kwargs):
-        """
-        :type args: *Any
-        :type kwargs: **Any
-        :return: Any
-        """
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         arg_list = []
         for arg in args:
             if isinstance(arg, (Issue, Project)):
@@ -110,27 +120,34 @@ def translate_resource_args(func):
     return wrapper
 
 
-def _field_worker(fields=None, **fieldargs):
-    """
-    :type fields: Optional[Dict[str, Any]]
-    :type fieldargs: **Any
-    :return: Union[Dict[str, Dict[str, Any]], Dict[str, Dict[str, str]]]
-    """
+def _field_worker(
+    fields: Dict[str, Any] = None, **fieldargs: Any
+) -> Union[Dict[str, Dict[str, Any]], Dict[str, Dict[str, str]]]:
     if fields is not None:
         return {"fields": fields}
     return {"fields": fieldargs}
 
 
-class ResultList(list):
+ResourceType = TypeVar("ResourceType", contravariant=True, bound=Resource)
+
+
+class ResultList(list, Generic[ResourceType]):
     def __init__(
-        self, iterable=None, _startAt=0, _maxResults=0, _total=0, _isLast=None
-    ):
+        self,
+        iterable: Iterable = None,
+        _startAt: int = 0,
+        _maxResults: int = 0,
+        _total: Optional[int] = None,
+        _isLast: Optional[bool] = None,
+    ) -> None:
         """
-        :type iterable: Any
-        :type _startAt: int
-        :type _maxResults: int
-        :type _total: int
-        :type isLast: Optional[bool]
+
+        Args:
+            iterable (Iterable): [description]. Defaults to None.
+            _startAt (int): Start page. Defaults to 0.
+            _maxResults (int): Max results per page. Defaults to 0.
+            _total (Optional[int]): Total results from query. Defaults to 0.
+            _isLast (Optional[bool]): Last Page? Defaults to None.
         """
         if iterable is not None:
             list.__init__(self, iterable)
@@ -141,15 +158,12 @@ class ResultList(list):
         self.maxResults = _maxResults
         # Optional parameters:
         self.isLast = _isLast
-        self.total = _total
+        self.total = _total if _total is not None else len(self)
 
-        self.iterable = iterable or []
+        self.iterable: List = list(iterable) if iterable else []
         self.current = self.startAt
 
-    def __next__(self):
-        """
-        :return: int
-        """
+    def __next__(self) -> Type[ResourceType]:
         self.current += 1
         if self.current > self.total:
             raise StopIteration
@@ -189,7 +203,16 @@ class JiraCookieAuth(AuthBase):
 
     """
 
-    def __init__(self, session, _get_session, auth):
+    def __init__(
+        self, session: ResilientSession, _get_session: Callable, auth: Tuple[str, str]
+    ):
+        """Cookie Based Authentication
+
+        Args:
+            session (ResilientSession): The Session object to communicate with the API.
+            _get_session (Callable): The function that returns a :py_class:``User``
+            auth (Tuple[str, str]): The username, password tuple
+        """
         self._session = session
         self._get_session = _get_session
         self.__auth = auth
@@ -234,7 +257,7 @@ class JIRA(object):
     """User interface to Jira.
 
     Clients interact with Jira by constructing an instance of this object and calling its methods. For addressable
-    resources in Jira -- those with "self" links -- an appropriate subclass of :py:class:`Resource` will be returned
+    resources in Jira -- those with "self" links -- an appropriate subclass of :py:class:`jira.resources.Resource` will be returned
     with customized ``update()`` and ``delete()`` methods, along with attribute access to fields. This means that calls
     of the form ``issue.fields.summary`` will be resolved into the proper lookups to return the JSON value at that
     mapping. Methods that do not return resources will return a dict constructed from the JSON response or a scalar
@@ -289,22 +312,22 @@ class JIRA(object):
 
     def __init__(
         self,
-        server=None,
-        options=None,
-        basic_auth=None,
-        oauth=None,
-        jwt=None,
+        server: str = None,
+        options: Dict[str, Union[str, bool, Any]] = None,
+        basic_auth: Union[None, Tuple[str, str]] = None,
+        oauth: Dict[str, Any] = None,
+        jwt: Dict[str, Any] = None,
         kerberos=False,
-        kerberos_options=None,
+        kerberos_options: Dict[str, Any] = None,
         validate=False,
-        get_server_info=True,
-        async_=False,
-        async_workers=5,
-        logging=True,
-        max_retries=3,
-        proxies=None,
-        timeout=None,
-        auth=None,
+        get_server_info: bool = True,
+        async_: bool = False,
+        async_workers: int = 5,
+        logging: bool = True,
+        max_retries: int = 3,
+        proxies: Any = None,
+        timeout: Optional[Union[Union[float, int], Tuple[float, float]]] = None,
+        auth: Tuple[str, str] = None,
     ):
         """Construct a Jira client instance.
 
@@ -329,7 +352,7 @@ class JIRA(object):
                 * rest_path -- the root REST path to use. Defaults to ``api``, where the Jira REST resources live.
                 * rest_api_version -- the version of the REST resources under rest_path to use. Defaults to ``2``.
                 * agile_rest_path - the REST path to use for Jira Agile requests. Defaults to ``greenhopper`` (old, private
-                  API). Check :py:class:``GreenHopperResource`` for other supported values.
+                  API). Check :py:class:`jira.resources.GreenHopperResource` for other supported values.
                 * verify -- Verify SSL certs. Defaults to ``True``.
                 * client_cert -- a tuple of (cert,key) for the requests library for client side SSL
                 * check_update -- Check whether using the newest python-jira library version.
@@ -356,7 +379,7 @@ class JIRA(object):
               The following properties are required:
 
                 * secret -- shared secret as delivered during 'installed' lifecycle event
-                    (see https://developer.atlassian.com/static/connect/docs/latest/modules/lifecycle.html for details)
+                  (see https://developer.atlassian.com/static/connect/docs/latest/modules/lifecycle.html for details)
                 * payload -- dict of fields to be inserted in the JWT payload, e.g. 'iss'
 
                 Example jwt structure: ``{'secret': SHARED_SECRET, 'payload': {'iss': PLUGIN_KEY}}``
@@ -367,7 +390,8 @@ class JIRA(object):
               are available.
             async_ (bool): To enable async requests for those actions where we implemented it, like issue update() or delete().
             async_workers (int): Set the number of worker threads for async operations.
-            timeout (Optional[Any]): Set a read/connect timeout for the underlying calls to Jira (default: None)
+            timeout (Optional[Union[Union[float, int], Tuple[float, float]]]): Set a read/connect timeout for the underlying
+              calls to Jira (default: None).
               Obviously this means that you cannot rely on the return code when this is enabled.
             max_retries (int): Sets the amount Retries for the HTTP sessions initiated by the client. (Default: 3)
             proxies (Optional[Any]): Sets the proxies for the HTTP session.
@@ -397,7 +421,7 @@ class JIRA(object):
         LOG.setLevel(_logging.INFO if logging else _logging.CRITICAL)
         self.log = LOG
 
-        self._options = copy.copy(JIRA.DEFAULT_OPTIONS)
+        self._options: Dict[str, Any] = copy.copy(JIRA.DEFAULT_OPTIONS)
 
         self._options.update(options)
 
@@ -414,6 +438,8 @@ class JIRA(object):
 
         self._try_magic()
 
+        assert isinstance(self._options["headers"], dict)  # for mypy benefit
+        self._session: ResilientSession  # for mypy benefit
         if oauth:
             self._create_oauth_session(oauth, timeout)
         elif basic_auth:
@@ -428,9 +454,10 @@ class JIRA(object):
             # always log in for cookie based auth, as we need a first request to be logged in
             validate = True
         else:
-            verify = self._options["verify"]
+            verify = bool(self._options["verify"])
             self._session = ResilientSession(timeout=timeout)
             self._session.verify = verify
+
         self._session.headers.update(self._options["headers"])
 
         if "cookies" in self._options:
@@ -476,15 +503,20 @@ class JIRA(object):
                     self._fields[name] = f["id"]
 
     @property
-    def server_url(self):
+    def server_url(self) -> str:
         """Return the server url"""
-        return self._options["server"]
+        return str(self._options["server"])
 
-    def _create_cookie_auth(self, auth, timeout):
+    def _create_cookie_auth(
+        self,
+        auth: Tuple[str, str],
+        timeout: Optional[Union[Union[float, int], Tuple[float, float]]],
+    ):
         self._session = ResilientSession(timeout=timeout)
         self._session.auth = JiraCookieAuth(self._session, self.session, auth)
-        self._session.verify = self._options["verify"]
-        self._session.cert = self._options["client_cert"]
+        self._session.verify = bool(self._options["verify"])
+        client_cert: Tuple[str, str] = self._options["client_cert"]  # to help mypy
+        self._session.cert = client_cert
 
     def _check_update_(self):
         """Check if the current version of the library is outdated."""
@@ -521,7 +553,7 @@ class JIRA(object):
                 pass
             self._session = None
 
-    def _check_for_html_error(self, content):
+    def _check_for_html_error(self, content: str):
         # Jira has the bad habit of returning errors in pages with 200 and
         # embedding the error in a huge webpage.
         if "<!-- SecurityTokenMissing -->" in content:
@@ -541,35 +573,32 @@ class JIRA(object):
 
     def _fetch_pages(
         self,
-        item_type,
-        items_key,
-        request_path,
-        startAt=0,
-        maxResults=50,
-        params=None,
-        base=JIRA_BASE_URL,
-    ):
-        """Fetch pages.
+        item_type: Type[ResourceType],
+        items_key: Optional[str],
+        request_path: str,
+        startAt: int = 0,
+        maxResults: int = 50,
+        params: Dict[str, Any] = None,
+        base: str = JIRA_BASE_URL,
+    ) -> ResultList[ResourceType]:
+        """Fetch from a paginated end point.
 
-        :param item_type: Type of single item. ResultList of such items will be returned.
-        :type item_type: type
-        :param items_key: Path to the items in JSON returned from server.
-                Set it to None, if response is an array, and not a JSON object.
-        :type items_key: Optional[str]
-        :param request_path: path in request URL
-        :type request_path: str
-        :param startAt: index of the first record to be fetched. (Default: 0)
-        :type startAt: int
-        :param maxResults: Maximum number of items to return.
-                If maxResults evaluates as False, it will try to get all items in batches. (Default:50)
-        :type maxResults: int
-        :param params: Params to be used in all requests. Should not contain startAt and maxResults,
-                        as they will be added for each request created from this function.
-        :type params: Dict[str, Any]
-        :param base: base URL
-        :type base: str
-        :rtype: ResultList
+        Args:
+            item_type (Type[Resource]): Type of single item. ResultList of such items will be returned.
+            items_key (Optional[str]): Path to the items in JSON returned from server.
+              Set it to None, if response is an array, and not a JSON object.
+            request_path (str): path in request URL
+            startAt (int): index of the first record to be fetched. (Default: 0)
+            maxResults (int): Maximum number of items to return.
+              If maxResults evaluates as False, it will try to get all items in batches. (Default:50)
+            params (Dict[str, Any]): Params to be used in all requests. Should not contain startAt and maxResults,
+              as they will be added for each request created from this function.
+            base (str): base URL to use for the requests.
+
+        Returns:
+            ResultList
         """
+        async_workers = None
         async_class = None
         if self._options["async"]:
             try:
@@ -578,7 +607,7 @@ class JIRA(object):
                 async_class = FuturesSession
             except ImportError:
                 pass
-            async_workers = self._options["async_workers"]
+            async_workers = self._options.get("async_workers")
         page_params = params.copy() if params else {}
         if startAt:
             page_params["startAt"] = startAt
@@ -593,6 +622,7 @@ class JIRA(object):
 
             if isinstance(resource, dict):
                 total = resource.get("total")
+                total = int(total) if total is not None else total
                 # 'isLast' is the optional key added to responses in Jira Agile 6.7.6. So far not used in basic Jira API.
                 is_last = resource.get("isLast", False)
                 start_at_from_response = resource.get("startAt", 0)
@@ -618,7 +648,7 @@ class JIRA(object):
                         session=self._session, max_workers=async_workers
                     )
                     for start_index in range(page_start, total, page_size):
-                        page_params = params.copy()
+                        page_params = params.copy() if params else {}
                         page_params["startAt"] = start_index
                         page_params["maxResults"] = page_size
                         url = self._get_url(request_path)
@@ -656,22 +686,22 @@ class JIRA(object):
             return ResultList(
                 items, start_at_from_response, max_results_from_response, total, is_last
             )
-        else:
-            # it seams that search_users can return a list() containing a single user!
+        else:  # TODO: unreachable
+            # it seems that search_users can return a list() containing a single user!
             return ResultList(
                 [item_type(self._options, self._session, resource)], 0, 1, 1, True
             )
 
-    def _get_items_from_page(self, item_type, items_key, resource):
-        """
-        :type item_type: type
-        :type items_key: str
-        :type resource: Dict[str, Any]
-        :rtype: Union[List[Dashboard], List[Issue]]
-        """
+    def _get_items_from_page(
+        self,
+        item_type: Type[ResourceType],
+        items_key: Optional[str],
+        resource: Dict[str, Any],
+    ) -> List[ResourceType]:
         try:
             return [
-                item_type(self._options, self._session, raw_issue_json)
+                # We need to ignore the type here, as 'Resource' is an option
+                item_type(self._options, self._session, raw_issue_json)  # type: ignore
                 for raw_issue_json in (resource[items_key] if items_key else resource)
             ]
         except KeyError as e:
@@ -680,13 +710,15 @@ class JIRA(object):
 
     # Information about this client
 
-    def client_info(self):
+    def client_info(self) -> str:
         """Get the server this client is connected to."""
         return self.server_url
 
     # Universal resource loading
 
-    def find(self, resource_format, ids=None):
+    def find(
+        self, resource_format: str, ids: Union[Tuple[str, str], int, str] = ""
+    ) -> Resource:
         """Find Resource object for any addressable resource on the server.
 
         This method is a universal resource locator for any REST-ful resource in Jira. The
@@ -701,20 +733,22 @@ class JIRA(object):
         reason, it is intended to support resources that are not included in the standard
         Atlassian REST API.
 
-        :param resource_format: the subpath to the resource string
-        :type resource_format: str
-        :param ids: values to substitute in the ``resource_format`` string
-        :type ids: tuple or None
-        :rtype: Resource
+        Args:
+            resource_format (str): the subpath to the resource string
+            ids (Optional[Tuple]): values to substitute in the ``resource_format`` string
+        Returns:
+            Resource
         """
         resource = Resource(resource_format, self._options, self._session)
         resource.find(ids)
         return resource
 
-    def async_do(self, size=10):
+    @no_type_check  # FIXME: This function fails type checking, probably a bug or two
+    def async_do(self, size: int = 10):
         """Execute all asynchronous jobs and wait for them to finish. By default it will run on 10 threads.
 
-        :param size: number of threads to run on.
+        Args:
+            size (int): number of threads to run on.
         """
         if hasattr(self._session, "_async_jobs"):
             self.log.info(
@@ -726,36 +760,39 @@ class JIRA(object):
             # Application properties
 
     # non-resource
-    def application_properties(self, key=None):
+    def application_properties(
+        self, key: str = None
+    ) -> Union[Dict[str, str], List[Dict[str, str]]]:
         """Return the mutable server application properties.
 
-        :param key: the single property to return a value for
-        :type key: Optional[str]
-        :rtype: Union[Dict[str, str], List[Dict[str, str]]]
-
+        Args:
+            key (Optional[str]): the single property to return a value for
+        Returns:
+            Union[Dict[str, str], List[Dict[str, str]]]
         """
         params = {}
         if key is not None:
             params["key"] = key
         return self._get_json("application-properties", params=params)
 
-    def set_application_property(self, key, value):
+    def set_application_property(self, key: str, value: str):
         """Set the application property.
 
-        :param key: key of the property to set
-        :type key: str
-        :param value: value to assign to the property
-        :type value: str
+        Args:
+            key (str): key of the property to set
+            value (str): value to assign to the property
         """
         url = self._get_latest_url("application-properties/" + key)
         payload = {"id": key, "value": value}
         return self._session.put(url, data=json.dumps(payload))
 
-    def applicationlinks(self, cached=True):
+    def applicationlinks(self, cached: bool = True) -> List:
         """List of application links.
 
-        :return: json
+        Returns:
+            List[Dict]: json, or empty list
         """
+        self._applicationlinks: List[Dict]  # for mypy benefit
         # if cached, return the last result
         if cached and hasattr(self, "_applicationlinks"):
             return self._applicationlinks
@@ -766,54 +803,55 @@ class JIRA(object):
         r = self._session.get(url)
 
         o = json_loads(r)
-        if "list" in o:
+        if "list" in o and isinstance(o, dict):
             self._applicationlinks = o["list"]
         else:
             self._applicationlinks = []
         return self._applicationlinks
 
     # Attachments
-    def attachment(self, id):
+    def attachment(self, id: str) -> Attachment:
         """Get an attachment Resource from the server for the specified ID.
 
-        :param id: The Attachment ID
-        :type id: str
-        :rtype: Attachment
+        Args:
+            id (str): The Attachment ID
+
+        Returns:
+            Attachment
         """
         return self._find_for_resource(Attachment, id)
 
     # non-resource
-    def attachment_meta(self):
+    def attachment_meta(self) -> Dict[str, int]:
         """Get the attachment metadata.
 
-        :rtype: Dict[str, int]
+        Return:
+            Dict[str, int]
         """
         return self._get_json("attachment/meta")
 
     @translate_resource_args
-    def add_attachment(self, issue, attachment, filename=None):
+    def add_attachment(
+        self, issue: str, attachment: Union[str, BufferedReader], filename: str = None
+    ) -> Attachment:
         """Attach an attachment to an issue and returns a Resource for it.
 
         The client will *not* attempt to open or validate the attachment; it expects a file-like object to be ready
         for its use. The user is still responsible for tidying up (e.g., closing the file, killing the socket, etc.)
 
-        :param issue: the issue to attach the attachment to
-        :type issue: str
-        :param attachment: file-like object to attach to the issue, also works if it is a string with the filename.
-        :type attachment: BufferedReader
-        :param filename: optional name for the attached file. If omitted, the file object's ``name`` attribute
-            is used. If you acquired the file-like object by any other method than ``open()``, make sure
-            that a name is specified in one way or the other.
-        :type filename: str
-        :rtype: Attachment
+        Args:
+            issue (str): the issue to attach the attachment to
+            attachment (Union[str,BufferedReader]): file-like object to attach to the issue, also works if it is a string with the filename.
+            filename (str): optional name for the attached file. If omitted, the file object's ``name`` attribute
+              is used. If you acquired the file-like object by any other method than ``open()``, make sure
+              that a name is specified in one way or the other.
+
+        Returns:
+            Attachment
         """
         if isinstance(attachment, str):
-            attachment = open(attachment, "rb")
-        if (
-            hasattr(attachment, "read")
-            and hasattr(attachment, "mode")
-            and attachment.mode != "rb"
-        ):
+            attachment: BufferedReader = open(attachment, "rb")  # type: ignore
+        elif isinstance(attachment, BufferedReader) and attachment.mode != "rb":
             self.log.warning(
                 "%s was not opened in 'rb' mode, attaching file may fail."
                 % attachment.name
@@ -822,7 +860,7 @@ class JIRA(object):
         url = self._get_url("issue/" + str(issue) + "/attachments")
 
         fname = filename
-        if not fname:
+        if not fname and isinstance(attachment, BufferedReader):
             fname = os.path.basename(attachment.name)
 
         if "MultipartEncoder" not in globals():
@@ -837,11 +875,8 @@ class JIRA(object):
         else:
             method = "MultipartEncoder"
 
-            def file_stream():
-                """Returns files stream of attachment.
-
-                :rtype: MultipartEncoder
-                """
+            def file_stream() -> MultipartEncoder:
+                """Returns files stream of attachment."""
                 return MultipartEncoder(
                     fields={"file": (fname, attachment, "application/octet-stream")}
                 )
@@ -856,61 +891,63 @@ class JIRA(object):
                 retry_data=file_stream,
             )
 
-        js = json_loads(r)
+        js: Union[Dict[str, Any], List[Dict[str, Any]]] = json_loads(r)
         if not js or not isinstance(js, Iterable):
             raise JIRAError("Unable to parse JSON: %s" % js)
-        attachment = Attachment(self._options, self._session, js[0])
-        if attachment.size == 0:
+        jira_attachment = Attachment(
+            self._options, self._session, js[0] if isinstance(js, List) else js
+        )
+        if jira_attachment.size == 0:
             raise JIRAError(
                 "Added empty attachment via %s method?!: r: %s\nattachment: %s"
-                % (method, r, attachment)
+                % (method, r, jira_attachment)
             )
-        return attachment
+        return jira_attachment
 
-    def delete_attachment(self, id):
+    def delete_attachment(self, id: str) -> Response:
         """Delete attachment by id.
 
-        :param id: ID of the attachment to delete
-        :type id: str
+        Args:
+            id (str): ID of the attachment to delete
+
+        Returns:
+            Response
         """
         url = self._get_url("attachment/" + str(id))
         return self._session.delete(url)
 
     # Components
 
-    def component(self, id):
+    def component(self, id: str):
         """Get a component Resource from the server.
 
-        :param id: ID of the component to get
-        :type id: str
+        Args:
+            id (str): ID of the component to get
         """
         return self._find_for_resource(Component, id)
 
     @translate_resource_args
     def create_component(
         self,
-        name,
-        project,
+        name: str,
+        project: str,
         description=None,
         leadUserName=None,
         assigneeType=None,
         isAssigneeTypeValid=False,
-    ):
+    ) -> Component:
         """Create a component inside a project and return a Resource for it.
 
-        :param name: name of the component
-        :type name: str
-        :param project: key of the project to create the component in
-        :type project: str
-        :param description: a description of the component
-        :type description: str
-        :param leadUserName: the username of the user responsible for this component
-        :type leadUserName: Optional[str]
-        :param assigneeType: see the ComponentBean.AssigneeType class for valid values
-        :type assigneeType: Optional[str]
-        :param isAssigneeTypeValid: boolean specifying whether the assignee type is acceptable (Default: False)
-        :type isAssigneeTypeValid: bool
-        :rtype: Component
+        Args:
+            name (str): name of the component
+            project (str): key of the project to create the component in
+            description (str): a description of the component
+            leadUserName (Optional[str]): the username of the user responsible for this component
+            assigneeType (Optional[str]): see the ComponentBean.AssigneeType class for valid values
+            isAssigneeTypeValid (bool): boolean specifying whether the assignee type is acceptable (Default: False)
+
+        Returns:
+            Component
         """
         data = {
             "name": name,
@@ -930,49 +967,56 @@ class JIRA(object):
         component = Component(self._options, self._session, raw=json_loads(r))
         return component
 
-    def component_count_related_issues(self, id):
+    def component_count_related_issues(self, id: str):
         """Get the count of related issues for a component.
 
-        :type id: integer
-        :param id: ID of the component to use
+        Args:
+            id (str): ID of the component to use
         """
-        return self._get_json("component/" + id + "/relatedIssueCounts")["issueCount"]
+        data: Dict[str, Any] = self._get_json(
+            "component/" + str(id) + "/relatedIssueCounts"
+        )
+        return data["issueCount"]
 
-    def delete_component(self, id):
+    def delete_component(self, id: str) -> Response:
         """Delete component by id.
 
-        :param id: ID of the component to use
-        :type id: str
-        :rtype: Response
+        Args:
+            id (str): ID of the component to use
+
+        Returns:
+            Response
         """
         url = self._get_url("component/" + str(id))
         return self._session.delete(url)
 
     # Custom field options
 
-    def custom_field_option(self, id):
+    def custom_field_option(self, id: str) -> CustomFieldOption:
         """Get a custom field option Resource from the server.
 
-        :param id: ID of the custom field to use
-        :type id: str
-        :rtype: CustomFieldOption
+        Args:
+            id (str): ID of the custom field to use
+
+        Returns:
+            CustomFieldOption
         """
         return self._find_for_resource(CustomFieldOption, id)
 
     # Dashboards
 
-    def dashboards(self, filter=None, startAt=0, maxResults=20):
+    def dashboards(
+        self, filter=None, startAt=0, maxResults=20
+    ) -> ResultList[Dashboard]:
         """Return a ResultList of Dashboard resources and a ``total`` count.
 
-        :param filter: either "favourite" or "my", the type of dashboards to return
-        :type filter: Optional[str]
-        :param startAt: index of the first dashboard to return (Default: 0)
-        :type startAt: int
-        :param maxResults: maximum number of dashboards to return.
-            If maxResults evaluates as False, it will try to get all items in batches. (Default: 20)
-        :type maxResults: int
+        Args:
+            filter (Optional[str]): either "favourite" or "my", the type of dashboards to return
+            startAt (int): index of the first dashboard to return (Default: 0)
+            maxResults (int): maximum number of dashboards to return. If maxResults evaluates as False, it will try to get all items in batches. (Default: 20)
 
-        :rtype: ResultList
+        Returns:
+            ResultList
         """
         params = {}
         if filter is not None:
@@ -981,63 +1025,74 @@ class JIRA(object):
             Dashboard, "dashboards", "dashboard", startAt, maxResults, params
         )
 
-    def dashboard(self, id):
+    def dashboard(self, id: str) -> Dashboard:
         """Get a dashboard Resource from the server.
 
-        :param id: ID of the dashboard to get.
-        :type id: str
-        :rtype: Dashboard
+        Args:
+            id (str): ID of the dashboard to get.
+
+        Returns:
+            Dashboard
         """
         return self._find_for_resource(Dashboard, id)
 
     # Fields
 
     # non-resource
-    def fields(self):
+    def fields(self) -> List[Dict[str, Any]]:
         """Return a list of all issue fields.
 
-        :rtype: List[Dict[str, Any]]
+        Returns:
+            List[Dict[str, Any]]
         """
         return self._get_json("field")
 
     # Filters
 
-    def filter(self, id):
+    def filter(self, id: str) -> Filter:
         """Get a filter Resource from the server.
 
-        :param id: ID of the filter to get.
-        :type id: str
-        :rtype: Filter
+        Args:
+            id (str): ID of the filter to get.
+
+        Returns:
+            Filter
         """
         return self._find_for_resource(Filter, id)
 
-    def favourite_filters(self):
+    def favourite_filters(self) -> List[Filter]:
         """Get a list of filter Resources which are the favourites of the currently authenticated user.
 
-        :rtype: List[Filter]
+        Returns:
+            List[Filter]
         """
-        r_json = self._get_json("filter/favourite")
+        r_json: List[Dict[str, Any]] = self._get_json("filter/favourite")
         filters = [
             Filter(self._options, self._session, raw_filter_json)
             for raw_filter_json in r_json
         ]
         return filters
 
-    def create_filter(self, name=None, description=None, jql=None, favourite=None):
+    def create_filter(
+        self,
+        name: str = None,
+        description: str = None,
+        jql: str = None,
+        favourite: bool = None,
+    ):
         """Create a new filter and return a filter Resource for it.
 
-        :param name: name of the new filter
-        :type name: str
-        :param description: useful human readable description of the new filter
-        :type description: str
-        :param jql: query string that defines the filter
-        :type jql: str
-        :param favourite: whether to add this filter to the current user's favorites
-        :type favourite: bool
-        :rtype: Filter
+        Args:
+            name (str): name of the new filter
+            description (str): useful human readable description of the new filter
+            jql (str): query string that defines the filter
+            favourite (bool): whether to add this filter to the current user's favorites
+
+        Returns:
+            Filter
 
         """
-        data = {}
+        data: Dict[str, Any] = {}
         if name is not None:
             data["name"] = name
         if description is not None:
@@ -1049,22 +1104,24 @@ class JIRA(object):
         url = self._get_url("filter")
         r = self._session.post(url, data=json.dumps(data))
 
-        raw_filter_json = json_loads(r)
+        raw_filter_json: Dict[str, Any] = json_loads(r)
         return Filter(self._options, self._session, raw=raw_filter_json)
 
     def update_filter(
-        self, filter_id, name=None, description=None, jql=None, favourite=None
+        self,
+        filter_id,
+        name: str = None,
+        description: str = None,
+        jql: str = None,
+        favourite: bool = None,
     ):
         """Update a filter and return a filter Resource for it.
 
-        :param name: name of the new filter
-        :type name: Optional[str]
-        :param description: useful human readable description of the new filter
-        :type description: Optional[str]
-        :param jql: query string that defines the filter
-        :type jql: Optional[str]
-        :param favourite: whether to add this filter to the current user's favorites
-        :type favourite: Optional[bool]
+        Args:
+            name (Optional[str]): name of the new filter
+            description (Optional[str]): useful human readable description of the new filter
+            jql (Optional[str]): query string that defines the filter
+            favourite (Optional[bool]): whether to add this filter to the current user's favorites
 
         """
         filter = self.filter(filter_id)
@@ -1084,15 +1141,15 @@ class JIRA(object):
 
     # Groups
 
-    def group(self, id, expand=None):
+    def group(self, id: str, expand: Any = None) -> Group:
         """Get a group Resource from the server.
 
-        :param id: ID of the group to get
-        :param id: str
-        :param expand: Extra information to fetch inside each resource
-        :type expand: Optional[Any]
+        Args:
+            id (str): ID of the group to get
+            expand (Optional[Any]): Extra information to fetch inside each resource
 
-        :rtype: User
+        Returns:
+            Group
         """
         group = Group(self._options, self._session)
         params = {}
@@ -1102,19 +1159,23 @@ class JIRA(object):
         return group
 
     # non-resource
-    def groups(self, query=None, exclude=None, maxResults=9999):
+    def groups(
+        self,
+        query: Optional[str] = None,
+        exclude: Optional[Any] = None,
+        maxResults: int = 9999,
+    ) -> List[str]:
         """Return a list of groups matching the specified criteria.
 
-        :param query: filter groups by name with this string
-        :type query: Optional[str]
-        :param exclude: filter out groups by name with this string
-        :type exclude: Optional[Any]
-        :param maxResults: maximum results to return. (Default: 9999)
-        :type maxResults: int
-        :rtype: List[str]
+        Args:
+            query (Optional[str]): filter groups by name with this string
+            exclude (Optional[Any]): filter out groups by name with this string
+            maxResults (int): maximum results to return. (Default: 9999)
+        Returns:
+            List[str]
 
         """
-        params = {}
+        params: Dict[str, Any] = {}
         groups = []
         if query is not None:
             params["query"] = query
@@ -1126,11 +1187,11 @@ class JIRA(object):
             groups.append(group["name"])
         return sorted(groups)
 
-    def group_members(self, group):
+    def group_members(self, group: str) -> OrderedDict:
         """Return a hash or users with their information. Requires Jira 6.0 or will raise NotImplemented.
 
-        :param group: Name of the group.
-        :type group: str
+        Args:
+            group (str): Name of the group.
         """
         if self._version < (6, 0, 0):
             raise NotImplementedError(
@@ -1163,13 +1224,14 @@ class JIRA(object):
             }
         return OrderedDict(sorted(result.items(), key=lambda t: t[0]))
 
-    def add_group(self, groupname):
+    def add_group(self, groupname: str) -> bool:
         """Create a new group in Jira.
 
-        :param groupname: The name of the group you wish to create.
-        :type groupname: str
-        :return: Boolean - True if successful.
-        :rtype: bool
+        Args:
+            groupname (str): The name of the group you wish to create.
+
+        Returns:
+            bool: True if successful.
         """
         url = self._get_latest_url("group")
 
@@ -1186,13 +1248,14 @@ class JIRA(object):
 
         return True
 
-    def remove_group(self, groupname):
+    def remove_group(self, groupname: str) -> bool:
         """Delete a group from the Jira instance.
 
-        :param groupname: The group to be deleted from the Jira instance.
-        :type groupname: str
-        :return: Boolean. Returns True on success.
-        :rtype: bool
+        Args:
+            groupname (str): The group to be deleted from the Jira instance.
+
+        Returns:
+            bool: Returns True on success.
         """
         # implementation based on
         # https://docs.atlassian.com/jira/REST/ondemand/#d2e5173
@@ -1203,16 +1266,20 @@ class JIRA(object):
 
     # Issues
 
-    def issue(self, id, fields=None, expand=None):
+    def issue(
+        self,
+        id: Union[Issue, str],
+        fields: Optional[str] = None,
+        expand: Optional[str] = None,
+    ) -> Issue:
         """Get an issue Resource from the server.
 
-        :param id: ID or key of the issue to get
-        :type id: Union[Issue, str]
-        :param fields: comma-separated string of issue fields to include in the results
-        :type fields: Optional[str]
-        :param expand: extra information to fetch inside each resource
-        :type expand: Optional[str]
-        :rtype: Issue
+        Args:
+            id (Union[Issue, str]): ID or key of the issue to get
+            fields (Optional[str]): comma-separated string of issue fields to include in the results
+            expand (Optional[str]): extra information to fetch inside each resource
+        Returns:
+            Issue
         """
         # this allows us to pass Issue objects to issue()
         if isinstance(id, Issue):
@@ -1228,7 +1295,12 @@ class JIRA(object):
         issue.find(id, params=params)
         return issue
 
-    def create_issue(self, fields=None, prefetch=True, **fieldargs):
+    def create_issue(
+        self,
+        fields: Optional[Dict[str, Any]] = None,
+        prefetch: bool = True,
+        **fieldargs
+    ) -> Issue:
         """Create a new issue and return an issue Resource for it.
 
         Each keyword argument (other than the predefined ones) is treated as a field name and the argument's value
@@ -1242,26 +1314,26 @@ class JIRA(object):
         fields in a new issue. This information is available through the 'createmeta' method. Further examples are
         available here: https://developer.atlassian.com/display/JIRADEV/JIRA+REST+API+Example+-+Create+Issue
 
-        :param fields: a dict containing field names and the values to use. If present, all other keyword arguments
-            will be ignored
-        :type fields: Optional[Dict[str, Any]]
-        :param prefetch: whether to reload the created issue Resource so that all of its data is present in the value
-            returned from this method
-        :type prefetch: bool
-        :rtype: Issue
+        Args:
+            fields (Optional[Dict[str, Any]]): a dict containing field names and the values to use. If present, all other keyword arguments
+              will be ignored
+            prefetch (bool): whether to reload the created issue Resource so that all of its data is present in the value
+              returned from this method
+        Returns:
+            Issue
         """
-        data = _field_worker(fields, **fieldargs)
+        data: Dict[str, Any] = _field_worker(fields, **fieldargs)
 
         p = data["fields"]["project"]
 
         if isinstance(p, str) or isinstance(p, int):
-            data["fields"]["project"] = {"id": self.project(p).id}
+            data["fields"]["project"] = {"id": self.project(str(p)).id}
 
         p = data["fields"]["issuetype"]
         if isinstance(p, int):
             data["fields"]["issuetype"] = {"id": p}
         if isinstance(p, str) or isinstance(p, int):
-            data["fields"]["issuetype"] = {"id": self.issue_type_by_name(p).id}
+            data["fields"]["issuetype"] = {"id": self.issue_type_by_name(str(p)).id}
 
         url = self._get_url("issue")
         r = self._session.post(url, data=json.dumps(data))
@@ -1276,34 +1348,36 @@ class JIRA(object):
         else:
             return Issue(self._options, self._session, raw=raw_issue_json)
 
-    def create_issues(self, field_list, prefetch=True):
+    def create_issues(
+        self, field_list: List[Dict[str, Any]], prefetch: bool = True
+    ) -> List[Dict[str, Any]]:
         """Bulk create new issues and return an issue Resource for each successfully created issue.
 
         See `create_issue` documentation for field information.
 
-        :param field_list: a list of dicts each containing field names and the values to use. Each dict
-            is an individual issue to create and is subject to its minimum requirements.
-        :type field_list: List[Dict[str, Any]]
-        :param prefetch: whether to reload the created issue Resource for each created issue so that all
-            of its data is present in the value returned from this method.
-        :type prefetch: bool
-        :rtype: List[Dict[str, Any]]
+        Args:
+            field_list (List[Dict[str, Any]]): a list of dicts each containing field names and the values to use. Each dict
+              is an individual issue to create and is subject to its minimum requirements.
+            prefetch (bool): whether to reload the created issue Resource for each created issue so that all
+              of its data is present in the value returned from this method.
+        Returns:
+            List[Dict[str, Any]]
 
         """
-        data = {"issueUpdates": []}
+        data: Dict[str, List] = {"issueUpdates": []}
         for field_dict in field_list:
-            issue_data = _field_worker(field_dict)
+            issue_data: Dict[str, Any] = _field_worker(field_dict)
             p = issue_data["fields"]["project"]
 
             if isinstance(p, str) or isinstance(p, int):
-                issue_data["fields"]["project"] = {"id": self.project(p).id}
+                issue_data["fields"]["project"] = {"id": self.project(str(p)).id}
 
             p = issue_data["fields"]["issuetype"]
             if isinstance(p, int):
                 issue_data["fields"]["issuetype"] = {"id": p}
             if isinstance(p, str) or isinstance(p, int):
                 issue_data["fields"]["issuetype"] = {
-                    "id": self.issue_type_by_name(p).id
+                    "id": self.issue_type_by_name(str(p)).id
                 }
 
             data["issueUpdates"].append(issue_data)
@@ -1314,7 +1388,7 @@ class JIRA(object):
             raw_issue_json = json_loads(r)
         # Catching case where none of the issues has been created. See https://github.com/pycontribs/jira/issues/350
         except JIRAError as je:
-            if je.status_code == 400:
+            if je.status_code == 400 and je.response:
                 raw_issue_json = json.loads(je.response.text)
             else:
                 raise
@@ -1351,7 +1425,8 @@ class JIRA(object):
     def supports_service_desk(self):
         """Returns whether or not the Jira instance supports service desk.
 
-        :rtype: bool
+        Returns:
+            bool
         """
         url = self.server_url + "/rest/servicedeskapi/info"
         headers = {"X-ExperimentalApi": "opt-in"}
@@ -1361,14 +1436,14 @@ class JIRA(object):
         except JIRAError:
             return False
 
-    def create_customer(self, email, displayName):
+    def create_customer(self, email: str, displayName: str) -> Customer:
         """Create a new customer and return an issue Resource for it.
 
-        :param email: Customer Email
-        :type email: str
-        :param displayName: Customer display name
-        :type displayName: str
-        :rtype: Customer
+        Args:
+            email (str): Customer Email
+            displayName (str): Customer display name
+        Returns:
+            Customer
 
         """
         url = self.server_url + "/rest/servicedeskapi/customer"
@@ -1385,10 +1460,11 @@ class JIRA(object):
             raise JIRAError(status_code=r.status_code, request=r)
         return Customer(self._options, self._session, raw=raw_customer_json)
 
-    def service_desks(self):
+    def service_desks(self) -> List[ServiceDesk]:
         """Get a list of ServiceDesk Resources from the server visible to the current authenticated user.
 
-        :rtype: List[ServiceDesk]
+        Returns:
+            List[ServiceDesk]
 
         """
         url = self.server_url + "/rest/servicedeskapi/servicedesk"
@@ -1401,17 +1477,22 @@ class JIRA(object):
         ]
         return projects
 
-    def service_desk(self, id):
+    def service_desk(self, id: str) -> ServiceDesk:
         """Get a Service Desk Resource from the server.
 
-        :param id: ID or key of the Service Desk to get
-        :type id: str
-        :rtype: ServiceDesk
+        Args:
+            id (str): ID or key of the Service Desk to get
+
+        Returns:
+            ServiceDesk
 
         """
         return self._find_for_resource(ServiceDesk, id)
 
-    def create_customer_request(self, fields=None, prefetch=True, **fieldargs):
+    @no_type_check  # FIXME: This function does not do what it wants to with fieldargs
+    def create_customer_request(
+        self, fields: Dict[str, Any] = None, prefetch: bool = True, **fieldargs
+    ) -> Issue:
         """Create a new customer request and return an issue Resource for it.
 
         Each keyword argument (other than the predefined ones) is treated as a field name and the argument's value
@@ -1425,13 +1506,13 @@ class JIRA(object):
         fields in a new issue. This information is available through the 'createmeta' method. Further examples are
         available here: https://developer.atlassian.com/display/JIRADEV/JIRA+REST+API+Example+-+Create+Issue
 
-        :param fields: a dict containing field names and the values to use. If present, all other keyword arguments
-            will be ignored
-        :type fields: Dict[str, Any]
-        :param prefetch: whether to reload the created issue Resource so that all of its data is present in the value
-            returned from this method
-        :type prefetch: bool
-        :rtype: Issue
+        Args:
+            fields (Dict[str, Any]): a dict containing field names and the values to use. If present, all other keyword arguments
+              will be ignored
+            prefetch (bool): whether to reload the created issue Resource so that all of its data is present in the value
+              returned from this method
+        Returns:
+            Issue
         """
         data = fields
 
@@ -1465,36 +1546,33 @@ class JIRA(object):
 
     def createmeta(
         self,
-        projectKeys=None,
-        projectIds=[],
-        issuetypeIds=None,
-        issuetypeNames=None,
-        expand=None,
-    ):
+        projectKeys: Optional[Union[Tuple[str, str], str]] = None,
+        projectIds: Union[List, Tuple[str, str]] = [],
+        issuetypeIds: Optional[List[str]] = None,
+        issuetypeNames: Optional[str] = None,
+        expand: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Get the metadata required to create issues, optionally filtered by projects and issue types.
 
-        :param projectKeys: keys of the projects to filter the results with.
-            Can be a single value or a comma-delimited string. May be combined
-            with projectIds.
-        :type projectKeys: Union[None, Tuple[str, str], str]
-        :param projectIds: IDs of the projects to filter the results with. Can
-            be a single value or a comma-delimited string. May be combined with
-            projectKeys.
-        :type projectIds: Union[List, Tuple[str, str]]
-        :param issuetypeIds: IDs of the issue types to filter the results with.
-            Can be a single value or a comma-delimited string. May be combined
-            with issuetypeNames.
-        :type issuetypeIds: Optional[List[str]]
-        :param issuetypeNames: Names of the issue types to filter the results
-            with. Can be a single value or a comma-delimited string. May be
-            combined with issuetypeIds.
-        :type issuetypeNames: Optional[str]
-        :param expand: extra information to fetch inside each resource.
-        :type expand: Optional[str]
-        :rtype: Dict[str, Any]
+        Args:
+            projectKeys (Optional[Union[Tuple[str, str], str]]): keys of the projects to filter the results with.
+              Can be a single value or a comma-delimited string. May be combined
+              with projectIds.
+            projectIds (Union[List, Tuple[str, str]]): IDs of the projects to filter the results with. Can
+              be a single value or a comma-delimited string. May be combined with
+              projectKeys.
+            issuetypeIds (Optional[List[str]]): IDs of the issue types to filter the results with.
+              Can be a single value or a comma-delimited string. May be combined
+              with issuetypeNames.
+            issuetypeNames (Optional[str]): Names of the issue types to filter the results
+              with. Can be a single value or a comma-delimited string. May be
+              combined with issuetypeIds.
+            expand (Optional[str]): extra information to fetch inside each resource.
+        Returns:
+            Dict[str, Any]
 
         """
-        params = {}
+        params: Dict[str, Any] = {}
         if projectKeys is not None:
             params["projectKeys"] = projectKeys
         if projectIds is not None:
@@ -1509,25 +1587,25 @@ class JIRA(object):
             params["expand"] = expand
         return self._get_json("issue/createmeta", params)
 
-    def _get_user_key(self, user):
+    def _get_user_key(self, user: str) -> str:
         """Internal method for translating an user (str) to an key."""
         try:
             key = self.search_users(user, maxResults=1)[0].key
         except Exception as e:
-            raise JIRAError(e)
+            raise JIRAError(str(e))
         return key
 
     # non-resource
     @translate_resource_args
-    def assign_issue(self, issue, assignee):
+    def assign_issue(self, issue: Union[int, str], assignee: str) -> bool:
         """Assign an issue to a user. None will set it to unassigned. -1 will set it to Automatic.
 
-        :param issue: the issue ID or key to assign
-        :type issue: int or str
-        :param assignee: the user to assign the issue to
-        :type assignee: str
+        Args:
+            issue (Union[int,str]): the issue ID or key to assign
+            assignee (str): the user to assign the issue to
 
-        :rtype: bool
+        Returns:
+            bool
         """
         url = self._get_latest_url("issue/{}/assignee".format(str(issue)))
         payload = {"name": self._get_user_key(assignee)}
@@ -1537,12 +1615,13 @@ class JIRA(object):
         return True
 
     @translate_resource_args
-    def comments(self, issue):
+    def comments(self, issue: str) -> List[Comment]:
         """Get a list of comment Resources.
 
-        :param issue: the issue to get comments from
-        :type issue: str
-        :rtype: List[Comment]
+        Args:
+            issue (str): the issue to get comments from
+        Returns:
+            List[Comment]
         """
         r_json = self._get_json("issue/{}/comment".format(str(issue)))
 
@@ -1553,35 +1632,41 @@ class JIRA(object):
         return comments
 
     @translate_resource_args
-    def comment(self, issue, comment):
+    def comment(self, issue: str, comment: str) -> Comment:
         """Get a comment Resource from the server for the specified ID.
 
-        :param issue: ID or key of the issue to get the comment from
-        :param comment: ID of the comment to get
+        Args:
+            issue (str): ID or key of the issue to get the comment from
+            comment (str): ID of the comment to get
         """
         return self._find_for_resource(Comment, (issue, comment))
 
     @translate_resource_args
-    def add_comment(self, issue, body, visibility=None, is_internal=False):
+    def add_comment(
+        self,
+        issue: str,
+        body: str,
+        visibility: Optional[Dict[str, str]] = None,
+        is_internal: bool = False,
+    ) -> Comment:
         """Add a comment from the current authenticated user on the specified issue and return a Resource for it.
 
         The issue identifier and comment body are required.
 
-        :param issue: ID or key of the issue to add the comment to
-        :type issue: str
-        :param body: Text of the comment to add
-        :type body: str
-        :param visibility: a dict containing two entries: "type" and "value".
-            "type" is 'role' (or 'group' if the Jira server has configured
-            comment visibility for groups) and 'value' is the name of the role
-            (or group) to which viewing of this comment will be restricted.
-        :type visibility: Optional[Dict[str, str]]
-        :param is_internal: Defines whether a comment has to be marked as 'Internal' in Jira Service Desk (Default: False)
-        :type is_internal: bool
-        :rtype: Comment
+        Args:
+            issue (str): ID or key of the issue to add the comment to
+            body (str): Text of the comment to add
+            visibility (Optional[Dict[str, str]]): a dict containing two entries: "type" and "value".
+              "type" is 'role' (or 'group' if the Jira server has configured
+              comment visibility for groups) and 'value' is the name of the role
+              (or group) to which viewing of this comment will be restricted.
+            is_internal (bool): Defines whether a comment has to be marked as 'Internal' in Jira Service Desk (Default: False)
+
+        Returns:
+            Comment: the created comment
 
         """
-        data = {"body": body}
+        data: Dict[str, Any] = {"body": body}
 
         if is_internal:
             data.update(
@@ -1603,20 +1688,24 @@ class JIRA(object):
 
     # non-resource
     @translate_resource_args
-    def editmeta(self, issue):
+    def editmeta(self, issue: Union[str, int]):
         """Get the edit metadata for an issue.
 
-        :param issue: the issue to get metadata for
-        :rtype: Dict[str, Dict[str, Dict[str, Any]]]
+        Args:
+            issue (str): the issue to get metadata for
+
+        Returns:
+            Dict[str, Dict[str, Dict[str, Any]]]
 
         """
         return self._get_json("issue/" + str(issue) + "/editmeta")
 
     @translate_resource_args
-    def remote_links(self, issue):
+    def remote_links(self, issue: Union[str, int]) -> List[RemoteLink]:
         """Get a list of remote link Resources from an issue.
 
-        :param issue: the issue to get remote links from
+        Args:
+            issue (str): the issue to get remote links from
         """
         r_json = self._get_json("issue/" + str(issue) + "/remotelink")
         remote_links = [
@@ -1626,19 +1715,25 @@ class JIRA(object):
         return remote_links
 
     @translate_resource_args
-    def remote_link(self, issue, id):
+    def remote_link(self, issue: str, id: str) -> RemoteLink:
         """Get a remote link Resource from the server.
 
-        :param issue: the issue holding the remote link
-        :param id: ID of the remote link
+        Args:
+            issue (str): the issue holding the remote link
+            id (str): ID of the remote link
         """
         return self._find_for_resource(RemoteLink, (issue, id))
 
     # removed the @translate_resource_args because it prevents us from finding
     # information for building a proper link
     def add_remote_link(
-        self, issue, destination, globalId=None, application=None, relationship=None
-    ):
+        self,
+        issue: str,
+        destination: Union[Issue, Dict[str, Any]],
+        globalId: Optional[str] = None,
+        application: Optional[Dict[str, Any]] = None,
+        relationship: Optional[str] = None,
+    ) -> RemoteLink:
         """Add a remote link from an issue to an external application and returns a remote link Resource for it.
 
         ``destination`` should be a dict containing at least ``url`` to the linked external URL and
@@ -1647,14 +1742,18 @@ class JIRA(object):
         For definitions of the allowable fields for ``object`` and the keyword arguments ``globalId``, ``application``
         and ``relationship``, see https://developer.atlassian.com/display/JIRADEV/JIRA+REST+API+for+Remote+Issue+Links.
 
-        :param issue: the issue to add the remote link to
-        :param destination: the link details to add (see the above link for details)
-        :param globalId: unique ID for the link (see the above link for details)
-        :param application: application information for the link (see the above link for details)
-        :param relationship: relationship description for the link (see the above link for details)
+        Args:
+            issue (str): the issue to add the remote link to
+            destination (Union[Issue, Dict[str, Any]]): the link details to add (see the above link for details)
+            globalId (Optional[str]): unique ID for the link (see the above link for details)
+            application (Optional[Dict[str,Any]]): application information for the link (see the above link for details)
+            relationship (Optional[str]): relationship description for the link (see the above link for details)
+
+        Returns:
+            RemoteLink: the added remote lint
         """
         try:
-            applicationlinks = self.applicationlinks()
+            applicationlinks: List[Dict] = self.applicationlinks()
         except JIRAError as e:
             applicationlinks = []
             # In many (if not most) configurations, non-admin users are
@@ -1667,11 +1766,9 @@ class JIRA(object):
                 Warning,
             )
 
-        data = {}
-        if isinstance(destination, Issue):
-
+        data: Dict[str, Any] = {}
+        if isinstance(destination, Issue) and destination.raw:
             data["object"] = {"title": str(destination), "url": destination.permalink()}
-
             for x in applicationlinks:
                 if x["application"]["displayUrl"] == destination._options["server"]:
                     data["globalId"] = "appId=%s&issueId=%s" % (
@@ -1697,17 +1794,18 @@ class JIRA(object):
             data["relationship"] = relationship
 
         # check if the link comes from one of the configured application links
-        for x in applicationlinks:
-            if x["application"]["displayUrl"] == self.server_url:
-                data["globalId"] = "appId=%s&issueId=%s" % (
-                    x["application"]["id"],
-                    destination.raw["id"],
-                )
-                data["application"] = {
-                    "name": x["application"]["name"],
-                    "type": "com.atlassian.jira",
-                }
-                break
+        if isinstance(destination, Issue) and destination.raw:
+            for x in applicationlinks:
+                if x["application"]["displayUrl"] == self.server_url:
+                    data["globalId"] = "appId=%s&issueId=%s" % (
+                        x["application"]["id"],
+                        destination.raw["id"],  # .raw only present on Issue
+                    )
+                    data["application"] = {
+                        "name": x["application"]["name"],
+                        "type": "com.atlassian.jira",
+                    }
+                    break
 
         url = self._get_url("issue/" + str(issue) + "/remotelink")
         r = self._session.post(url, data=json.dumps(data))
@@ -1715,20 +1813,24 @@ class JIRA(object):
         remote_link = RemoteLink(self._options, self._session, raw=json_loads(r))
         return remote_link
 
-    def add_simple_link(self, issue, object):
+    def add_simple_link(self, issue: str, object: Dict[str, Any]):
         """Add a simple remote link from an issue to web resource.
 
         This avoids the admin access problems from add_remote_link by just
-            using a simple object and presuming all fields are correct and not
-            requiring more complex ``application`` data.
+        using a simple object and presuming all fields are correct and not
+        requiring more complex ``application`` data.
 
         ``object`` should be a dict containing at least ``url`` to the
-            linked external URL and ``title`` to display for the link inside Jira.
+        linked external URL and ``title`` to display for the link inside Jira.
 
         For definitions of the allowable fields for ``object`` , see https://developer.atlassian.com/display/JIRADEV/JIRA+REST+API+for+Remote+Issue+Links.
 
-        :param issue: the issue to add the remote link to
-        :param object: the dictionary used to create remotelink data
+        Args:
+            issue (str): the issue to add the remote link to
+            object (Dict[str,Any]): the dictionary used to create remotelink data
+
+        Returns:
+            RemoteLint
         """
         data = {"object": object}
         url = self._get_url("issue/" + str(issue) + "/remotelink")
@@ -1739,12 +1841,16 @@ class JIRA(object):
 
     # non-resource
     @translate_resource_args
-    def transitions(self, issue, id=None, expand=None):
+    def transitions(self, issue: str, id: Optional[str] = None, expand=None):
         """Get a list of the transitions available on the specified issue to the current user.
 
-        :param issue: ID or key of the issue to get the transitions from
-        :param id: if present, get only the transition matching this ID
-        :param expand: extra information to fetch inside each transition
+        Args:
+            issue (str): ID or key of the issue to get the transitions from
+            id (Optional[str]): if present, get only the transition matching this ID
+            expand (Optional): extra information to fetch inside each transition
+
+        Returns:
+            Any: json of response
         """
         params = {}
         if id is not None:
@@ -1755,16 +1861,19 @@ class JIRA(object):
             "transitions"
         ]
 
-    def find_transitionid_by_name(self, issue, transition_name):
+    def find_transitionid_by_name(
+        self, issue: str, transition_name: str
+    ) -> Optional[int]:
         """Get a transitionid available on the specified issue to the current user.
 
         Look at https://developer.atlassian.com/static/rest/jira/6.1.html#d2e1074 for json reference
 
-        :param issue: ID or key of the issue to get the transitions from
-        :param trans_name: iname of transition we are looking for
+        Args:
+            issue (str): ID or key of the issue to get the transitions from
+            trans_name (str): iname of transition we are looking for
         """
         transitions_json = self.transitions(issue)
-        id = None
+        id: Optional[int] = None
 
         for transition in transitions_json:
             if transition["name"].lower() == transition_name.lower():
@@ -1774,7 +1883,13 @@ class JIRA(object):
 
     @translate_resource_args
     def transition_issue(
-        self, issue, transition, fields=None, comment=None, worklog=None, **fieldargs
+        self,
+        issue: str,
+        transition: str,
+        fields: Optional[Dict[str, Any]] = None,
+        comment: Optional[str] = None,
+        worklog: Optional[str] = None,
+        **fieldargs
     ):
         """Perform a transition on an issue.
 
@@ -1782,14 +1897,15 @@ class JIRA(object):
         is treated as the intended value for that field -- if the fields argument is used, all other keyword arguments
         will be ignored. Field values will be set on the issue as part of the transition process.
 
-        :param issue: ID or key of the issue to perform the transition on
-        :param transition: ID or name of the transition to perform
-        :param comment: *Optional* String to add as comment to the issue when
-            performing the transition.
-        :param fields: a dict containing field names and the values to use.
-            If present, all other keyword arguments will be ignored
+        Args:
+            issue (str): ID or key of the issue to perform the transition on
+            transition (str): ID or name of the transition to perform
+            fields (Optional[Dict[str,Any]]): a dict containing field names and the values to use.
+            comment (Optional[str]): String to add as comment to the issue when performing the transition.
+            workload (Optional[str]): String to add as time spent on the issue when performing the transition.
+            **fieldargs: If present, all other keyword arguments will be ignored
         """
-        transitionId = None
+        transitionId: Optional[int] = None
 
         try:
             transitionId = int(transition)
@@ -1799,7 +1915,7 @@ class JIRA(object):
             if transitionId is None:
                 raise JIRAError("Invalid transition name. %s" % transition)
 
-        data = {"transition": {"id": transitionId}}
+        data: Dict[str, Any] = {"transition": {"id": transitionId}}
         if comment:
             data["update"] = {"comment": [{"add": {"body": comment}}]}
         if worklog:
@@ -1822,59 +1938,71 @@ class JIRA(object):
         return r_json
 
     @translate_resource_args
-    def votes(self, issue):
+    def votes(self, issue: str) -> Votes:
         """Get a votes Resource from the server.
 
-        :param issue: ID or key of the issue to get the votes for
-        :rtype: Votes
+        Args:
+            issue (str): ID or key of the issue to get the votes for
+        Returns:
+            Votes
         """
         return self._find_for_resource(Votes, issue)
 
     @translate_resource_args
-    def add_vote(self, issue):
+    def add_vote(self, issue: str) -> Response:
         """Register a vote for the current authenticated user on an issue.
 
-        :param issue: ID or key of the issue to vote on
-        :rtype: Response
+        Args:
+            issue (str): ID or key of the issue to vote on
+
+        Returns:
+            Response
         """
         url = self._get_url("issue/" + str(issue) + "/votes")
         return self._session.post(url)
 
     @translate_resource_args
-    def remove_vote(self, issue):
+    def remove_vote(self, issue: str):
         """Remove the current authenticated user's vote from an issue.
 
-        :param issue: ID or key of the issue to remove vote on
+        Args:
+            issue (str): ID or key of the issue to remove vote on
         """
         url = self._get_url("issue/" + str(issue) + "/votes")
         self._session.delete(url)
 
     @translate_resource_args
-    def watchers(self, issue):
+    def watchers(self, issue: str) -> Watchers:
         """Get a watchers Resource from the server for an issue.
 
-        :param issue: ID or key of the issue to get the watchers for
-        :rtype: Watchers
+        Args:
+            issue (str): ID or key of the issue to get the watchers for
+        Returns:
+            Watchers
         """
         return self._find_for_resource(Watchers, issue)
 
     @translate_resource_args
-    def add_watcher(self, issue, watcher):
+    def add_watcher(self, issue: str, watcher: str) -> Response:
         """Add a user to an issue's watchers list.
 
-        :param issue: ID or key of the issue affected
-        :param watcher: key of the user to add to the watchers list
+        Args:
+            issue (str): ID or key of the issue affected
+            watcher (str): key of the user to add to the watchers list
         """
         url = self._get_url("issue/" + str(issue) + "/watchers")
-        self._session.post(url, data=json.dumps(watcher))
+        return self._session.post(url, data=json.dumps(watcher))
 
     @translate_resource_args
-    def remove_watcher(self, issue, watcher):
+    def remove_watcher(self, issue: str, watcher: str) -> Response:
         """Remove a user from an issue's watch list.
 
-        :param issue: ID or key of the issue affected
-        :param watcher: key of the user to remove from the watchers list
-        :rtype: Response
+        Args:
+            issue (str): ID or key of the issue affected
+            watcher (str): key of the user to remove from the watchers list
+
+        Returns:
+            Response
         """
         url = self._get_url("issue/" + str(issue) + "/watchers")
         # https://docs.atlassian.com/software/jira/docs/api/REST/8.13.6/#api/2/issue-removeWatcher
@@ -1883,11 +2011,13 @@ class JIRA(object):
         return result
 
     @translate_resource_args
-    def worklogs(self, issue):
+    def worklogs(self, issue: str) -> List[Worklog]:
         """Get a list of worklog Resources from the server for an issue.
 
-        :param issue: ID or key of the issue to get worklogs from
-        :rtype: List[Worklog]
+        Args:
+            issue (str): ID or key of the issue to get worklogs from
+        Returns:
+            List[Worklog]
         """
         r_json = self._get_json("issue/" + str(issue) + "/worklog")
         worklogs = [
@@ -1897,12 +2027,14 @@ class JIRA(object):
         return worklogs
 
     @translate_resource_args
-    def worklog(self, issue, id):
+    def worklog(self, issue: str, id: str) -> Worklog:
         """Get a specific worklog Resource from the server.
 
-        :param issue: ID or key of the issue to get the worklog from
-        :param id: ID of the worklog to get
-        :rtype: Worklog
+        Args:
+            issue (str): ID or key of the issue to get the worklog from
+            id (str): ID of the worklog to get
+        Returns:
+            Worklog
         """
         return self._find_for_resource(Worklog, (issue, id))
 
@@ -1910,26 +2042,30 @@ class JIRA(object):
     def add_worklog(
         self,
         issue,
-        timeSpent=None,
-        timeSpentSeconds=None,
-        adjustEstimate=None,
-        newEstimate=None,
-        reduceBy=None,
-        comment=None,
-        started=None,
-        user=None,
-    ):
+        timeSpent: (Optional[str]) = None,
+        timeSpentSeconds: (Optional[str]) = None,
+        adjustEstimate: (Optional[str]) = None,
+        newEstimate: (Optional[str]) = None,
+        reduceBy: (Optional[str]) = None,
+        comment: (Optional[str]) = None,
+        started: (Optional[datetime.datetime]) = None,
+        user: (Optional[str]) = None,
+    ) -> Worklog:
         """Add a new worklog entry on an issue and return a Resource for it.
 
-        :param issue: the issue to add the worklog to
-        :param timeSpent: a worklog entry with this amount of time spent, e.g. "2d"
-        :param adjustEstimate: (optional) allows the user to provide specific instructions to update the remaining
-            time estimate of the issue. The value can either be ``new``, ``leave``, ``manual`` or ``auto`` (default).
-        :param newEstimate: the new value for the remaining estimate field. e.g. "2d"
-        :param reduceBy: the amount to reduce the remaining estimate by e.g. "2d"
-        :param started: Moment when the work is logged, if not specified will default to now
-        :param comment: optional worklog comment
-        :rtype: Worklog
+        Args:
+            issue (str): the issue to add the worklog to
+            timeSpent (Optional[str]): a worklog entry with this amount of time spent, e.g. "2d"
+            timeSpentSeconds (Optional[str]): a worklog entry with this amount of time spent in seconds
+            adjustEstimate (Optional[str]):  allows the user to provide specific instructions to update
+              the remaining time estimate of the issue. The value can either be ``new``, ``leave``, ``manual`` or ``auto`` (default).
+            newEstimate (Optional[str]): the new value for the remaining estimate field. e.g. "2d"
+            reduceBy (Optional[str]): the amount to reduce the remaining estimate by e.g. "2d"
+            comment (Optional[str]): optional worklog comment
+            started (Optional[datetime.datetime]): Moment when the work is logged, if not specified will default to now
+            user (Optional[str]): the user ID or name to use for this worklog
+        Returns:
+            Worklog
         """
         params = {}
         if adjustEstimate is not None:
@@ -1939,7 +2075,7 @@ class JIRA(object):
         if reduceBy is not None:
             params["reduceBy"] = reduceBy
 
-        data = {}
+        data: Dict[str, Any] = {}
         if timeSpent is not None:
             data["timeSpent"] = timeSpent
         if timeSpentSeconds is not None:
@@ -1974,21 +2110,29 @@ class JIRA(object):
     # Issue links
 
     @translate_resource_args
-    def create_issue_link(self, type, inwardIssue, outwardIssue, comment=None):
+    def create_issue_link(
+        self,
+        type: Union[str, IssueLinkType],
+        inwardIssue: str,
+        outwardIssue: str,
+        comment: Optional[Dict[str, Any]] = None,
+    ) -> Response:
         """Create a link between two issues.
 
-        :param type: the type of link to create
-        :param inwardIssue: the issue to link from
-        :param outwardIssue: the issue to link to
-        :param comment:  a comment to add to the issues with the link. Should be
-            a dict containing ``body`` and ``visibility`` fields: ``body`` being
-            the text of the comment and ``visibility`` being a dict containing
-            two entries: ``type`` and ``value``. ``type`` is ``role`` (or
-            ``group`` if the Jira server has configured comment visibility for
-            groups) and ``value`` is the name of the role (or group) to which
-            viewing of this comment will be restricted.
-        :type comment: Optional[Dict[str, Any]]
-        :rtype: Response
+        Args:
+            type (Union[str,IssueLinkType]): the type of link to create
+            inwardIssue: the issue to link from
+            outwardIssue: the issue to link to
+            comment (Optional[Dict[str, Any]]):  a comment to add to the issues with the link.
+              Should be a dict containing ``body`` and ``visibility`` fields: ``body`` being
+              the text of the comment and ``visibility`` being a dict containing
+              two entries: ``type`` and ``value``. ``type`` is ``role`` (or
+              ``group`` if the Jira server has configured comment visibility for
+              groups) and ``value`` is the name of the role (or group) to which
+              viewing of this comment will be restricted.
+
+        Returns:
+            Response
         """
         # let's see if we have the right issue link 'type' and fix it if needed
         issue_link_types = self.issue_link_types()
@@ -2014,27 +2158,30 @@ class JIRA(object):
         url = self._get_url("issueLink")
         return self._session.post(url, data=json.dumps(data))
 
-    def delete_issue_link(self, id):
+    def delete_issue_link(self, id: str):
         """Delete a link between two issues.
 
-        :param id: ID of the issue link to delete
+        Args:
+            id (str): ID of the issue link to delete
         """
         url = self._get_url("issueLink") + "/" + id
         return self._session.delete(url)
 
-    def issue_link(self, id):
+    def issue_link(self, id: str):
         """Get an issue link Resource from the server.
 
-        :param id: ID of the issue link to get
+        Args:
+            id (str): ID of the issue link to get
         """
         return self._find_for_resource(IssueLink, id)
 
     # Issue link types
 
-    def issue_link_types(self, force=False):
+    def issue_link_types(self, force: bool = False) -> List[IssueLinkType]:
         """Get a list of issue link type Resources from the server.
 
-        :rtype: List[IssueLinkType]
+        Returns:
+            List[IssueLinkType]
         """
         if not hasattr(self, "self._cached_issue_link_types") or force:
             r_json = self._get_json("issueLinkType")
@@ -2044,22 +2191,25 @@ class JIRA(object):
             ]
         return self._cached_issue_link_types
 
-    def issue_link_type(self, id):
+    def issue_link_type(self, id: str) -> IssueLinkType:
         """Get an issue link type Resource from the server.
 
-        :param id: ID of the issue link type to get
-        :type id: str
-        :rtype: IssueLinkType
+        Args:
+            id (str): ID of the issue link type to get
+
+        Returns:
+            IssueLinkType
 
         """
         return self._find_for_resource(IssueLinkType, id)
 
     # Issue types
 
-    def issue_types(self):
+    def issue_types(self) -> List[IssueType]:
         """Get a list of issue type Resources from the server.
 
-        :rtype: List[IssueType]
+        Returns:
+            List[IssueType]
 
         """
         r_json = self._get_json("issuetype")
@@ -2069,19 +2219,24 @@ class JIRA(object):
         ]
         return issue_types
 
-    def issue_type(self, id):
+    def issue_type(self, id: str) -> IssueType:
         """Get an issue type Resource from the server.
 
-        :param id: ID of the issue type to get
-        :rtype: IssueType
+        Args:
+            id (str): ID of the issue type to get
+
+        Returns:
+            IssueType
         """
         return self._find_for_resource(IssueType, id)
 
-    def issue_type_by_name(self, name):
+    def issue_type_by_name(self, name: str) -> IssueType:
         """
-        :param name: Name of the issue type
-        :type name: str
-        :rtype: IssueType
+        Args:
+            name (str): Name of the issue type
+
+        Returns:
+            IssueType
         """
         issue_types = self.issue_types()
         try:
@@ -2090,11 +2245,14 @@ class JIRA(object):
             raise KeyError("Issue type '%s' is unknown." % name)
         return issue_type
 
-    def request_types(self, service_desk):
+    def request_types(self, service_desk: ServiceDesk) -> List[RequestType]:
         """Returns request types supported by a service desk instance.
-        :param service_desk: The service desk instance.
-        :type service_desk: ServiceDesk
-        :rtype: List[RequestType]
+
+        Args:
+            service_desk (ServiceDesk): The service desk instance.
+
+        Returns:
+            List[RequestType]
         """
         if hasattr(service_desk, "id"):
             service_desk = service_desk.id
@@ -2110,7 +2268,7 @@ class JIRA(object):
         ]
         return request_types
 
-    def request_type_by_name(self, service_desk, name):
+    def request_type_by_name(self, service_desk: ServiceDesk, name: str):
         request_types = self.request_types(service_desk)
         try:
             request_type = [rt for rt in request_types if rt.name == name][0]
@@ -2122,19 +2280,22 @@ class JIRA(object):
 
     # non-resource
     def my_permissions(
-        self, projectKey=None, projectId=None, issueKey=None, issueId=None
-    ):
+        self,
+        projectKey: Optional[str] = None,
+        projectId: Optional[str] = None,
+        issueKey: Optional[str] = None,
+        issueId: Optional[str] = None,
+    ) -> Dict[str, Dict[str, Dict[str, str]]]:
         """Get a dict of all available permissions on the server.
 
-        :param projectKey: limit returned permissions to the specified project
-        :type projectKey: Optional[str]
-        :param projectId: limit returned permissions to the specified project
-        :type projectId: Optional[str]
-        :param issueKey: limit returned permissions to the specified issue
-        :type issueKey: Optional[str]
-        :param issueId: limit returned permissions to the specified issue
-        :type issueId: Optional[str]
-        :rtype: Dict[str, Dict[str, Dict[str, str]]]
+        Args:
+            projectKey (Optional[str]): limit returned permissions to the specified project
+            projectId (Optional[str]): limit returned permissions to the specified project
+            issueKey (Optional[str]): limit returned permissions to the specified issue
+            issueId (Optional[str]): limit returned permissions to the specified issue
+
+        Returns:
+            Dict[str, Dict[str, Dict[str, str]]]
         """
         params = {}
         if projectKey is not None:
@@ -2152,7 +2313,8 @@ class JIRA(object):
     def priorities(self):
         """Get a list of priority Resources from the server.
 
-        :rtype: List[Priority]
+        Returns:
+            List[Priority]
 
         """
         r_json = self._get_json("priority")
@@ -2162,22 +2324,25 @@ class JIRA(object):
         ]
         return priorities
 
-    def priority(self, id):
+    def priority(self, id: str) -> Priority:
         """Get a priority Resource from the server.
 
-        :param id: ID of the priority to get
-        :type id: str
-        :rtype: Priority
+        Args:
+            id (str): ID of the priority to get
+
+        Returns:
+            Priority
 
         """
         return self._find_for_resource(Priority, id)
 
     # Projects
 
-    def projects(self):
+    def projects(self) -> List[Project]:
         """Get a list of project Resources from the server visible to the current authenticated user.
 
-        :rtype: List[Project]
+        Returns:
+            List[Project]
 
         """
         r_json = self._get_json("project")
@@ -2187,52 +2352,61 @@ class JIRA(object):
         ]
         return projects
 
-    def project(self, id):
+    def project(self, id: str) -> Project:
         """Get a project Resource from the server.
 
-        :param id: ID or key of the project to get
-        :rtype: Project
+        Args:
+            id (str): ID or key of the project to get
+
+        Returns:
+            Project
         """
         return self._find_for_resource(Project, id)
 
     # non-resource
     @translate_resource_args
-    def project_avatars(self, project):
+    def project_avatars(self, project: str):
         """Get a dict of all avatars for a project visible to the current authenticated user.
 
-        :param project: ID or key of the project to get avatars for
+        Args:
+            project (str): ID or key of the project to get avatars for
         """
         return self._get_json("project/" + project + "/avatars")
 
     @translate_resource_args
     def create_temp_project_avatar(
-        self, project, filename, size, avatar_img, contentType=None, auto_confirm=False
+        self,
+        project: str,
+        filename: str,
+        size: int,
+        avatar_img: bytes,
+        contentType: str = None,
+        auto_confirm: bool = False,
     ):
         """Register an image file as a project avatar.
 
-        The avatar created is temporary and must be confirmed before it can
-            be used.
+        The avatar created is temporary and must be confirmed before it can be used.
 
         Avatar images are specified by a filename, size, and file object. By default, the client will attempt to
-            autodetect the picture's content type: this mechanism relies on libmagic and will not work out of the box
-            on Windows systems (see https://filemagic.readthedocs.io/en/latest/guide.html for details on how to install
-            support). The ``contentType`` argument can be used to explicitly set the value (note that Jira will reject any
-            type other than the well-known ones for images, e.g. ``image/jpg``, ``image/png``, etc.)
+        autodetect the picture's content type: this mechanism relies on libmagic and will not work out of the box
+        on Windows systems (see https://filemagic.readthedocs.io/en/latest/guide.html for details on how to install
+        support). The ``contentType`` argument can be used to explicitly set the value (note that Jira will reject any
+        type other than the well-known ones for images, e.g. ``image/jpg``, ``image/png``, etc.)
 
         This method returns a dict of properties that can be used to crop a subarea of a larger image for use. This
-            dict should be saved and passed to :py:meth:`confirm_project_avatar` to finish the avatar creation process. If
-            you want to cut out the middleman and confirm the avatar with Jira's default cropping, pass the 'auto_confirm'
-            argument with a truthy value and :py:meth:`confirm_project_avatar` will be called for you before this method
-            returns.
+        dict should be saved and passed to :py:meth:`confirm_project_avatar` to finish the avatar creation process. If
+        you want to cut out the middleman and confirm the avatar with Jira's default cropping, pass the 'auto_confirm'
+        argument with a truthy value and :py:meth:`confirm_project_avatar` will be called for you before this method
+        returns.
 
-        :param project: ID or key of the project to create the avatar in
-        :param filename: name of the avatar file
-        :param size: size of the avatar file
-        :param avatar_img: file-like object holding the avatar
-        :param contentType: explicit specification for the avatar image's content-type
-        :param auto_confirm: whether to automatically confirm the temporary avatar by calling
-            :py:meth:`confirm_project_avatar` with the return value of this method. (Default: False)
-        :type auto_confirm: bool
+        Args:
+            project (str): ID or key of the project to create the avatar in
+            filename (str): name of the avatar file
+            size (int): size of the avatar file
+            avatar_img (bytes): file-like object holding the avatar
+            contentType (str): explicit specification for the avatar image's content-type
+            auto_confirm (bool): whether to automatically confirm the temporary avatar by calling
+              :py:meth:`confirm_project_avatar` with the return value of this method. (Default: False)
         """
         size_from_file = os.path.getsize(filename)
         if size != size_from_file:
@@ -2240,7 +2414,7 @@ class JIRA(object):
 
         params = {"filename": filename, "size": size}
 
-        headers = {"X-Atlassian-Token": "no-check"}
+        headers: Dict[str, Any] = {"X-Atlassian-Token": "no-check"}
         if contentType is not None:
             headers["content-type"] = contentType
         else:
@@ -2250,14 +2424,14 @@ class JIRA(object):
         url = self._get_url("project/" + project + "/avatar/temporary")
         r = self._session.post(url, params=params, headers=headers, data=avatar_img)
 
-        cropping_properties = json_loads(r)
+        cropping_properties: Dict[str, Any] = json_loads(r)
         if auto_confirm:
             return self.confirm_project_avatar(project, cropping_properties)
         else:
             return cropping_properties
 
     @translate_resource_args
-    def confirm_project_avatar(self, project, cropping_properties):
+    def confirm_project_avatar(self, project: str, cropping_properties: Dict[str, Any]):
         """Confirm the temporary avatar image previously uploaded with the specified cropping.
 
         After a successful registry with :py:meth:`create_temp_project_avatar`, use this method to confirm the avatar
@@ -2265,8 +2439,9 @@ class JIRA(object):
         ``cropping_properties``: the return value of :py:meth:`create_temp_project_avatar` should be used for this
         argument.
 
-        :param project: ID or key of the project to confirm the avatar in
-        :param cropping_properties: a dict of cropping properties from :py:meth:`create_temp_project_avatar`
+        Args:
+            project (str): ID or key of the project to confirm the avatar in
+            cropping_properties (Dict[str,Any]): a dict of cropping properties from :py:meth:`create_temp_project_avatar`
         """
         data = cropping_properties
         url = self._get_url("project/" + project + "/avatar")
@@ -2275,31 +2450,35 @@ class JIRA(object):
         return json_loads(r)
 
     @translate_resource_args
-    def set_project_avatar(self, project, avatar):
+    def set_project_avatar(self, project: str, avatar: str):
         """Set a project's avatar.
 
-        :param project: ID or key of the project to set the avatar on
-        :param avatar: ID of the avatar to set
+        Args:
+            project (str): ID or key of the project to set the avatar on
+            avatar (str): ID of the avatar to set
         """
         self._set_avatar(None, self._get_url("project/" + project + "/avatar"), avatar)
 
     @translate_resource_args
-    def delete_project_avatar(self, project, avatar):
+    def delete_project_avatar(self, project: str, avatar: str) -> Response:
         """Delete a project's avatar.
 
-        :param project: ID or key of the project to delete the avatar from
-        :param avatar: ID of the avatar to delete
+        Args:
+            project (str): ID or key of the project to delete the avatar from
+            avatar (str): ID of the avatar to delete
         """
         url = self._get_url("project/" + project + "/avatar/" + avatar)
         return self._session.delete(url)
 
     @translate_resource_args
-    def project_components(self, project):
+    def project_components(self, project: str) -> List[Component]:
         """Get a list of component Resources present on a project.
 
-        :param project: ID or key of the project to get components from
-        :type project: str
-        :rtype: List[Component]
+        Args:
+            project (str): ID or key of the project to get components from
+
+        Returns:
+            List[Component]
         """
         r_json = self._get_json("project/" + project + "/components")
         components = [
@@ -2309,12 +2488,14 @@ class JIRA(object):
         return components
 
     @translate_resource_args
-    def project_versions(self, project):
+    def project_versions(self, project: str) -> List[Version]:
         """Get a list of version Resources present on a project.
 
-        :param project: ID or key of the project to get versions from
-        :type project: str
-        :rtype: List[Version]
+        Args:
+            project (str): ID or key of the project to get versions from
+
+        Returns:
+            List[Version]
         """
         r_json = self._get_json("project/" + project + "/versions")
         versions = [
@@ -2324,31 +2505,35 @@ class JIRA(object):
         return versions
 
     @translate_resource_args
-    def get_project_version_by_name(self, project, version_name):
+    def get_project_version_by_name(
+        self, project: str, version_name: str
+    ) -> Optional[Version]:
         """Get a version Resource by its name present on a project.
 
-        :param project: ID or key of the project to get versions from
-        :type project: str
-        :param version_name: name of the version to search for
-        :type version_name: str
-        :rtype: Optional[Version]
+        Args:
+            project (str): ID or key of the project to get versions from
+            version_name (str): name of the version to search for
+
+        Returns:
+            Optional[Version]
         """
-        versions = self.project_versions(project)
+        versions: List[Version] = self.project_versions(project)
         for version in versions:
             if version.name == version_name:
                 return version
+        return None
 
     @translate_resource_args
-    def rename_version(self, project, old_name, new_name):
+    def rename_version(self, project: str, old_name: str, new_name: str) -> None:
         """Rename a version Resource on a project.
 
-        :param project: ID or key of the project to get versions from
-        :type project: str
-        :param old_name: old name of the version to rename
-        :type old_name: str
-        :param new_name: new name of the version to rename
-        :type new_name: str
-        :rtype: None
+        Args:
+            project (str): ID or key of the project to get versions from
+            old_name (str): old name of the version to rename
+            new_name (str): new name of the version to rename
+
+        Returns:
+            None
         """
         version = self.get_project_version_by_name(project, old_name)
         if version:
@@ -2356,17 +2541,18 @@ class JIRA(object):
 
     # non-resource
     @translate_resource_args
-    def project_roles(self, project):
+    def project_roles(self, project: str) -> Dict[str, Dict[str, str]]:
         """Get a dict of role names to resource locations for a project.
 
-        :param project: ID or key of the project to get roles from
+        Args:
+            project (str): ID or key of the project to get roles from
         """
         path = "project/" + project + "/role"
-        _rolesdict = self._get_json(path)
-        rolesdict = {}
+        _rolesdict: Dict[str, str] = self._get_json(path)
+        rolesdict: Dict[str, Dict[str, str]] = {}
 
         for k, v in _rolesdict.items():
-            tmp = {}
+            tmp: Dict[str, str] = {}
             tmp["id"] = v.split("/")[-1]
             tmp["url"] = v
             rolesdict[k] = tmp
@@ -2374,11 +2560,12 @@ class JIRA(object):
         # TODO(ssbarnea): return a list of Roles()
 
     @translate_resource_args
-    def project_role(self, project, id):
+    def project_role(self, project: str, id: str) -> Role:
         """Get a role Resource.
 
-        :param project: ID or key of the project to get the role from
-        :param id: ID of the role to get
+        Args:
+            project (str): ID or key of the project to get the role from
+            id (str): ID of the role to get
         """
         if isinstance(id, Number):
             id = "%s" % id
@@ -2386,10 +2573,11 @@ class JIRA(object):
 
     # Resolutions
 
-    def resolutions(self):
+    def resolutions(self) -> List[Resolution]:
         """Get a list of resolution Resources from the server.
 
-        :rtype: List[Resolution]
+        Returns:
+            List[Resolution]
 
         """
         r_json = self._get_json("resolution")
@@ -2399,12 +2587,14 @@ class JIRA(object):
         ]
         return resolutions
 
-    def resolution(self, id):
+    def resolution(self, id: str) -> Resolution:
         """Get a resolution Resource from the server.
 
-        :param id: ID of the resolution to get
-        :type id: str
-        :rtype: Resolution
+        Args:
+            id (str): ID of the resolution to get
+
+        Returns:
+            Resolution
         """
         return self._find_for_resource(Resolution, id)
 
@@ -2412,36 +2602,31 @@ class JIRA(object):
 
     def search_issues(
         self,
-        jql_str,
-        startAt=0,
-        maxResults=50,
-        validate_query=True,
-        fields=None,
-        expand=None,
-        json_result=None,
-    ):
+        jql_str: str,
+        startAt: int = 0,
+        maxResults: int = 50,
+        validate_query: bool = True,
+        fields: Optional[Union[str, List[str]]] = None,
+        expand: Optional[str] = None,
+        json_result: bool = False,
+    ) -> Union[List[Dict[str, Any]], ResultList[Issue]]:
         """Get a :class:`~jira.client.ResultList` of issue Resources matching a JQL search string.
 
-        :param jql_str: The JQL search string.
-        :type jql_str: str
-        :param startAt: Index of the first issue to return. (Default: 0)
-        :type startAt: int
-        :param maxResults: Maximum number of issues to return. Total number of results
-            is available in the ``total`` attribute of the returned :class:`~jira.client.ResultList`.
-            If maxResults evaluates as False, it will try to get all issues in batches. (Default: 50)
-        :type maxResults: int
-        :param validate_query: Whether or not the query should be validated. (Default: True)
-        :type validate_query: bool
-        :param fields: comma-separated string or list of issue fields to include in the results.
-            Default is to include all fields.
-        :type fields: Optional[str or list]
-        :param expand: extra information to fetch inside each resource
-        :type expand: Optional[str]
-        :param json_result: JSON response will be returned when this parameter is set to True.
-                Otherwise, :class:`~jira.client.ResultList` will be returned.
-        :type json_result: bool
+        Args:
+            jql_str (str): The JQL search string.
+            startAt (int): Index of the first issue to return. (Default: 0)
+            maxResults (int): Maximum number of issues to return. Total number of results
+              is available in the ``total`` attribute of the returned :class:`~jira.client.ResultList`.
+              If maxResults evaluates as False, it will try to get all issues in batches. (Default: 50)
+            validate_query (bool): Whether or not the query should be validated. (Default: True)
+            fields (Optional[Union[str, List[str]]]): comma-separated string or list of issue fields to include in the results.
+              Default is to include all fields.
+            expand (Optional[str]): extra information to fetch inside each resource
+            json_result (bool): JSON response will be returned when this parameter is set to True.
+              Otherwise, :class:`~jira.client.ResultList` will be returned.
 
-        :rtype: dict or :class:`~jira.client.ResultList`
+        Returns:
+            Union[Dict,ResultList]: Dict if ``json_result=True``
 
         """
         if isinstance(fields, str):
@@ -2472,34 +2657,42 @@ class JIRA(object):
                     "All issues cannot be fetched at once, when json_result parameter is set",
                     Warning,
                 )
-            return self._get_json("search", params=search_params)
+            r_json: List[Dict[str, Any]] = self._get_json(
+                "search", params=search_params
+            )
+            return r_json
 
         issues = self._fetch_pages(
             Issue, "issues", "search", startAt, maxResults, search_params
         )
 
         if untranslate:
-            for i in issues:
+            iss: Issue
+            for iss in issues:
                 for k, v in untranslate.items():
-                    if k in i.raw.get("fields", {}):
-                        i.raw["fields"][v] = i.raw["fields"][k]
+                    if iss.raw:
+                        if k in iss.raw.get("fields", {}):
+                            iss.raw["fields"][v] = iss.raw["fields"][k]
 
         return issues
 
     # Security levels
-    def security_level(self, id):
+    def security_level(self, id: str) -> SecurityLevel:
         """Get a security level Resource.
 
-        :param id: ID of the security level to get
+        Args:
+            id (str): ID of the security level to get
         """
         return self._find_for_resource(SecurityLevel, id)
 
     # Server info
 
     # non-resource
-    def server_info(self):
+    def server_info(self) -> Dict[str, Any]:
         """Get a dict of server information for this Jira instance.
-        :rtype: Dict[str, Any]
+
+        Returns:
+            Dict[str, Any]
         """
         retry = 0
         j = self._get_json("serverInfo")
@@ -2511,17 +2704,17 @@ class JIRA(object):
             j = self._get_json("serverInfo")
         return j
 
-    def myself(self):
+    def myself(self) -> Dict[str, Any]:
         """Get a dict of server information for this Jira instance."""
         return self._get_json("myself")
 
     # Status
 
-    def statuses(self):
+    def statuses(self) -> List[Status]:
         """Get a list of status Resources from the server.
 
-        :rtype: List[Status]
-
+        Returns:
+            List[Status]
         """
         r_json = self._get_json("status")
         statuses = [
@@ -2530,22 +2723,24 @@ class JIRA(object):
         ]
         return statuses
 
-    def status(self, id):
+    def status(self, id: str) -> Status:
         """Get a status Resource from the server.
 
-        :param id: ID of the status resource to get
-        :type id: str
+        Args:
+            id (str): ID of the status resource to get
 
-        :rtype: Status
+        Returns:
+            Status
         """
         return self._find_for_resource(Status, id)
 
     # Category
 
-    def statuscategories(self):
+    def statuscategories(self) -> List[StatusCategory]:
         """Get a list of status category Resources from the server.
 
-        :rtype: List[StatusCategory]
+        Returns:
+            List[StatusCategory]
         """
         r_json = self._get_json("statuscategory")
         statuscategories = [
@@ -2554,28 +2749,29 @@ class JIRA(object):
         ]
         return statuscategories
 
-    def statuscategory(self, id):
+    def statuscategory(self, id: int) -> StatusCategory:
         """Get a status category Resource from the server.
 
-        :param id: ID of the status category resource to get
-        :type id: int
+        Args:
+            id (int): ID of the status category resource to get
 
-        :rtype: StatusCategory
+        Returns:
+            StatusCategory
 
         """
         return self._find_for_resource(StatusCategory, id)
 
     # Users
 
-    def user(self, id, expand=None):
+    def user(self, id: str, expand: Optional[Any] = None) -> User:
         """Get a user Resource from the server.
 
-        :param id: ID of the user to get
-        :param id: str
-        :param expand: Extra information to fetch inside each resource
-        :type expand: Optional[Any]
+        Args:
+            id (str): ID of the user to get
+            expand (Optional[Any]): Extra information to fetch inside each resource
 
-        :rtype: User
+        Returns:
+            User
         """
         user = User(self._options, self._session)
         params = {}
@@ -2585,21 +2781,19 @@ class JIRA(object):
         return user
 
     def search_assignable_users_for_projects(
-        self, username, projectKeys, startAt=0, maxResults=50
-    ):
+        self, username: str, projectKeys: str, startAt: int = 0, maxResults: int = 50
+    ) -> ResultList:
         """Get a list of user Resources that match the search string and can be assigned issues for projects.
 
-        :param username: A string to match usernames against
-        :type username: str
-        :param projectKeys: Comma-separated list of project keys to check for issue assignment permissions
-        :type projectKeys: str
-        :param startAt: Index of the first user to return (Default: 0)
-        :type startAt: int
-        :param maxResults: Maximum number of users to return.
-                If maxResults evaluates as False, it will try to get all users in batches. (Default: 50)
-        :type maxResults: int
+        Args:
+            username (str): A string to match usernames against
+            projectKeys (str): Comma-separated list of project keys to check for issue assignment permissions
+            startAt (int): Index of the first user to return (Default: 0)
+            maxResults (int): Maximum number of users to return.
+              If maxResults evaluates as False, it will try to get all users in batches. (Default: 50)
 
-        :rtype: ResultList
+        Returns:
+            ResultList
 
         """
         params = {"username": username, "projectKeys": projectKeys}
@@ -2614,12 +2808,12 @@ class JIRA(object):
 
     def search_assignable_users_for_issues(
         self,
-        username,
-        project=None,
-        issueKey=None,
-        expand=None,
-        startAt=0,
-        maxResults=50,
+        username: str,
+        project: Optional[str] = None,
+        issueKey: Optional[str] = None,
+        expand: Optional[Any] = None,
+        startAt: int = 0,
+        maxResults: int = 50,
     ):
         """Get a list of user Resources that match the search string for assigning or creating issues.
 
@@ -2627,21 +2821,19 @@ class JIRA(object):
         to an existing issue. When searching for eligible creators, specify a project. When searching for eligible
         assignees, specify an issue key.
 
-        :param username: A string to match usernames against
-        :type username: str
-        :param project: Filter returned users by permission in this project (expected if a result will be used to
-            create an issue)
-        :type project: Optional[str]
-        :param issueKey: Filter returned users by this issue (expected if a result will be used to edit this issue)
-        :type issueKey: Optional[str]
-        :param expand: Extra information to fetch inside each resource
-        :type expand: Optional[Any]
-        :param startAt: Index of the first user to return (Default: 0)
-        :type startAt: int
-        :param maxResults: maximum number of users to return.
-                If maxResults evaluates as False, it will try to get all items in batches. (Default: 50)
+        Args:
+            username (str): A string to match usernames against
+            project (Optional[str]): Filter returned users by permission in this project
+              (expected if a result will be used to create an issue)
+            issueKey (Optional[str]): Filter returned users by this issue
+              (expected if a result will be used to edit this issue)
+            expand (Optional[Any]): Extra information to fetch inside each resource
+            startAt (int): Index of the first user to return (Default: 0)
+            maxResults (int): maximum number of users to return.
+              If maxResults evaluates as False, it will try to get all items in batches. (Default: 50)
 
-        :rtype: ResultList
+        Returns:
+            ResultList
         """
         params = {"username": username}
         if project is not None:
@@ -2655,15 +2847,22 @@ class JIRA(object):
         )
 
     # non-resource
-    def user_avatars(self, username):
+    def user_avatars(self, username: str) -> Dict[str, Any]:
         """Get a dict of avatars for the specified user.
 
-        :param username: the username to get avatars for
+        Args:
+            username (str): the username to get avatars for
         """
         return self._get_json("user/avatars", params={"username": username})
 
     def create_temp_user_avatar(
-        self, user, filename, size, avatar_img, contentType=None, auto_confirm=False
+        self,
+        user: str,
+        filename: str,
+        size: int,
+        avatar_img: bytes,
+        contentType: Any = None,
+        auto_confirm: bool = False,
     ):
         """Register an image file as a user avatar.
 
@@ -2682,21 +2881,15 @@ class JIRA(object):
         argument with a truthy value and :py:meth:`confirm_user_avatar` will be called for you before this method
         returns.
 
-        :param user: User to register the avatar for
-        :type user: str
-        :param filename: name of the avatar file
-        :type filename: str
-        :param size: size of the avatar file
-        :type size: int
-        :param avatar_img: file-like object containing the avatar
-        :type avatar_img: bytes
-        :param contentType: explicit specification for the avatar image's content-type
-        :type contentType: Optional[Any]
-        :param auto_confirm: whether to automatically confirm the temporary avatar by calling
-            :py:meth:`confirm_user_avatar` with the return value of this method. (Default: False)
-        :type auto_confirm: bool
+        Args:
+            user (str): User to register the avatar for
+            filename (str): name of the avatar file
+            size (int): size of the avatar file
+            avatar_img (bytes): file-like object containing the avatar
+            contentType (Optional[Any]): explicit specification for the avatar image's content-type
+            auto_confirm (bool): whether to automatically confirm the temporary avatar by calling
+              :py:meth:`confirm_user_avatar` with the return value of this method. (Default: False)
 
-        :rtype: NoReturn
         """
         size_from_file = os.path.getsize(filename)
         if size != size_from_file:
@@ -2707,6 +2900,7 @@ class JIRA(object):
 
         params = {"username": user, "filename": filename, "size": size}
 
+        headers: Dict[str, Any]
         headers = {"X-Atlassian-Token": "no-check"}
         if contentType is not None:
             headers["content-type"] = contentType
@@ -2717,13 +2911,13 @@ class JIRA(object):
         url = self._get_url("user/avatar/temporary")
         r = self._session.post(url, params=params, headers=headers, data=avatar_img)
 
-        cropping_properties = json_loads(r)
+        cropping_properties: Dict[str, Any] = json_loads(r)
         if auto_confirm:
             return self.confirm_user_avatar(user, cropping_properties)
         else:
             return cropping_properties
 
-    def confirm_user_avatar(self, user, cropping_properties):
+    def confirm_user_avatar(self, user: str, cropping_properties: Dict[str, Any]):
         """Confirm the temporary avatar image previously uploaded with the specified cropping.
 
         After a successful registry with :py:meth:`create_temp_user_avatar`, use this method to confirm the avatar for
@@ -2731,10 +2925,9 @@ class JIRA(object):
         ``cropping_properties``: the return value of :py:meth:`create_temp_user_avatar` should be used for this
         argument.
 
-        :param user: the user to confirm the avatar for
-        :type user: str
-        :param cropping_properties: a dict of cropping properties from :py:meth:`create_temp_user_avatar`
-        :type cropping_properties: Dict[str,Any]
+        Args:
+            user (str): the user to confirm the avatar for
+            cropping_properties (Dict[str,Any]): a dict of cropping properties from :py:meth:`create_temp_user_avatar`
         """
         data = cropping_properties
         url = self._get_url("user/avatar")
@@ -2742,43 +2935,48 @@ class JIRA(object):
 
         return json_loads(r)
 
-    def set_user_avatar(self, username, avatar):
+    def set_user_avatar(self, username: str, avatar: str) -> Response:
         """Set a user's avatar.
 
-        :param username: the user to set the avatar for
-        :param avatar: ID of the avatar to set
+        Args:
+            username (str): the user to set the avatar for
+            avatar (str): ID of the avatar to set
         """
-        self._set_avatar({"username": username}, self._get_url("user/avatar"), avatar)
+        return self._set_avatar(
+            {"username": username}, self._get_url("user/avatar"), avatar
+        )
 
-    def delete_user_avatar(self, username, avatar):
+    def delete_user_avatar(self, username: str, avatar: str):
         """Delete a user's avatar.
 
-        :param username: the user to delete the avatar from
-        :param avatar: ID of the avatar to remove
+        Args:
+            username (str): the user to delete the avatar from
+            avatar (str): ID of the avatar to remove
         """
         params = {"username": username}
         url = self._get_url("user/avatar/" + avatar)
         return self._session.delete(url, params=params)
 
     def search_users(
-        self, user, startAt=0, maxResults=50, includeActive=True, includeInactive=False
-    ):
+        self,
+        user: str,
+        startAt: int = 0,
+        maxResults: int = 50,
+        includeActive: bool = True,
+        includeInactive: bool = False,
+    ) -> ResultList[User]:
         """Get a list of user Resources that match the specified search string.
 
-        :param user: a string to match usernames, name or email against.
-        :type user: str
-        :param startAt: index of the first user to return.
-        :type startAt: int
-        :param maxResults: maximum number of users to return.
-                If maxResults evaluates as False, it will try to get all items in batches.
-        :type maxResults: int
-        :param includeActive: If true, then active users are included in the results. (Default: True)
-        :type includeActive: bool
-        :param includeInactive: If true, then inactive users are included in the results. (Default: False)
-        :type includeInactive: bool
+        Args:
+            user (str): a string to match usernames, name or email against.
+            startAt (int): index of the first user to return.
+            maxResults (int): maximum number of users to return.
+              If maxResults evaluates as False, it will try to get all items in batches.
+            includeActive (bool): If true, then active users are included in the results. (Default: True)
+            includeInactive (bool): If true, then inactive users are included in the results. (Default: False)
 
-
-        :rtype: ResultList
+        Returns:
+            ResultList[User]
         """
         params = {
             "username": user,
@@ -2788,21 +2986,25 @@ class JIRA(object):
         return self._fetch_pages(User, None, "user/search", startAt, maxResults, params)
 
     def search_allowed_users_for_issue(
-        self, user, issueKey=None, projectKey=None, startAt=0, maxResults=50
-    ):
+        self,
+        user: str,
+        issueKey: str = None,
+        projectKey: str = None,
+        startAt: int = 0,
+        maxResults: int = 50,
+    ) -> ResultList:
         """Get a list of user Resources that match a username string and have browse permission for the issue or project.
 
-        :param user: a string to match usernames against.
-        :type user: str
-        :param issueKey: find users with browse permission for this issue.
-        :type issueKey: Optional[str]
-        :param projectKey: find users with browse permission for this project.
-        :type projectKey: Optional[str]
-        :param startAt: index of the first user to return. (Default: 0)
-        :type startAt: int
-        :param maxResults: maximum number of users to return.
-                If maxResults evaluates as False, it will try to get all items in batches. (Default: 50)
-        :type maxResults: int
+        Args:
+            user (str): a string to match usernames against.
+            issueKey (Optional[str]): find users with browse permission for this issue.
+            projectKey (Optional[str]): find users with browse permission for this project.
+            startAt (int): index of the first user to return. (Default: 0)
+            maxResults (int): maximum number of users to return.
+              If maxResults evaluates as False, it will try to get all items in batches. (Default: 50)
+
+        Returns:
+            ResultList
         """
         params = {"username": user}
         if issueKey is not None:
@@ -2818,32 +3020,27 @@ class JIRA(object):
     @translate_resource_args
     def create_version(
         self,
-        name,
-        project,
-        description=None,
-        releaseDate=None,
-        startDate=None,
-        archived=False,
-        released=False,
-    ):
+        name: str,
+        project: str,
+        description: str = None,
+        releaseDate: Any = None,
+        startDate: Any = None,
+        archived: bool = False,
+        released: bool = False,
+    ) -> Version:
         """Create a version in a project and return a Resource for it.
 
-        :param name: name of the version to create
-        :type name: str
-        :param project: key of the project to create the version in
-        :type project: str
-        :param description: a description of the version
-        :type description: str
-        :param releaseDate: the release date assigned to the version
-        :type releaseDate: Optional[Any]
-        :param startDate: The start date for the version
-        :type startDate: Optional[Any]
-        :param archived: Denotes whether a version should be archived. (Default: False)
-        :type archived: bool
-        :param released: Denotes whether a version is released. (Default: False)
-        :type released: bool
+        Args:
+            name (str): name of the version to create
+            project (str): key of the project to create the version in
+            description (str): a description of the version
+            releaseDate (Optional[Any]): the release date assigned to the version
+            startDate (Optional[Any]): The start date for the version
+            archived (bool): Denotes whether a version should be archived. (Default: False)
+            released (bool): Denotes whether a version is released. (Default: False)
 
-        :rtype: Version
+        Returns:
+            Version
         """
         data = {
             "name": name,
@@ -2865,15 +3062,19 @@ class JIRA(object):
         version = Version(self._options, self._session, raw=json_loads(r))
         return version
 
-    def move_version(self, id, after=None, position=None):
+    def move_version(self, id: str, after: str = None, position: str = None) -> Version:
         """Move a version within a project's ordered version list and return a new version Resource for it.
 
         One, but not both, of ``after`` and ``position`` must be specified.
 
-        :param id: ID of the version to move
-        :param after: the self attribute of a version to place the specified version after (that is, higher in the list)
-        :param position: the absolute position to move this version to: must be one of ``First``, ``Last``,
-            ``Earlier``, or ``Later``
+        Args:
+            id (str): ID of the version to move
+            after (str): the self attribute of a version to place the specified version after (that is, higher in the list)
+            position (Optional[str]): the absolute position to move this version to:
+              must be one of ``First``, ``Last``, ``Earlier``, or ``Later``
+
+        Returns:
+            Version
         """
         data = {}
         if after is not None:
@@ -2887,15 +3088,15 @@ class JIRA(object):
         version = Version(self._options, self._session, raw=json_loads(r))
         return version
 
-    def version(self, id, expand=None):
+    def version(self, id: str, expand: Any = None) -> Version:
         """Get a version Resource.
 
-        :param id: ID of the version to get
-        :type id: str
-        :param expand: extra information to fetch inside each resource
-        :type expand: Optional[Any]
+        Args:
+            id (str): ID of the version to get
+            expand (Optional[Any]): extra information to fetch inside each resource
 
-        :rtype: Version
+        Returns:
+            Version
         """
         version = Version(self._options, self._session)
         params = {}
@@ -2904,31 +3105,34 @@ class JIRA(object):
         version.find(id, params=params)
         return version
 
-    def version_count_related_issues(self, id):
+    def version_count_related_issues(self, id: str):
         """Get a dict of the counts of issues fixed and affected by a version.
 
-        :param id: the version to count issues for
+        Args:
+            id (str): the version to count issues for
         """
-        r_json = self._get_json("version/" + id + "/relatedIssueCounts")
+        r_json: Dict[str, Any] = self._get_json("version/" + id + "/relatedIssueCounts")
         del r_json["self"]  # this isn't really an addressable resource
         return r_json
 
-    def version_count_unresolved_issues(self, id):
+    def version_count_unresolved_issues(self, id: str):
         """Get the number of unresolved issues for a version.
 
-        :param id: ID of the version to count issues for
+        Args:
+            id (str): ID of the version to count issues for
         """
-        return self._get_json("version/" + id + "/unresolvedIssueCount")[
-            "issuesUnresolvedCount"
-        ]
+        r_json: Dict[str, Any] = self._get_json(
+            "version/" + id + "/unresolvedIssueCount"
+        )
+        return r_json["issuesUnresolvedCount"]
 
     # Session authentication
 
-    def session(self):
+    def session(self) -> User:
         """Get a dict of the current authenticated user's session information.
 
-        :rtype: User
-
+        Returns:
+            User
         """
         url = "{server}{auth_url}".format(**self._options)
         r = self._session.get(url)
@@ -2936,49 +3140,58 @@ class JIRA(object):
         user = User(self._options, self._session, json_loads(r))
         return user
 
-    def kill_session(self):
+    def kill_session(self) -> Response:
         """Destroy the session of the current authenticated user."""
         url = self.server_url + "/rest/auth/latest/session"
         return self._session.delete(url)
 
     # Websudo
-    def kill_websudo(self):
+    def kill_websudo(self) -> Optional[Response]:
         """Destroy the user's current WebSudo session.
 
         Works only for non-cloud deployments, for others does nothing.
 
-        :rtype: Optional[Any]
+        Returns:
+            Optional[Response]
         """
         if self.deploymentType != "Cloud":
             url = self.server_url + "/rest/auth/1/websudo"
             return self._session.delete(url)
+        return None
 
     # Utilities
-    def _create_http_basic_session(self, username, password, timeout=None):
+    def _create_http_basic_session(
+        self,
+        username: str,
+        password: str,
+        timeout: Optional[Union[Union[float, int], Tuple[float, float]]] = None,
+    ):
         """Creates a basic http session.
 
-        :param username: Username for the session
-        :type username: str
-        :param password: Password for the username
-        :type password: str
-        :param timeout: If set determines the timeout period for the Session.
-        :type timeout: Optional[int]
+        Args:
+            username (str): Username for the session
+            password (str): Password for the username
+            timeout (Optional[int]): If set determines the timeout period for the Session.
 
-        :rtype: NoReturn
+        Returns:
+            ResilientSession
         """
-        verify = self._options["verify"]
+        verify = bool(self._options["verify"])
         self._session = ResilientSession(timeout=timeout)
         self._session.verify = verify
         self._session.auth = (username, password)
-        self._session.cert = self._options["client_cert"]
+        client_cert: Tuple[str, str] = self._options["client_cert"]  # to help mypy
+        self._session.cert = client_cert
 
-    def _create_oauth_session(self, oauth, timeout):
-        verify = self._options["verify"]
+    def _create_oauth_session(
+        self, oauth, timeout: Optional[Union[Union[float, int], Tuple[float, float]]]
+    ):
+        verify = bool(self._options["verify"])
 
         from oauthlib.oauth1 import SIGNATURE_RSA
         from requests_oauthlib import OAuth1
 
-        oauth = OAuth1(
+        oauth_instance = OAuth1(
             oauth["consumer_key"],
             rsa_key=oauth["key_cert"],
             signature_method=SIGNATURE_RSA,
@@ -2987,10 +3200,14 @@ class JIRA(object):
         )
         self._session = ResilientSession(timeout)
         self._session.verify = verify
-        self._session.auth = oauth
+        self._session.auth = oauth_instance
 
-    def _create_kerberos_session(self, timeout, kerberos_options=None):
-        verify = self._options["verify"]
+    def _create_kerberos_session(
+        self,
+        timeout: Optional[Union[Union[float, int], Tuple[float, float]]],
+        kerberos_options=None,
+    ):
+        verify = bool(self._options["verify"])
         if kerberos_options is None:
             kerberos_options = {}
 
@@ -3013,13 +3230,15 @@ class JIRA(object):
         )
 
     @staticmethod
-    def _timestamp(dt=None):
+    def _timestamp(dt: datetime.timedelta = None):
         t = datetime.datetime.utcnow()
         if dt is not None:
             t += dt
         return calendar.timegm(t.timetuple())
 
-    def _create_jwt_session(self, jwt, timeout):
+    def _create_jwt_session(
+        self, jwt, timeout: Optional[Union[Union[float, int], Tuple[float, float]]]
+    ):
         try:
             jwt_auth = JWTAuth(jwt["secret"], alg="HS256")
         except NameError as e:
@@ -3035,58 +3254,55 @@ class JIRA(object):
         for f in jwt["payload"].items():
             jwt_auth.add_field(f[0], f[1])
         self._session = ResilientSession(timeout=timeout)
-        self._session.verify = self._options["verify"]
+        self._session.verify = bool(self._options["verify"])
         self._session.auth = jwt_auth
 
     def _set_avatar(self, params, url, avatar):
         data = {"id": avatar}
         return self._session.put(url, params=params, data=json.dumps(data))
 
-    def _get_url(self, path, base=JIRA_BASE_URL):
+    def _get_url(self, path: str, base: str = JIRA_BASE_URL) -> str:
         """Returns the full url based on Jira base url and the path provided.
         Using the API version specified during the __init__.
 
-        :param path: The subpath desired.
-        :type path: str
-        :param base: The base url which should be prepended to the path
-        :type base: Optional[str]
+        Args:
+            path (str): The subpath desired.
+            base (Optional[str]): The base url which should be prepended to the path
 
-        :return Fully qualified URL
-        :rtype: str
-
+        Returns:
+            str: Fully qualified URL
         """
         options = self._options.copy()
         options.update({"path": path})
         return base.format(**options)
 
-    def _get_latest_url(self, path, base=JIRA_BASE_URL):
+    def _get_latest_url(self, path: str, base: str = JIRA_BASE_URL) -> str:
         """Returns the full url based on Jira base url and the path provided.
         Using the latest API endpoint.
 
-        :param path: The subpath desired.
-        :type path: str
-        :param base: The base url which should be prepended to the path
-        :type base: Optional[str]
+        Args:
+            path (str): The subpath desired.
+            base (Optional[str]): The base url which should be prepended to the path
 
-        :return Fully qualified URL
-        :rtype: str
-
+        Returns:
+            str: Fully qualified URL
         """
         options = self._options.copy()
         options.update({"path": path, "rest_api_version": "latest"})
         return base.format(**options)
 
-    def _get_json(self, path, params=None, base=JIRA_BASE_URL):
+    def _get_json(
+        self, path: str, params: Dict[str, Any] = None, base: str = JIRA_BASE_URL
+    ):
         """Get the json for a given path and params.
 
-        :param path: The subpath required
-        :type path: str
-        :param params: Parameters to filter the json query.
-        :type params: Optional[Dict[str, Any]]
-        :param base: The Base Jira URL, defaults to the instance base.
-        :type base: Optional[str]
+        Args:
+            path (str): The subpath required
+            params (Optional[Dict[str, Any]]): Parameters to filter the json query.
+            base (Optional[str]): The Base Jira URL, defaults to the instance base.
 
-        :rtype: Union[Dict[str, Any], List[Dict[str, str]]]
+        Returns:
+            Union[Dict[str, Any], List[Dict[str, str]]]
 
         """
         url = self._get_url(path, base)
@@ -3094,18 +3310,34 @@ class JIRA(object):
         try:
             r_json = json_loads(r)
         except ValueError as e:
-            self.log.error("%s\n%s" % (e, r.text))
+            self.log.error("%s\n%s" % (e, r.text if r else r))
             raise e
         return r_json
 
-    def _find_for_resource(self, resource_cls, ids, expand=None):
+    def _find_for_resource(
+        self, resource_cls: Any, ids: Union[Tuple[str, str], int, str], expand=None
+    ) -> Any:
+        """Uses the find method of the provided Resource class
+
+        Args:
+            resource_cls (Any): Any instance of :py:class`Resource`
+            ids (Union[Tuple[str, str], int, str]): The arguments to the Resource's ``find()``
+            expand ([type], optional): The value for the expand property in the Resource's
+              ``find()`` params. Defaults to None.
+
+        Raises:
+            JIRAError: If the Resource cannot be found
+
+        Returns:
+            Any: A class of the same type as ``resource_cls``
+        """
         resource = resource_cls(self._options, self._session)
         params = {}
         if expand is not None:
             params["expand"] = expand
         resource.find(id=ids, params=params)
         if not resource:
-            raise JIRAError("Unable to find resource %s(%s)", resource_cls, ids)
+            raise JIRAError("Unable to find resource %s(%s)", resource_cls, str(ids))
         return resource
 
     def _try_magic(self):
@@ -3129,20 +3361,21 @@ class JIRA(object):
             except AttributeError:
                 self._magic = None
 
-    def _get_mime_type(self, buff):
+    def _get_mime_type(self, buff: bytes) -> Optional[str]:
         """Get the MIME type for a given stream of bytes
 
-        :param buff: Stream of bytes
-        :type buff: bytes
+        Args:
+            buff (bytes): Stream of bytes
 
-        :rtype: str
+        Returns:
+            Optional[str]: the MIME type
 
         """
         if self._magic is not None:
             return self._magic.id_buffer(buff)
         else:
             try:
-                return mimetypes.guess_type("f." + imghdr.what(0, buff))[0]
+                return mimetypes.guess_type("f." + str(imghdr.what(0, buff)))[0]
             except (IOError, TypeError):
                 self.log.warning(
                     "Couldn't detect content type of avatar image"
@@ -3150,13 +3383,12 @@ class JIRA(object):
                 )
                 return None
 
-    def rename_user(self, old_user, new_user):
+    def rename_user(self, old_user: str, new_user: str):
         """Rename a Jira user.
 
-        :param old_user: Old username login
-        :type old_user: str
-        :param new_user: New username login
-        :type new_user: str
+        Args:
+            old_user (str): Old username login
+            new_user (str): New username login
 
         """
         if self._version > (6, 0, 0):
@@ -3174,14 +3406,14 @@ class JIRA(object):
                 "Support for renaming users in Jira " "< 6.0.0 has been removed."
             )
 
-    def delete_user(self, username):
+    def delete_user(self, username: str) -> bool:
         """Deletes a Jira User.
 
-        :param username: Username to delete
-        :type username: str
+        Args:
+            username (str): Username to delete
 
-        :return: Success of user deletion
-        :rtype: bool
+        Returns:
+            bool: Success of user deletion
 
         """
 
@@ -3194,13 +3426,14 @@ class JIRA(object):
             self.log.error(r.status_code)
             return False
 
-    def deactivate_user(self, username):
+    def deactivate_user(self, username: str) -> Union[str, int]:
         """Disable/deactivate the user.
 
-        :param username: User to be deactivated.
-        :type username: str
+        Args:
+            username (str): User to be deactivated.
 
-        :rtype: Union[str, int]
+        Returns:
+            Union[str, int]
         """
         if self.deploymentType == "Cloud":
             # Disabling users now needs cookie auth in the Cloud - see https://jira.atlassian.com/browse/ID-6230
@@ -3267,13 +3500,17 @@ class JIRA(object):
                 self.log.error("Error Deactivating %s: %s" % (username, e))
                 raise JIRAError("Error Deactivating %s: %s" % (username, e))
 
-    def reindex(self, force=False, background=True):
+    def reindex(self, force: bool = False, background: bool = True) -> bool:
         """Start jira re-indexing. Returns True if reindexing is in progress or not needed, or False.
 
         If you call reindex() without any parameters it will perform a background reindex only if Jira thinks it should do it.
 
-        :param force: reindex even if Jira doesn't say this is needed, False by default.
-        :param background: reindex in background, slower but does not impact the users, defaults to True.
+        Args:
+            force (bool): reindex even if Jira doesn't say this is needed, False by default.
+            background (bool): reindex in background, slower but does not impact the users, defaults to True.
+
+        Returns:
+            bool: Returns True if reindexing is in progress or not needed, or False.
         """
         # /secure/admin/IndexAdmin.jspa
         # /secure/admin/jira/IndexProgress.jspa?taskId=1
@@ -3287,7 +3524,7 @@ class JIRA(object):
         r = self._session.get(url, headers=self._options["headers"])
         if r.status_code == 503:
             # self.log.warning("Jira returned 503, this could mean that a full reindex is in progress.")
-            return 503
+            return 503  # type: ignore # FIXME: is this a bug?
 
         if (
             not r.text.find("To perform the re-index now, please go to the")
@@ -3307,12 +3544,13 @@ class JIRA(object):
             )
             if r.text.find("All issues are being re-indexed") != -1:
                 return True
-            else:
-                self.log.error("Failed to reindex jira, probably a bug.")
-                return False
 
-    def backup(self, filename="backup.zip", attachments=False):
+        self.log.error("Failed to reindex jira, probably a bug.")
+        return False
+
+    def backup(self, filename: str = "backup.zip", attachments: bool = False):
         """Will call jira export to backup as zipped xml. Returning with success does not mean that the backup process finished."""
+        payload: Any  # _session.post is pretty open
         if self.deploymentType == "Cloud":
             url = self.server_url + "/rest/backup/1/export/runbackup"
             payload = json.dumps({"cbAttachments": attachments})
@@ -3361,19 +3599,20 @@ class JIRA(object):
                 progress[k] = root.get(k)
             return progress
 
-    def backup_complete(self):
+    def backup_complete(self) -> Optional[bool]:
         """Return boolean based on 'alternativePercentage' and 'size' returned from backup_progress (cloud only)."""
         if self.deploymentType != "Cloud":
             self.log.warning("This functionality is not available in Server version")
             return None
         status = self.backup_progress()
+        perc_search = re.search(r"\s([0-9]*)\s", status["alternativePercentage"])
         perc_complete = int(
-            re.search(r"\s([0-9]*)\s", status["alternativePercentage"]).group(1)
+            perc_search.group(1)  # type: ignore # ignore that re.search can return None
         )
         file_size = int(status["size"])
         return perc_complete >= 100 and file_size > 0
 
-    def backup_download(self, filename=None):
+    def backup_download(self, filename: str = None):
         """Download backup file from WebDAV (cloud only)."""
         if self.deploymentType != "Cloud":
             self.log.warning("This functionality is not available in Server version")
@@ -3401,35 +3640,39 @@ class JIRA(object):
             self.log.error(ioe)
         return None
 
-    def current_user(self, field="key"):
+    def current_user(self, field: str = "key") -> str:
         """Returns the username or emailAddress of the current user. For anonymous
         users it will return a value that evaluates as False.
 
-        :rtype: str
+        Returns:
+            str
         """
         if not hasattr(self, "_myself"):
 
             url = self._get_url("myself")
             r = self._session.get(url, headers=self._options["headers"])
 
-            r_json = json_loads(r)
+            r_json: Dict[str, str] = json_loads(r)
             self._myself = r_json
 
         return self._myself[field]
 
-    def delete_project(self, pid):
+    def delete_project(self, pid: Union[str, Project]) -> Optional[bool]:
         """Delete project from Jira.
 
-        :param pid: Jira projectID or Project or slug
-        :type pid: str
-        :return: True if project was deleted
-        :rtype: bool
-        :raises JIRAError:  If project not found or not enough permissions
-        :raises ValueError: If pid parameter is not Project, slug or ProjectID
+        Args:
+            pid (Union[str, Project]): Jira projectID or Project or slug
+
+        Raises:
+            JIRAError:  If project not found or not enough permissions
+            ValueError: If pid parameter is not Project, slug or ProjectID
+
+        Returns:
+            bool: True if project was deleted
         """
         # allows us to call it with Project objects
-        if hasattr(pid, "id"):
-            pid = pid.id
+        if isinstance(pid, Project) and hasattr(pid, "id"):
+            pid = str(pid.id)
 
         url = self._get_url("project/%s" % pid)
         r = self._session.delete(url)
@@ -3462,12 +3705,12 @@ class JIRA(object):
         )
 
     @lru_cache(maxsize=None)
-    def templates(self):
+    def templates(self) -> Dict:
 
         url = self.server_url + "/rest/project-templates/latest/templates"
 
         r = self._session.get(url)
-        data = json_loads(r)
+        data: Dict[str, Any] = json_loads(r)
 
         templates = {}
         if "projectTemplatesGroupedByType" in data:
@@ -3483,9 +3726,9 @@ class JIRA(object):
         url = self._get_url("permissionscheme")
 
         r = self._session.get(url)
-        data = json_loads(r)["permissionSchemes"]
+        data: Dict[str, Any] = json_loads(r)
 
-        return data
+        return data["permissionSchemes"]
 
     @lru_cache(maxsize=None)
     def issuesecurityschemes(self):
@@ -3493,9 +3736,9 @@ class JIRA(object):
         url = self._get_url("issuesecurityschemes")
 
         r = self._session.get(url)
-        data = json_loads(r)["issueSecuritySchemes"]
+        data: Dict[str, Any] = json_loads(r)
 
-        return data
+        return data["issueSecuritySchemes"]
 
     @lru_cache(maxsize=None)
     def projectcategories(self):
@@ -3513,9 +3756,9 @@ class JIRA(object):
         url = self._get_url("avatar/%s/system" % entity)
 
         r = self._session.get(url)
-        data = json_loads(r)["system"]
+        data: Dict[str, Any] = json_loads(r)
 
-        return data
+        return data["system"]
 
     @lru_cache(maxsize=None)
     def notificationschemes(self):
@@ -3523,7 +3766,7 @@ class JIRA(object):
         url = self._get_url("notificationscheme")
 
         r = self._session.get(url)
-        data = json_loads(r)
+        data: Dict[str, Any] = json_loads(r)
         return data["values"]
 
     @lru_cache(maxsize=None)
@@ -3532,7 +3775,7 @@ class JIRA(object):
         url = self._get_url("screens")
 
         r = self._session.get(url)
-        data = json_loads(r)
+        data: Dict[str, Any] = json_loads(r)
         return data["values"]
 
     @lru_cache(maxsize=None)
@@ -3553,7 +3796,7 @@ class JIRA(object):
         data = json_loads(r)
         return data  # ['values']
 
-    def delete_screen(self, id):
+    def delete_screen(self, id: str):
 
         url = self._get_url("screens/%s" % id)
 
@@ -3563,7 +3806,7 @@ class JIRA(object):
         self.screens.cache_clear()
         return data
 
-    def delete_permissionscheme(self, id):
+    def delete_permissionscheme(self, id: str):
 
         url = self._get_url("permissionscheme/%s" % id)
 
@@ -3575,35 +3818,31 @@ class JIRA(object):
 
     def create_project(
         self,
-        key,
-        name=None,
-        assignee=None,
-        ptype="software",
-        template_name=None,
+        key: str,
+        name: str = None,
+        assignee: str = None,
+        ptype: str = "software",
+        template_name: str = None,
         avatarId=None,
         issueSecurityScheme=None,
         permissionScheme=None,
         projectCategory=None,
         notificationScheme=10000,
         categoryId=None,
-        url="",
+        url: str = "",
     ):
         """Create a project with the specified parameters.
 
-        :param key: Mandatory. Must match Jira project key requirements, usually only 2-10 uppercase characters.
-        :type: str
-        :param name: If not specified it will use the key value.
-        :type name: Optional[str]
-        :param assignee: key of the lead, if not specified it will use current user.
-        :type assignee: Optional[str]
-        :param type: Determines the type of project should be created.
-        :type ptype: Optional[str]
-        :param template_name: is used to create a project based on one of the existing project templates.
-                If `template_name` is not specified, then it should use one of the default values.
-        :type template_name: Optional[str]
+        Args:
+            key (str): Mandatory. Must match Jira project key requirements, usually only 2-10 uppercase characters.
+            name (Optional[str]): If not specified it will use the key value.
+            assignee (Optional[str]): key of the lead, if not specified it will use current user.
+            ptype (Optional[str]): Determines the type of project should be created.
+            template_name (Optional[str]): is used to create a project based on one of the existing project templates.
+              If `template_name` is not specified, then it should use one of the default values.
 
-        :return: Should evaluate to False if it fails otherwise it will be the new project id.
-        :rtype: Union[bool,int]
+        Returns:
+            Union[bool,int]: Should evaluate to False if it fails otherwise it will be the new project id.
 
         """
         template_key = None
@@ -3612,6 +3851,8 @@ class JIRA(object):
             assignee = self.current_user()
         if name is None:
             name = key
+
+        ps_list: List[Dict[str, Any]]
 
         if not permissionScheme:
             ps_list = self.permissionschemes()
@@ -3733,41 +3974,35 @@ class JIRA(object):
 
     def add_user(
         self,
-        username,
-        email,
-        directoryId=1,
-        password=None,
-        fullname=None,
-        notify=False,
-        active=True,
-        ignore_existing=False,
-        application_keys=None,
+        username: str,
+        email: str,
+        directoryId: int = 1,
+        password: str = None,
+        fullname: str = None,
+        notify: bool = False,
+        active: bool = True,
+        ignore_existing: bool = False,
+        application_keys: Optional[List] = None,
     ):
         """Create a new Jira user.
 
-        :param username: the username of the new user
-        :type username: str
-        :param email: email address of the new user
-        :type email: str
-        :param directoryId: The directory ID the new user should be a part of (Default: 1)
-        :type directoryId: int
-        :param password: Optional, the password for the new user
-        :type password: Optional[str]
-        :param fullname: Optional, the full name of the new user
-        :type fullname: Optional[str]
-        :param notify: Whether or not to send a notification to the new user. (Default: False)
-        :type notify: bool
-        :param active: Whether or not to make the new user active upon creation. (Default: True)
-        :type active: bool
-        :param ignore_existing: Whether or not to ignore and existing user. (Default: False)
-        :type ignore_existing: bool
-        :param applicationKeys: Keys of products user should have access to
-        :type applicationKeys: Optional[list]
+        Args:
+            username (str): the username of the new user
+            email (str): email address of the new user
+            directoryId (int): The directory ID the new user should be a part of (Default: 1)
+            password (Optional[str]): Optional, the password for the new user
+            fullname (Optional[str]): Optional, the full name of the new user
+            notify (bool): Whether or not to send a notification to the new user. (Default: False)
+            active (bool): Whether or not to make the new user active upon creation. (Default: True)
+            ignore_existing (bool): Whether or not to ignore and existing user. (Default: False)
+            applicationKeys (Optional[list]): Keys of products user should have access to
 
-        :return: Whether or not the user creation was successful.
-        :rtype: bool
+        Raises:
+            JIRAError:  If username already exists and `ignore_existing` has not been set to `True`.
 
-        :raises JIRAError:  If username already exists and `ignore_existing` has not been set to `True`.
+        Returns:
+            bool: Whether or not the user creation was successful.
+
 
         """
         if not fullname:
@@ -3778,7 +4013,7 @@ class JIRA(object):
 
         # implementation based on
         # https://docs.atlassian.com/jira/REST/ondemand/#d2e5173
-        x = OrderedDict()
+        x: Dict[str, Any] = OrderedDict()
 
         x["displayName"] = fullname
         x["emailAddress"] = email
@@ -3794,26 +4029,28 @@ class JIRA(object):
         try:
             self._session.post(url, data=payload)
         except JIRAError as e:
-            err = e.response.json()["errors"]
-            if (
-                "username" in err
-                and err["username"] == "A user with that username already exists."
-                and ignore_existing
-            ):
-                return True
+            if e.response:
+                err = e.response.json()["errors"]
+                if (
+                    "username" in err
+                    and err["username"] == "A user with that username already exists."
+                    and ignore_existing
+                ):
+                    return True
             raise e
         return True
 
-    def add_user_to_group(self, username, group):
+    def add_user_to_group(
+        self, username: str, group: str
+    ) -> Union[bool, Dict[str, Any]]:
         """Add a user to an existing group.
 
-        :param username: Username that will be added to specified group.
-        :type username: str
-        :param group: Group that the user will be added to.
-        :type group: str
+        Args:
+            username (str): Username that will be added to specified group.
+            group (str): Group that the user will be added to.
 
-        :return: json response from Jira server for success or a value that evaluates as False in case of failure.
-        :rtype: Union[bool,Dict[str,Any]]
+        Returns:
+            Union[bool,Dict[str,Any]]: json response from Jira server for success or a value that evaluates as False in case of failure.
         """
         url = self._get_latest_url("group/user")
         x = {"groupname": group}
@@ -3821,17 +4058,18 @@ class JIRA(object):
 
         payload = json.dumps(y)
 
-        r = json_loads(self._session.post(url, params=x, data=payload))
+        r: Dict[str, Any] = json_loads(self._session.post(url, params=x, data=payload))
         if "name" not in r or r["name"] != group:
             return False
         else:
             return r
 
-    def remove_user_from_group(self, username, groupname):
+    def remove_user_from_group(self, username: str, groupname: str):
         """Remove a user from a group.
 
-        :param username: The user to remove from the group.
-        :param groupname: The group that the user will be removed from.
+        Args:
+            username (str): The user to remove from the group.
+            groupname (str): The group that the user will be removed from.
         """
         url = self._get_latest_url("group/user")
         x = {"groupname": groupname, "username": username}
@@ -3840,11 +4078,11 @@ class JIRA(object):
 
         return True
 
-    def role(self):
+    def role(self) -> List[Dict[str, Any]]:
         """Return Jira role information.
 
-        :return: List of current user roles
-        :rtype: Iterable
+        Returns:
+            List[Dict[str,Any]]: List of current user roles
 
         """
         # https://developer.atlassian.com/cloud/jira/platform/rest/v3/?utm_source=%2Fcloud%2Fjira%2Fplatform%2Frest%2F&utm_medium=302#api-rest-api-3-role-get
@@ -3852,12 +4090,13 @@ class JIRA(object):
         url = self._get_latest_url("role")
 
         r = self._session.get(url)
-        return json_loads(r)
+        data: List[Dict[str, Any]] = json_loads(r)
+        return data
 
     # Experimental
     # Experimental support for iDalko Grid, expect API to change as it's using private APIs currently
     # https://support.idalko.com/browse/IGRID-1017
-    def get_igrid(self, issueid, customfield, schemeid):
+    def get_igrid(self, issueid: str, customfield: str, schemeid: str):
         url = self.server_url + "/rest/idalko-igrid/1.0/datagrid/data"
         if str(customfield).isdigit():
             customfield = "customfield_%s" % customfield
@@ -3876,16 +4115,24 @@ class JIRA(object):
 
     @translate_resource_args
     def boards(
-        self, startAt=0, maxResults=50, type=None, name=None, projectKeyOrID=None
-    ):
+        self,
+        startAt: int = 0,
+        maxResults: int = 50,
+        type: str = None,
+        name: str = None,
+        projectKeyOrID=None,
+    ) -> ResultList[Board]:
         """Get a list of board resources.
 
-        :param startAt: The starting index of the returned boards. Base index: 0.
-        :param maxResults: The maximum number of boards to return per page. Default: 50
-        :param type: Filters results to boards of the specified type. Valid values: scrum, kanban.
-        :param name: Filters results to boards that match or partially match the specified name.
-        :param projectKeyOrID: Filters results to boards that match the specified project key or ID.
-        :rtype: ResultList[Board]
+        Args:
+            startAt: The starting index of the returned boards. Base index: 0.
+            maxResults: The maximum number of boards to return per page. Default: 50
+            type: Filters results to boards of the specified type. Valid values: scrum, kanban.
+            name: Filters results to boards that match or partially match the specified name.
+            projectKeyOrID: Filters results to boards that match the specified project key or ID.
+
+        Returns:
+            ResultList[Board]
 
         When old GreenHopper private API is used, paging is not enabled and all parameters are ignored.
         """
@@ -3909,7 +4156,9 @@ class JIRA(object):
                     Warning,
                 )
 
-            r_json = self._get_json("rapidviews/list", base=self.AGILE_BASE_URL)
+            r_json: Dict[str, Any] = self._get_json(
+                "rapidviews/list", base=self.AGILE_BASE_URL
+            )
             boards = [
                 Board(self._options, self._session, raw_boards_json)
                 for raw_boards_json in r_json["views"]
@@ -3927,26 +4176,28 @@ class JIRA(object):
             )
 
     @translate_resource_args
-    def sprints(self, board_id, extended=False, startAt=0, maxResults=50, state=None):
+    def sprints(
+        self,
+        board_id: int,
+        extended: bool = False,
+        startAt: int = 0,
+        maxResults: int = 50,
+        state: str = None,
+    ) -> ResultList[Sprint]:
         """Get a list of sprint GreenHopperResources.
 
-        :param board_id: the board to get sprints from
-        :param extended: Used only by old GreenHopper API to fetch additional information like
-            startDate, endDate, completeDate, much slower because it requires an additional requests for each sprint.
-            New Jira Agile API always returns this information without a need for additional requests.
-        :param startAt: the index of the first sprint to return (0 based)
-        :param maxResults: the maximum number of sprints to return
-        :param state: Filters results to sprints in specified states. Valid values: `future`, `active`, `closed`.
-            You can define multiple states separated by commas
+        Args:
+            board_id (int): the board to get sprints from
+            extended (bool): Used only by old GreenHopper API to fetch additional information like
+              startDate, endDate, completeDate, much slower because it requires an additional requests for each sprint.
+              New Jira Agile API always returns this information without a need for additional requests.
+            startAt (int): the index of the first sprint to return (0 based)
+            maxResults (int): the maximum number of sprints to return
+            state (str): Filters results to sprints in specified states. Valid values: `future`, `active`, `closed`.
+              You can define multiple states separated by commas
 
-        :type board_id: int
-        :type extended: bool
-        :type startAt: int
-        :type maxResults: int
-        :type state: str
-
-        :rtype: list of :class:`~jira.resources.Sprint`
-        :return: (content depends on API version, but always contains id, name, state, startDate and endDate)
+        Returns:
+            ResultList[Sprint]: (content depends on API version, but always contains id, name, state, startDate and endDate)
             When old GreenHopper private API is used, paging is not enabled,
             and `startAt`, `maxResults` and `state` parameters are ignored.
         """
@@ -3958,7 +4209,7 @@ class JIRA(object):
             self._options["agile_rest_path"]
             == GreenHopperResource.GREENHOPPER_REST_PATH
         ):
-            r_json = self._get_json(
+            r_json: Dict[str, Any] = self._get_json(
                 "sprintquery/%s?includeHistoricSprints=true&includeFutureSprints=true"
                 % board_id,
                 base=self.AGILE_BASE_URL,
@@ -3976,7 +4227,7 @@ class JIRA(object):
                     Sprint(
                         self._options,
                         self._session,
-                        self.sprint_info(None, raw_sprints_json["id"]),
+                        self.sprint_info("", raw_sprints_json["id"]),
                     )
                     for raw_sprints_json in r_json["sprints"]
                 ]
@@ -4030,17 +4281,18 @@ class JIRA(object):
 
         return json_loads(r)
 
-    def incompletedIssuesEstimateSum(self, board_id, sprint_id):
+    def incompletedIssuesEstimateSum(self, board_id: str, sprint_id: str):
         """Return the total incompleted points this sprint."""
-        return self._get_json(
+        data: Dict[str, Any] = self._get_json(
             "rapid/charts/sprintreport?rapidViewId=%s&sprintId=%s"
             % (board_id, sprint_id),
             base=self.AGILE_BASE_URL,
-        )["contents"]["incompletedIssuesEstimateSum"]["value"]
+        )
+        return data["contents"]["incompletedIssuesEstimateSum"]["value"]
 
-    def removed_issues(self, board_id, sprint_id):
+    def removed_issues(self, board_id: str, sprint_id: str):
         """Return the completed issues for the sprint."""
-        r_json = self._get_json(
+        r_json: Dict[str, Any] = self._get_json(
             "rapid/charts/sprintreport?rapidViewId=%s&sprintId=%s"
             % (board_id, sprint_id),
             base=self.AGILE_BASE_URL,
@@ -4052,33 +4304,35 @@ class JIRA(object):
 
         return issues
 
-    def removedIssuesEstimateSum(self, board_id, sprint_id):
+    def removedIssuesEstimateSum(self, board_id: str, sprint_id: str):
         """Return the total incompleted points this sprint."""
-        return self._get_json(
+        data: Dict[str, Any] = self._get_json(
             "rapid/charts/sprintreport?rapidViewId=%s&sprintId=%s"
             % (board_id, sprint_id),
             base=self.AGILE_BASE_URL,
-        )["contents"]["puntedIssuesEstimateSum"]["value"]
+        )
+        return data["contents"]["puntedIssuesEstimateSum"]["value"]
 
     # TODO(ssbarnea): remove sprint_info() method, sprint() method suit the convention more
-    def sprint_info(self, board_id, sprint_id):
+    def sprint_info(self, board_id: str, sprint_id: str) -> Optional[Dict[str, Any]]:
         """Return the information about a sprint.
 
-        :param board_id: the board retrieving issues from. Deprecated and ignored.
-        :param sprint_id: the sprint retrieving issues from
+        Args:
+            board_id (str): the board retrieving issues from. Deprecated and ignored.
+            sprint_id (str): the sprint retrieving issues from
         """
         sprint = Sprint(self._options, self._session)
         sprint.find(sprint_id)
         return sprint.raw
 
-    def sprint(self, id):
+    def sprint(self, id: int) -> Sprint:
         """Return the information about a sprint.
 
-        :param sprint_id: the sprint retrieving issues from
+        Args:
+            sprint_id (int): the sprint retrieving issues from
 
-        :type sprint_id: int
-
-        :rtype: :class:`~jira.resources.Sprint`
+        Returns:
+            Sprint
         """
         sprint = Sprint(self._options, self._session)
         sprint.find(id)
@@ -4091,24 +4345,25 @@ class JIRA(object):
         board.delete()
 
     def create_board(
-        self, name, project_ids, preset="scrum", location_type="user", location_id=None
-    ):
+        self,
+        name: str,
+        project_ids: Union[str, List[str]],
+        preset: str = "scrum",
+        location_type: str = "user",
+        location_id: Optional[str] = None,
+    ) -> Board:
         """Create a new board for the ``project_ids``.
 
-        :param name: name of the board
-        :type name: str
-        :param project_ids: the projects to create the board in
-        :type project_ids: str
-        :param preset: What preset to use for this board. (Default: scrum)
-        :type preset: kanban, scrum, diy
-        :param location_type: the location type. Available in cloud. (Default: user)
-        :type location_type: user, project
-        :param location_id: the id of project that the board should be
-            located under. Omit this for a 'user' location_type. Available in cloud.
-        :type location_id: Optional[str]
+        Args:
+            name (str): name of the board
+            project_ids (str): the projects to create the board in
+            preset (str): What preset to use for this board, options: kanban, scrum, diy. (Default: scrum)
+            location_type (str): the location type. Available in cloud. (Default: user)
+            location_id (Optional[str]): the id of project that the board should be located under.
+             Omit this for a 'user' location_type. Available in cloud.
 
-        :return: The newly created board
-        :rtype: Board
+        Returns:
+            Board: The newly created board
         """
         if (
             self._options["agile_rest_path"]
@@ -4118,7 +4373,7 @@ class JIRA(object):
                 "Jira Agile Public API does not support this request"
             )
 
-        payload = {}
+        payload: Dict[str, Any] = {}
         if isinstance(project_ids, str):
             ids = []
             for p in project_ids.split(","):
@@ -4128,7 +4383,7 @@ class JIRA(object):
             location_id = self.project(location_id).id
         payload["name"] = name
         if isinstance(project_ids, str):
-            project_ids = project_ids.split(",")
+            project_ids = project_ids.split(",")  # type: ignore # re-use of variable
         payload["projectIds"] = project_ids
         payload["preset"] = preset
         if self.deploymentType == "Cloud":
@@ -4140,27 +4395,31 @@ class JIRA(object):
         raw_issue_json = json_loads(r)
         return Board(self._options, self._session, raw=raw_issue_json)
 
-    def create_sprint(self, name, board_id, startDate=None, endDate=None):
+    def create_sprint(
+        self,
+        name: str,
+        board_id: int,
+        startDate: Optional[Any] = None,
+        endDate: Optional[Any] = None,
+    ) -> Sprint:
         """Create a new sprint for the ``board_id``.
 
-        :param name: Name of the sprint
-        :type name: str
-        :param board_id: Which board the sprint should be assigned.
-        :type board_id: int
-        :param startDate: Start date for the sprint.
-        :type startDate: Optional[Any]
-        :param endDate: End date for the sprint.
-        :type endDate: Optional[Any]
+        Args:
+            name (str): Name of the sprint
+            board_id (int): Which board the sprint should be assigned.
+            startDate (Optional[Any]): Start date for the sprint.
+            endDate (Optional[Any]): End date for the sprint.
 
-        :return: The newly created Sprint
-        :rtype: Sprint
+        Returns:
+            Sprint: The newly created Sprint
         """
-        payload = {"name": name}
+        payload: Dict[str, Any] = {"name": name}
         if startDate:
             payload["startDate"] = startDate
         if endDate:
             payload["endDate"] = endDate
 
+        raw_issue_json: Dict[str, Any]
         if (
             self._options["agile_rest_path"]
             == GreenHopperResource.GREENHOPPER_REST_PATH
@@ -4193,7 +4452,7 @@ class JIRA(object):
 
         return Sprint(self._options, self._session, raw=raw_issue_json)
 
-    def add_issues_to_sprint(self, sprint_id, issue_keys):
+    def add_issues_to_sprint(self, sprint_id: int, issue_keys: List[str]) -> Response:
         """Add the issues in ``issue_keys`` to the ``sprint_id``.
 
         The sprint must be started but not completed.
@@ -4206,18 +4465,18 @@ class JIRA(object):
         If a sprint was not started, then have to edit the marker and copy the
         rank of each issue too.
 
-        :param sprint_id: the sprint to add issues to
-        :type sprint_id: int
-        :param issue_keys: the issues to add to the sprint
-        :type issue_keys: List[str]
+        Args:
+            sprint_id (int): the sprint to add issues to
+            issue_keys (List[str]): the issues to add to the sprint
 
-        :rtype: Response
+        Returns:
+            Response
         """
         if self._options["agile_rest_path"] == GreenHopperResource.AGILE_BASE_REST_PATH:
             url = self._get_url("sprint/%s/issue" % sprint_id, base=self.AGILE_BASE_URL)
             payload = {"issues": issue_keys}
             try:
-                self._session.post(url, data=json.dumps(payload))
+                return self._session.post(url, data=json.dumps(payload))
             except JIRAError as e:
                 if e.status_code == 404:
                     warnings.warn(
@@ -4249,15 +4508,15 @@ class JIRA(object):
                 % self._options["agile_rest_path"]
             )
 
-    def add_issues_to_epic(self, epic_id, issue_keys, ignore_epics=True):
+    def add_issues_to_epic(
+        self, epic_id: int, issue_keys: str, ignore_epics: bool = True
+    ) -> Response:
         """Add the issues in ``issue_keys`` to the ``epic_id``.
 
-        :param epic_id: The ID for the epic where issues should be added.
-        :type epic_id: int
-        :param issue_keys: The issues to add to the epic
-        :type issue_keys: str
-        :param ignore_epics: ignore any issues listed in ``issue_keys`` that are epics. (Default: True)
-        :type ignore_epics: bool
+        Args:
+            epic_id (int): The ID for the epic where issues should be added.
+            issue_keys (str): The issues to add to the epic
+            ignore_epics (bool): ignore any issues listed in ``issue_keys`` that are epics. (Default: True)
 
         """
         if (
@@ -4269,18 +4528,19 @@ class JIRA(object):
                 "Jira Agile Public API does not support this request"
             )
 
-        data = {}
+        data: Dict[str, Any] = {}
         data["issueKeys"] = issue_keys
         data["ignoreEpics"] = ignore_epics
         url = self._get_url("epics/%s/add" % epic_id, base=self.AGILE_BASE_URL)
         return self._session.put(url, data=json.dumps(data))
 
     # TODO(ssbarnea): Both GreenHopper and new Jira Agile API support moving more than one issue.
-    def rank(self, issue, next_issue):
+    def rank(self, issue: str, next_issue: str) -> Response:
         """Rank an issue before another using the default Ranking field, the one named 'Rank'.
 
-        :param issue: issue key of the issue to be ranked before the second one.
-        :param next_issue: issue key of the second issue.
+        Args:
+            issue (str): issue key of the issue to be ranked before the second one.
+            next_issue (str): issue key of the second issue.
         """
         if not self._rank:
             for field in self.fields():
@@ -4331,19 +4591,20 @@ class JIRA(object):
                 % self._options["agile_rest_path"]
             )
 
-    def move_to_backlog(self, issue_keys):
+    def move_to_backlog(self, issue_keys: str) -> Response:
         """Move issues in ``issue_keys`` to the backlog, removing them from all sprints that have not been completed.
 
-        :param issue_keys: the issues to move to the backlog
-        :param issue_keys: str
+        Args:
+            issue_keys (str): the issues to move to the backlog
 
-        :raises JIRAError: If moving issues to backlog fails
+        Raises:
+            JIRAError: If moving issues to backlog fails
         """
         if self._options["agile_rest_path"] == GreenHopperResource.AGILE_BASE_REST_PATH:
             url = self._get_url("backlog/issue", base=self.AGILE_BASE_URL)
             payload = {"issues": issue_keys}
             try:
-                self._session.post(url, data=json.dumps(payload))
+                return self._session.post(url, data=json.dumps(payload))
             except JIRAError as e:
                 if e.status_code == 404:
                     warnings.warn(

--- a/jira/client.py
+++ b/jira/client.py
@@ -4509,12 +4509,12 @@ class JIRA(object):
             )
 
     def add_issues_to_epic(
-        self, epic_id: int, issue_keys: str, ignore_epics: bool = True
+        self, epic_id: str, issue_keys: str, ignore_epics: bool = True
     ) -> Response:
         """Add the issues in ``issue_keys`` to the ``epic_id``.
 
         Args:
-            epic_id (int): The ID for the epic where issues should be added.
+            epic_id (str): The ID for the epic where issues should be added.
             issue_keys (str): The issues to add to the epic
             ignore_epics (bool): ignore any issues listed in ``issue_keys`` that are epics. (Default: True)
 

--- a/jira/client.py
+++ b/jira/client.py
@@ -1268,7 +1268,9 @@ class JIRA(object):
 
         raw_issue_json = json_loads(r)
         if "key" not in raw_issue_json:
-            raise JIRAError(r.status_code, response=r, url=url, text=json.dumps(data))
+            raise JIRAError(
+                status_code=r.status_code, response=r, url=url, text=json.dumps(data)
+            )
         if prefetch:
             return self.issue(raw_issue_json["key"])
         else:
@@ -1380,7 +1382,7 @@ class JIRA(object):
         raw_customer_json = json_loads(r)
 
         if r.status_code != 201:
-            raise JIRAError(r.status_code, request=r)
+            raise JIRAError(status_code=r.status_code, request=r)
         return Customer(self._options, self._session, raw=raw_customer_json)
 
     def service_desks(self):
@@ -1455,7 +1457,7 @@ class JIRA(object):
 
         raw_issue_json = json_loads(r)
         if "issueKey" not in raw_issue_json:
-            raise JIRAError(r.status_code, request=r)
+            raise JIRAError(status_code=r.status_code, request=r)
         if prefetch:
             return self.issue(raw_issue_json["issueKey"])
         else:

--- a/jira/config.py
+++ b/jira/config.py
@@ -10,28 +10,36 @@ import configparser
 import logging
 import os
 import sys
+from typing import Optional
 
 from jira.client import JIRA
 
 
 def get_jira(
-    profile=None,
-    url="http://localhost:2990",
-    username="admin",
-    password="admin",
+    profile: Optional[str] = None,
+    url: str = "http://localhost:2990",
+    username: str = "admin",
+    password: str = "admin",
     appid=None,
     autofix=False,
-    verify=True,
+    verify: bool = True,
 ):
     """Return a JIRA object by loading the connection details from the `config.ini` file.
 
-    :param profile: The name of the section from config.ini file that stores server config url/username/password
-    :param url: URL of the Jira server
-    :param username: username to use for authentication
-    :param password: password to use for authentication
-    :param verify: boolean indicating whether SSL certificates should be verified
-    :return: JIRA -- an instance to a JIRA object.
-    :raises: EnvironmentError
+    Args:
+        profile (Optional[str]): The name of the section from config.ini file that stores server config url/username/password
+        url (str): URL of the Jira server
+        username (str): username to use for authentication
+        password (str): password to use for authentication
+        appid: appid
+        autofix: autofix
+        verify (bool): boolean indicating whether SSL certificates should be verified
+
+    Returns:
+        JIRA: an instance to a JIRA object.
+
+    Raises:
+        EnvironmentError
 
     Usage:
 

--- a/jira/exceptions.py
+++ b/jira/exceptions.py
@@ -2,6 +2,8 @@
 import os
 import tempfile
 
+from requests import Response
+
 
 class JIRAError(Exception):
     """General error raised for all problems in operation of the client."""
@@ -12,26 +14,22 @@ class JIRAError(Exception):
 
     def __init__(
         self,
-        status_code=None,
-        text=None,
-        url=None,
-        request=None,
-        response=None,
+        text: str = None,
+        status_code: int = None,
+        url: str = None,
+        request: Response = None,
+        response: Response = None,
         **kwargs
     ):
         """Creates a JIRAError.
 
-        :param status_code: Status code for the error.
-        :type status_code: Optional[int]
-        :param text: Message for the error.
-        :type text: Optional[str]
-        :param url: Url related to the error.
-        :type url: Optional[str]
-        :param request: Request made related to the error.
-        :type request: Optional[Any]
-        :param response: Response received related to the error.
-        :type response: Optional[Response]
-        :type kwargs: **Any
+        Args:
+            status_code (Optional[int]): Status code for the error.
+            text (Optional[str]): Message for the error.
+            url (Optional[str]): Url related to the error.
+            request (Optional[requests.Response]): Request made related to the error.
+            response (Optional[requests.Response]): Response received related to the error.
+            **kwargs: Will be used to get request headers.
         """
         self.status_code = status_code
         self.text = text
@@ -46,10 +44,11 @@ class JIRAError(Exception):
         if "TRAVIS" in os.environ:
             self.travis = True
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return a string representation of the error.
 
-        :rtype: str
+        Returns:
+            str
         """
         t = "JiraError HTTP %s" % self.status_code
         if self.url:

--- a/jira/exceptions.py
+++ b/jira/exceptions.py
@@ -24,8 +24,8 @@ class JIRAError(Exception):
         """Creates a JIRAError.
 
         Args:
-            status_code (Optional[int]): Status code for the error.
             text (Optional[str]): Message for the error.
+            status_code (Optional[int]): Status code for the error.
             url (Optional[str]): Url related to the error.
             request (Optional[requests.Response]): Request made related to the error.
             response (Optional[requests.Response]): Response received related to the error.

--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -51,11 +51,18 @@ def raise_on_error(r, verb="???", **kwargs):
             except ValueError:
                 error = r.text
         raise JIRAError(
-            r.status_code, error, r.url, request=request, response=r, **kwargs
+            error,
+            status_code=r.status_code,
+            url=r.url,
+            request=request,
+            response=r,
+            **kwargs
         )
     # for debugging weird errors on CI
     if r.status_code not in [200, 201, 202, 204]:
-        raise JIRAError(r.status_code, request=request, response=r, **kwargs)
+        raise JIRAError(
+            status_code=r.status_code, request=request, response=r, **kwargs
+        )
     # testing for the bug exposed on
     # https://answers.atlassian.com/questions/11457054/answers/11975162
     if (

--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -3,8 +3,9 @@ import json
 import logging
 import random
 import time
+from typing import Callable, Optional, Union, cast
 
-from requests import Session
+from requests import Response, Session
 from requests.exceptions import ConnectionError
 
 from jira.exceptions import JIRAError
@@ -12,7 +13,18 @@ from jira.exceptions import JIRAError
 logging.getLogger("jira").addHandler(logging.NullHandler())
 
 
-def raise_on_error(r, verb="???", **kwargs):
+def raise_on_error(r: Optional[Response], verb="???", **kwargs):
+    """Handle errors from a Jira Request
+
+    Args:
+        r (Optional[Response]): Response from Jira request
+        verb (Optional[str]): Request type, e.g. POST. Defaults to "???".
+
+    Raises:
+        JIRAError: If Response is None
+        JIRAError: for unhandled 400 status codes.
+        JIRAError: for unhandled 200 status codes.
+    """
     request = kwargs.get("request", None)
     # headers = kwargs.get('headers', None)
 
@@ -56,7 +68,7 @@ def raise_on_error(r, verb="???", **kwargs):
             url=r.url,
             request=request,
             response=r,
-            **kwargs
+            **kwargs,
         )
     # for debugging weird errors on CI
     if r.status_code not in [200, 201, 202, 204]:
@@ -88,8 +100,14 @@ class ResilientSession(Session):
         # Indicate our preference for JSON to avoid https://bitbucket.org/bspeakmon/jira-python/issue/46 and https://jira.atlassian.com/browse/JRA-38551
         self.headers.update({"Accept": "application/json,*.*;q=0.9"})
 
-    def __recoverable(self, response, url, request, counter=1):
-        msg = response
+    def __recoverable(
+        self,
+        response: Optional[Union[ConnectionError, Response]],
+        url: str,
+        request,
+        counter: int = 1,
+    ):
+        msg = str(response)
         if isinstance(response, ConnectionError):
             logging.warning(
                 "Got ConnectionError [%s] errno:%s on %s %s\n%s\n%s"
@@ -102,10 +120,10 @@ class ResilientSession(Session):
                     response.__dict__,
                 )
             )
-        if hasattr(response, "status_code"):
+        if isinstance(response, Response):
             if response.status_code in [502, 503, 504, 401]:
                 # 401 UNAUTHORIZED still randomly returned by Atlassian Cloud as of 2017-01-16
-                msg = "%s %s" % (response.status_code, response.reason)
+                msg = f"{response.status_code} {response.reason}"
                 # 2019-07-25: Disabled recovery for codes above^
                 return False
             elif not (
@@ -124,12 +142,15 @@ class ResilientSession(Session):
             "Got recoverable error from %s %s, will retry [%s/%s] in %ss. Err: %s"
             % (request, url, counter, self.max_retries, delay, msg)
         )
-        logging.debug("response.headers: %s", response.headers)
-        logging.debug("response.body: %s", response.content)
+        if isinstance(response, Response):
+            logging.debug("response.headers: %s", response.headers)
+            logging.debug("response.body: %s", response.content)
         time.sleep(delay)
         return True
 
-    def __verb(self, verb, url, retry_data=None, **kwargs):
+    def __verb(
+        self, verb: str, url: str, retry_data: Callable = None, **kwargs
+    ) -> Response:
 
         d = self.headers.copy()
         d.update(kwargs.get("headers", {}))
@@ -142,6 +163,8 @@ class ResilientSession(Session):
             data = json.dumps(data)
 
         retry_number = 0
+        exception = None
+        response = None
         while retry_number <= self.max_retries:
             response = None
             exception = None
@@ -173,25 +196,27 @@ class ResilientSession(Session):
         if exception is not None:
             raise exception
         raise_on_error(response, verb=verb, **kwargs)
+        # after raise_on_error, only Response objects are allowed through
+        response = cast(Response, response)  # tell mypy only Response-like are here
         return response
 
-    def get(self, url, **kwargs):
-        return self.__verb("GET", url, **kwargs)
+    def get(self, url: Union[str, bytes], **kwargs) -> Response:
+        return self.__verb("GET", str(url), **kwargs)
 
-    def post(self, url, **kwargs):
-        return self.__verb("POST", url, **kwargs)
+    def post(self, url: Union[str, bytes], data=None, json=None, **kwargs) -> Response:
+        return self.__verb("POST", str(url), data=data, json=json, **kwargs)
 
-    def put(self, url, **kwargs):
-        return self.__verb("PUT", url, **kwargs)
+    def put(self, url: Union[str, bytes], data=None, **kwargs) -> Response:
+        return self.__verb("PUT", str(url), data=data, **kwargs)
 
-    def delete(self, url, **kwargs):
-        return self.__verb("DELETE", url, **kwargs)
+    def delete(self, url: Union[str, bytes], **kwargs) -> Response:
+        return self.__verb("DELETE", str(url), **kwargs)
 
-    def head(self, url, **kwargs):
-        return self.__verb("HEAD", url, **kwargs)
+    def head(self, url: Union[str, bytes], **kwargs) -> Response:
+        return self.__verb("HEAD", str(url), **kwargs)
 
-    def patch(self, url, **kwargs):
-        return self.__verb("PATCH", url, **kwargs)
+    def patch(self, url: Union[str, bytes], data=None, **kwargs) -> Response:
+        return self.__verb("PATCH", str(url), data=data, **kwargs)
 
-    def options(self, url, **kwargs):
-        return self.__verb("OPTIONS", url, **kwargs)
+    def options(self, url: Union[str, bytes], **kwargs) -> Response:
+        return self.__verb("OPTIONS", str(url), **kwargs)

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -8,8 +8,15 @@ import json
 import logging
 import re
 import time
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union, cast
 
+from requests import Response
+
+from jira.resilientsession import ResilientSession
 from jira.utils import CaseInsensitiveDict, json_loads, threaded_requests
+
+if TYPE_CHECKING:
+    from jira.client import JIRA
 
 __all__ = (
     "Resource",
@@ -44,14 +51,14 @@ __all__ = (
 logging.getLogger("jira").addHandler(logging.NullHandler())
 
 
-def get_error_list(r):
+def get_error_list(r: Response) -> List[str]:
     error_list = []
     if r.status_code >= 400:
         if r.status_code == 403 and "x-authentication-denied-reason" in r.headers:
             error_list = [r.headers["x-authentication-denied-reason"]]
         elif r.text:
             try:
-                response = json_loads(r)
+                response: Dict[str, Any] = json_loads(r)
                 if "message" in response:
                     # Jira 5.1 errors
                     error_list = [response["message"]]
@@ -60,7 +67,7 @@ def get_error_list(r):
                     # Sometimes this is present but empty
                     errorMessages = response["errorMessages"]
                     if isinstance(errorMessages, (list, tuple)):
-                        error_list = errorMessages
+                        error_list = list(errorMessages)
                     else:
                         error_list = [errorMessages]
                 elif "errors" in response and len(response["errors"]) > 0:
@@ -115,16 +122,20 @@ class Resource(object):
         "closed",
     )
 
-    def __init__(self, resource, options, session, base_url=JIRA_BASE_URL):
+    def __init__(
+        self,
+        resource: str,
+        options: Dict[str, Any],
+        session: ResilientSession,
+        base_url: str = JIRA_BASE_URL,
+    ):
         """Initializes a generic resource.
-        :param resource: The name of the resource.
-        :type resource: str
-        :param options: Options for the new resource
-        :type options: Dict[str,str]
-        :param session: Session used for the resource.
-        :type session: ResilientSession
-        :param base_url: The Base Jira url.
-        :type base_url: Optional[str]
+
+        Args:
+            resource (str): The name of the resource.
+            options (Dict[str,str]): Options for the new resource
+            session (ResilientSession): Session used for the resource.
+            base_url (Optional[str]): The Base Jira url.
 
         """
         self._resource = resource
@@ -134,12 +145,13 @@ class Resource(object):
 
         # Explicitly define as None so we know when a resource has actually
         # been loaded
-        self.raw = None
+        self.raw: Optional[Dict[str, Any]] = None
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return the first value we find that is likely to be human readable.
 
-        :rtype: str
+        Returns:
+            str
         """
         if self.raw:
             for name in self._READABLE_IDS:
@@ -153,12 +165,13 @@ class Resource(object):
         # If all else fails, use repr to make sure we get something.
         return repr(self)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Identify the class and include any and all relevant values.
 
-        :rtype: str
+        Returns:
+            str
         """
-        names = []
+        names: List[str] = []
         if self.raw:
             for name in self._READABLE_IDS:
                 if name in self.raw:
@@ -167,20 +180,21 @@ class Resource(object):
             return "<JIRA %s at %s>" % (self.__class__.__name__, id(self))
         return "<JIRA %s: %s>" % (self.__class__.__name__, ", ".join(names))
 
-    def __getattr__(self, item):
+    def __getattr__(self, item: str):
         """Allow access of attributes via names.
 
-        :param item: Attribute name
-        :type item: str
+        Args:
+            item (str): Attribute Name
 
-        :rtype: Any
+        Raises:
+            KeyError: When the attribute does not exist.
+            AttributeError: When attribute does not exist.
 
-        :raises KeyError: When the attribute does not exist.
-        :raises AttributeError: When attribute does not exist.
-
+        Returns:
+            Any: Attribute value.
         """
         try:
-            return self[item]
+            return self[item]  # type: ignore
         except Exception as e:
             # Make sure pickling doesn't break
             #   *MORE INFO*: This conditional wouldn't be necessary if __getattr__ wasn't used. But
@@ -193,7 +207,7 @@ class Resource(object):
             if item == "__getnewargs__":
                 raise KeyError(item)
 
-            if hasattr(self, "raw") and item in self.raw:
+            if hasattr(self, "raw") and self.raw is not None and item in self.raw:
                 return self.raw[item]
             else:
                 raise AttributeError(
@@ -213,11 +227,16 @@ class Resource(object):
     #     self._parse_raw(raw_pickled)
     #
 
-    def find(self, id, params=None):
+    def find(
+        self,
+        id: Union[Tuple[str, str], int, str],
+        params: Optional[Dict[str, str]] = None,
+    ):
         """Finds a resource based on the input parameters.
 
-        :type id: Union[Tuple[str, str], int, str]
-        :type params: Optional[Dict[str, str]]
+        Args:
+            id (Union[Tuple[str, str], int, str]): id
+            params (Optional[Dict[str, str]]): params
 
         """
 
@@ -231,51 +250,54 @@ class Resource(object):
         url = self._get_url(path)
         self._load(url, params=params)
 
-    def _get_url(self, path):
+    def _get_url(self, path: str) -> str:
         """Gets the url for the specified path.
 
-        :type path: str
+        Args:
+            path (str): str
 
-        :rtype: str
-
+        Returns:
+            str
         """
         options = self._options.copy()
         options.update({"path": path})
         return self._base_url.format(**options)
 
-    def update(self, fields=None, async_=None, jira=None, notify=True, **kwargs):
+    def update(
+        self,
+        fields: Optional[Dict[str, Any]] = None,
+        async_: Optional[bool] = None,
+        jira: "JIRA" = None,
+        notify: bool = True,
+        **kwargs: Any
+    ):
         """Update this resource on the server.
 
         Keyword arguments are marshalled into a dict before being sent. If this
         resource doesn't support ``PUT``, a :py:exc:`.JIRAError` will be raised; subclasses that specialize this method
         will only raise errors in case of user error.
 
-        :param fields: Fields which should be updated for the object.
-        :type fields: Optional[Dict[str, Any]]
-        :param async_: If true the request will be added to the queue so it can be executed later using async_run()
-        :type async_: bool
-        :param jira: Instance of Jira Client
-        :type jira: jira.JIRA
-        :param notify: Whether or not to notify users about the update. (Default: True)
-        :type notify: bool
-        :type kwargs: **Any
+        Args:
+            fields (Optional[Dict[str, Any]]): Fields which should be updated for the object.
+            async_ (bool): If true the request will be added to the queue so it can be executed later using async_run()
+            jira (jira.client.JIRA): Instance of Jira Client
+            notify (bool): Whether or not to notify users about the update. (Default: True)
+            kwargs (Any): extra arguments to the PUT request.
         """
         if async_ is None:
-            async_ = self._options["async"]
+            async_: bool = self._options["async"]  # type: ignore # redefinition
 
         data = {}
         if fields is not None:
             data.update(fields)
         data.update(kwargs)
 
-        data = json.dumps(data)
-
         if not notify:
             querystring = "?notifyUsers=false"
         else:
             querystring = ""
 
-        r = self._session.put(self.self + querystring, data=data)
+        r = self._session.put(self.self + querystring, data=json.dumps(data))
         if "autofix" in self._options and r.status_code == 400:
             user = None
             error_list = get_error_list(r)
@@ -330,7 +352,7 @@ class Resource(object):
                     else:
                         raise NotImplementedError()
 
-            if user:
+            if user and jira:
                 logging.warning(
                     "Trying to add missing orphan user '%s' in order to complete the previous failed operation."
                     % user
@@ -340,11 +362,13 @@ class Resource(object):
                 #    logging.warning("autofix: setting assignee to '%s' and retrying the update." % self._options['autofix'])
                 #    data['fields']['assignee'] = {'name': self._options['autofix']}
             # EXPERIMENTAL --->
-            if async_:
+            if async_:  # FIXME: no async
                 if not hasattr(self._session, "_async_jobs"):
-                    self._session._async_jobs = set()
-                self._session._async_jobs.add(
-                    threaded_requests.put(self.self, data=json.dumps(data))
+                    self._session._async_jobs = set()  # type: ignore
+                self._session._async_jobs.add(  # type: ignore
+                    threaded_requests.put(  # type: ignore
+                        self.self, data=json.dumps(data)
+                    )
                 )
             else:
                 r = self._session.put(self.self, data=json.dumps(data))
@@ -352,35 +376,47 @@ class Resource(object):
         time.sleep(self._options["delay_reload"])
         self._load(self.self)
 
-    def delete(self, params=None):
+    def delete(self, params: Optional[Dict[str, Any]] = None) -> Optional[Response]:
         """Delete this resource from the server, passing the specified query parameters.
 
         If this resource doesn't support ``DELETE``, a :py:exc:`.JIRAError`
         will be raised; subclasses that specialize this method will only raise errors
         in case of user error.
 
-        :param params: Parameters for the delete request.
-        :type params: Optional[Dict[str, Any]]
+        Args:
+            params: Parameters for the delete request.
 
-        :rtype: Response
+        Returns:
+            Optional[Response]: Returns None if async
         """
         if self._options["async"]:
+            # FIXME: mypy doesn't think this should work
             if not hasattr(self._session, "_async_jobs"):
-                self._session._async_jobs = set()
-            self._session._async_jobs.add(
-                threaded_requests.delete(url=self.self, params=params)
+                self._session._async_jobs = set()  # type: ignore
+            self._session._async_jobs.add(  # type: ignore
+                threaded_requests.delete(url=self.self, params=params)  # type: ignore
             )
+            return None
         else:
             return self._session.delete(url=self.self, params=params)
 
-    def _load(self, url, headers=CaseInsensitiveDict(), params=None, path=None):
+    def _load(
+        self,
+        url: str,
+        headers=CaseInsensitiveDict(),
+        params: Optional[Dict[str, str]] = None,
+        path: Optional[str] = None,
+    ):
         """Load a resource.
 
-        :type url: str
-        :type headers: CaseInsensitiveDict
-        :type params: Optional[Dict[str,str]]
-        :type path: Optional[str]
+        Args:
+            url (str): url
+            headers (Optional[CaseInsensitiveDict]): headers. Defaults to CaseInsensitiveDict().
+            params (Optional[Dict[str,str]]): params to get request. Defaults to None.
+            path (Optional[str]): field to get. Defaults to None.
 
+        Raises:
+            ValueError: If json cannot be loaded
         """
         r = self._session.get(url, headers=headers, params=params)
         try:
@@ -392,10 +428,11 @@ class Resource(object):
             j = j[path]
         self._parse_raw(j)
 
-    def _parse_raw(self, raw):
+    def _parse_raw(self, raw: Dict[str, Any]):
         """Parse a raw dictionary to create a resource.
 
-        :type raw: Dict[str, Any]
+        Args:
+            raw (Dict[str, Any])
         """
         self.raw = raw
         if not raw:
@@ -413,7 +450,12 @@ class Resource(object):
 class Attachment(Resource):
     """An issue attachment."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "attachment/{0}", options, session)
         if raw:
             self._parse_raw(raw)
@@ -432,15 +474,21 @@ class Attachment(Resource):
 class Component(Resource):
     """A project component."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "component/{0}", options, session)
         if raw:
             self._parse_raw(raw)
 
-    def delete(self, moveIssuesTo=None):
+    def delete(self, moveIssuesTo: Optional[str] = None):  # type: ignore[override]
         """Delete this component from the server.
 
-        :param moveIssuesTo: the name of the component to which to move any issues this component is applied
+        Args:
+            moveIssuesTo: the name of the component to which to move any issues this component is applied
         """
         params = {}
         if moveIssuesTo is not None:
@@ -452,7 +500,12 @@ class Component(Resource):
 class CustomFieldOption(Resource):
     """An existing option for a custom issue field."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "customFieldOption/{0}", options, session)
         if raw:
             self._parse_raw(raw)
@@ -461,7 +514,12 @@ class CustomFieldOption(Resource):
 class Dashboard(Resource):
     """A Jira dashboard."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "dashboard/{0}", options, session)
         if raw:
             self._parse_raw(raw)
@@ -470,7 +528,12 @@ class Dashboard(Resource):
 class Filter(Resource):
     """An issue navigator filter."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "filter/{0}", options, session)
         if raw:
             self._parse_raw(raw)
@@ -481,33 +544,36 @@ class Issue(Resource):
 
     class _IssueFields(object):
         def __init__(self):
-            self.attachment = None
-            """ :type : list[Attachment] """
-            self.description = None
-            """ :type : str """
-            self.project = None
-            """ :type : Project """
-            self.comment = None
-            """ :type : list[Comment] """
-            self.issuelinks = None
-            """ :type : list[IssueLink] """
-            self.worklog = None
-            """ :type : list[Worklog] """
+            self.attachment: Optional[List[Attachment]] = None
+            self.comment: Optional[List[Comment]] = None
+            self.description: Optional[str] = None
+            self.issuelinks: Optional[List[IssueLink]] = None
+            self.labels: Optional[List[str]] = None
+            self.project: Optional[Project] = None
+            self.worklog: Optional[List[Worklog]] = None
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "issue/{0}", options, session)
 
-        self.fields = None
-        """ :type: :class:`~Issue._IssueFields` """
-        self.id = None
-        """ :type: int """
-        self.key = None
-        """ :type: str """
+        self.fields: Optional[Issue._IssueFields] = None
+        self.id: Optional[int] = None
+        self.key: Optional[str] = None
         if raw:
             self._parse_raw(raw)
 
-    def update(
-        self, fields=None, update=None, async_=None, jira=None, notify=True, **fieldargs
+    def update(  # type: ignore # incompatible supertype ignored
+        self,
+        fields: Dict[str, Any] = None,
+        update: Dict[str, Any] = None,
+        async_: bool = None,
+        jira: "JIRA" = None,
+        notify: bool = True,
+        **fieldargs
     ):
         """Update this issue on the server.
 
@@ -519,15 +585,14 @@ class Issue(Resource):
         fields in an issue. This information is available through the :py:meth:`.JIRA.editmeta` method. Further examples
         are available here: https://developer.atlassian.com/display/JIRADEV/JIRA+REST+API+Example+-+Edit+issues
 
-        :param fields: a dict containing field names and the values to use
-        :param update: a dict containing update operations to apply
-        :param notify: query parameter notifyUsers. If true send the email with notification that the issue was updated
-                       to users that watch it. Admin or project admin permissions are required to disable the notification.
-        :param fieldargs: keyword arguments will generally be merged into fields, except lists,
-                          which will be merged into updates
-
-        :type fields: dict
-        :type update: dict
+        Args:
+            fields (Dict[str,Any]): a dict containing field names and the values to use
+            update (Dict[str,Any]): a dict containing update operations to apply
+            notify (bool): query parameter notifyUsers. If true send the email with notification that the issue was updated
+              to users that watch it. Admin or project admin permissions are required to disable the notification.
+            jira (Optional[jira.client.JIRA]): JIRA instance.
+            fieldargs (dict): keyword arguments will generally be merged into fields, except lists,
+              which will be merged into updates
 
         """
         data = {}
@@ -562,33 +627,32 @@ class Issue(Resource):
 
         super(Issue, self).update(async_=async_, jira=jira, notify=notify, fields=data)
 
-    def add_field_value(self, field, value):
+    def add_field_value(self, field: str, value: str):
         """Add a value to a field that supports multiple values, without resetting the existing values.
 
         This should work with: labels, multiple checkbox lists, multiple select
 
-        :param field: The field name
-        :param value: The field's value
+        Args:
+            field (str): The field name
+            value (str): The field's value
 
-        :type field: str
         """
         super(Issue, self).update(fields={"update": {field: [{"add": value}]}})
 
     def delete(self, deleteSubtasks=False):
         """Delete this issue from the server.
 
-        :param deleteSubtasks: if the issue has subtasks, this argument must be set to true for the call to succeed.
+        Args:
+            deleteSubtasks (bool): if the issue has subtasks, this argument must be set to true for the call to succeed.
 
-        :type deleteSubtasks: bool
         """
         super(Issue, self).delete(params={"deleteSubtasks": deleteSubtasks})
 
     def permalink(self):
         """Get the URL of the issue, the browsable one not the REST one.
 
-        :return: URL of the issue
-
-        :rtype: str
+        Returns:
+            str: URL of the issue
         """
         return "%s/browse/%s" % (self._options["server"], self.key)
 
@@ -600,7 +664,12 @@ class Issue(Resource):
 class Comment(Resource):
     """An issue comment."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "issue/{0}/comment/{1}", options, session)
         if raw:
             self._parse_raw(raw)
@@ -618,7 +687,12 @@ class Comment(Resource):
 class RemoteLink(Resource):
     """A link to a remote application from an issue."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "issue/{0}/remotelink/{1}", options, session)
         if raw:
             self._parse_raw(raw)
@@ -629,10 +703,11 @@ class RemoteLink(Resource):
         For definitions of the allowable fields for 'object' and the keyword arguments 'globalId', 'application' and
         'relationship', see https://developer.atlassian.com/display/JIRADEV/JIRA+REST+API+for+Remote+Issue+Links.
 
-        :param object: the link details to add (see the above link for details)
-        :param globalId: unique ID for the link (see the above link for details)
-        :param application: application information for the link (see the above link for details)
-        :param relationship: relationship description for the link (see the above link for details)
+        Args:
+            object: the link details to add (see the above link for details)
+            globalId: unique ID for the link (see the above link for details)
+            application: application information for the link (see the above link for details)
+            relationship: relationship description for the link (see the above link for details)
         """
         data = {"object": object}
         if globalId is not None:
@@ -648,7 +723,12 @@ class RemoteLink(Resource):
 class Votes(Resource):
     """Vote information on an issue."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "issue/{0}/votes", options, session)
         if raw:
             self._parse_raw(raw)
@@ -657,7 +737,12 @@ class Votes(Resource):
 class Watchers(Resource):
     """Watcher information on an issue."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "issue/{0}/watchers", options, session)
         if raw:
             self._parse_raw(raw)
@@ -668,7 +753,12 @@ class Watchers(Resource):
 
 
 class TimeTracking(Resource):
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "issue/{0}/worklog/{1}", options, session)
         self.remainingEstimate = None
         if raw:
@@ -678,19 +768,27 @@ class TimeTracking(Resource):
 class Worklog(Resource):
     """Worklog on an issue."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "issue/{0}/worklog/{1}", options, session)
         if raw:
             self._parse_raw(raw)
 
-    def delete(self, adjustEstimate=None, newEstimate=None, increaseBy=None):
+    def delete(  # type: ignore[override]
+        self, adjustEstimate: Optional[str] = None, newEstimate=None, increaseBy=None
+    ):
         """Delete this worklog entry from its associated issue.
 
-        :param adjustEstimate: one of ``new``, ``leave``, ``manual`` or ``auto``.
-            ``auto`` is the default and adjusts the estimate automatically.
-            ``leave`` leaves the estimate unchanged by this deletion.
-        :param newEstimate: combined with ``adjustEstimate=new``, set the estimate to this value
-        :param increaseBy: combined with ``adjustEstimate=manual``, increase the remaining estimate by this amount
+        Args:
+            adjustEstimate: one of ``new``, ``leave``, ``manual`` or ``auto``.
+              ``auto`` is the default and adjusts the estimate automatically.
+              ``leave`` leaves the estimate unchanged by this deletion.
+            newEstimate: combined with ``adjustEstimate=new``, set the estimate to this value
+            increaseBy: combined with ``adjustEstimate=manual``, increase the remaining estimate by this amount
         """
         params = {}
         if adjustEstimate is not None:
@@ -706,7 +804,12 @@ class Worklog(Resource):
 class IssueLink(Resource):
     """Link between two issues."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "issueLink/{0}", options, session)
         if raw:
             self._parse_raw(raw)
@@ -715,7 +818,12 @@ class IssueLink(Resource):
 class IssueLinkType(Resource):
     """Type of link between two issues."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "issueLinkType/{0}", options, session)
         if raw:
             self._parse_raw(raw)
@@ -724,7 +832,12 @@ class IssueLinkType(Resource):
 class IssueType(Resource):
     """Type of an issue."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "issuetype/{0}", options, session)
         if raw:
             self._parse_raw(raw)
@@ -733,7 +846,12 @@ class IssueType(Resource):
 class Priority(Resource):
     """Priority that can be set on an issue."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "priority/{0}", options, session)
         if raw:
             self._parse_raw(raw)
@@ -742,7 +860,12 @@ class Priority(Resource):
 class Project(Resource):
     """A Jira project."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "project/{0}", options, session)
         if raw:
             self._parse_raw(raw)
@@ -751,18 +874,26 @@ class Project(Resource):
 class Role(Resource):
     """A role inside a project."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "project/{0}/role/{1}", options, session)
         if raw:
             self._parse_raw(raw)
 
-    def update(self, users=None, groups=None):
+    def update(  # type: ignore[override]
+        self,
+        users: Union[str, List, Tuple] = None,
+        groups: Union[str, List, Tuple] = None,
+    ):
         """Add the specified users or groups to this project role. One of ``users`` or ``groups`` must be specified.
 
-        :param users: a user or users to add to the role
-        :type users: string, list or tuple
-        :param groups: a group or groups to add to the role
-        :type groups: string, list or tuple
+        Args:
+            users (Optional[Union[str,List,Tuple]]): a user or users to add to the role
+            groups (Optional[Union[str,List,Tuple]]): a group or groups to add to the role
         """
 
         if users is not None and isinstance(users, str):
@@ -780,15 +911,18 @@ class Role(Resource):
 
         super(Role, self).update(**data)
 
-    def add_user(self, users=None, groups=None):
+    def add_user(
+        self,
+        users: Union[str, List, Tuple] = None,
+        groups: Union[str, List, Tuple] = None,
+    ):
         """Add the specified users or groups to this project role.
 
         One of ``users`` or ``groups`` must be specified.
 
-        :param users: a user or users to add to the role
-        :type users: string, list or tuple
-        :param groups: a group or groups to add to the role
-        :type groups: string, list or tuple
+        Args:
+            users (Optional[Union[str,List,Tuple]]): a user or users to add to the role
+            groups (Optional[Union[str,List,Tuple]]): a group or groups to add to the role
         """
 
         if users is not None and isinstance(users, str):
@@ -796,14 +930,19 @@ class Role(Resource):
         if groups is not None and isinstance(groups, str):
             groups = (groups,)
 
-        data = {"user": users}
+        data = {"user": users}  # FIXME: groups is not used.
         self._session.post(self.self, data=json.dumps(data))
 
 
 class Resolution(Resource):
     """A resolution for an issue."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "resolution/{0}", options, session)
         if raw:
             self._parse_raw(raw)
@@ -812,7 +951,12 @@ class Resolution(Resource):
 class SecurityLevel(Resource):
     """A security level for an issue or project."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "securitylevel/{0}", options, session)
         if raw:
             self._parse_raw(raw)
@@ -821,7 +965,12 @@ class SecurityLevel(Resource):
 class Status(Resource):
     """Status for an issue."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "status/{0}", options, session)
         if raw:
             self._parse_raw(raw)
@@ -830,7 +979,12 @@ class Status(Resource):
 class StatusCategory(Resource):
     """StatusCategory for an issue."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "statuscategory/{0}", options, session)
         if raw:
             self._parse_raw(raw)
@@ -839,7 +993,12 @@ class StatusCategory(Resource):
 class User(Resource):
     """A Jira user."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "user?username={0}", options, session)
         if raw:
             self._parse_raw(raw)
@@ -856,7 +1015,12 @@ class User(Resource):
 class Group(Resource):
     """A Jira user group."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "group?groupname={0}", options, session)
         if raw:
             self._parse_raw(raw)
@@ -873,7 +1037,12 @@ class Group(Resource):
 class Version(Resource):
     """A version of a project."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "version/{0}", options, session)
         if raw:
             self._parse_raw(raw)
@@ -884,10 +1053,11 @@ class Version(Resource):
         If neither of the arguments are specified, the version is
             removed from all issues it is attached to.
 
-        :param moveFixIssuesTo: in issues for which this version is a fix
-            version, add this argument version to the fix version list
-        :param moveAffectedIssuesTo: in issues for which this version is an
-            affected version, add this argument version to the affected version list
+        Args:
+            moveFixIssuesTo: in issues for which this version is a fix
+              version, add this argument version to the fix version list
+            moveAffectedIssuesTo: in issues for which this version is an
+              affected version, add this argument version to the affected version list
         """
 
         params = {}
@@ -926,7 +1096,13 @@ class GreenHopperResource(Resource):
     AGILE_BASE_REST_PATH = "agile"
     """ Public API introduced in Jira Agile 6.7.7. """
 
-    def __init__(self, path, options, session, raw):
+    def __init__(
+        self,
+        path: str,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         self.self = None
 
         Resource.__init__(self, path, options, session, self.AGILE_BASE_URL)
@@ -940,7 +1116,12 @@ class GreenHopperResource(Resource):
 class Sprint(GreenHopperResource):
     """A GreenHopper sprint."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         GreenHopperResource.__init__(self, "sprint/{0}", options, session, raw)
 
     def find(self, id, params=None):
@@ -958,7 +1139,12 @@ class Sprint(GreenHopperResource):
 class Board(GreenHopperResource):
     """A GreenHopper board."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         path = (
             "rapidview/{0}"
             if options["agile_rest_path"] == self.GREENHOPPER_REST_PATH
@@ -984,7 +1170,12 @@ class Board(GreenHopperResource):
 class Customer(Resource):
     """A Service Desk customer."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(
             self, "customer", options, session, "{server}/rest/servicedeskapi/{path}"
         )
@@ -995,7 +1186,12 @@ class Customer(Resource):
 class ServiceDesk(Resource):
     """A Service Desk."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(
             self,
             "servicedesk/{0}",
@@ -1010,7 +1206,12 @@ class ServiceDesk(Resource):
 class RequestType(Resource):
     """A Service Desk Request Type."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         if raw:
             self._parse_raw(raw)
 
@@ -1026,7 +1227,9 @@ class RequestType(Resource):
 # Utilities
 
 
-def dict2resource(raw, top=None, options=None, session=None):
+def dict2resource(
+    raw: Dict[str, Any], top=None, options=None, session=None
+) -> Union["PropertyHolder", Type[Resource]]:
     """Convert a dictionary into a Jira Resource object.
 
     Recursively walks a dict structure, transforming the properties into attributes
@@ -1040,19 +1243,36 @@ def dict2resource(raw, top=None, options=None, session=None):
     for i, j in raw.items():
         if isinstance(j, dict):
             if "self" in j:
-                resource = cls_for_resource(j["self"])(options, session, j)
+                # to try and help mypy know that cls_for_resource can never be 'Resource'
+                resource_class = cast(Type[Resource], cls_for_resource(j["self"]))
+                resource = cast(
+                    Type[Resource],
+                    resource_class(  # type: ignore
+                        options=options, session=session, raw=j  # type: ignore
+                    ),
+                )
                 setattr(top, i, resource)
             elif i == "timetracking":
                 setattr(top, "timetracking", TimeTracking(options, session, j))
             else:
                 setattr(top, i, dict2resource(j, options=options, session=session))
         elif isinstance(j, seqs):
-            seq_list = []
+            j = cast(List[Dict[str, Any]], j)  # help mypy
+            seq_list: List[Any] = []
             for seq_elem in j:
                 if isinstance(seq_elem, dict):
                     if "self" in seq_elem:
-                        resource = cls_for_resource(seq_elem["self"])(
-                            options, session, seq_elem
+                        # to try and help mypy know that cls_for_resource can never be 'Resource'
+                        resource_class = cast(
+                            Type[Resource], cls_for_resource(seq_elem["self"])
+                        )
+                        resource = cast(
+                            Type[Resource],
+                            resource_class(  # type: ignore
+                                options=options,
+                                session=session,
+                                raw=seq_elem,  # type: ignore
+                            ),
                         )
                         seq_list.append(resource)
                     else:
@@ -1067,7 +1287,7 @@ def dict2resource(raw, top=None, options=None, session=None):
     return top
 
 
-resource_class_map = {
+resource_class_map: Dict[str, Type[Resource]] = {
     # Jira-specific resources
     r"attachment/[^/]+$": Attachment,
     r"component/[^/]+$": Component,
@@ -1101,13 +1321,18 @@ resource_class_map = {
 class UnknownResource(Resource):
     """A Resource from Jira that is not (yet) supported."""
 
-    def __init__(self, options, session, raw=None):
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
         Resource.__init__(self, "unknown{0}", options, session)
         if raw:
             self._parse_raw(raw)
 
 
-def cls_for_resource(resource_literal):
+def cls_for_resource(resource_literal: str) -> Type[Resource]:
     for resource in resource_class_map:
         if re.search(resource, resource_literal):
             return resource_class_map[resource]

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -543,14 +543,22 @@ class Issue(Resource):
     """A Jira issue."""
 
     class _IssueFields(object):
+        class _Comment(object):
+            def __init__(self) -> None:
+                self.comments: List[Comment] = []
+
+        class _Worklog(object):
+            def __init__(self) -> None:
+                self.worklogs: List[Worklog] = []
+
         def __init__(self):
-            self.attachment: Optional[List[Attachment]] = None
-            self.comment: Optional[List[Comment]] = None
+            self.attachment: List[Attachment] = []
+            self.comment = self._Comment()
             self.description: Optional[str] = None
-            self.issuelinks: Optional[List[IssueLink]] = None
-            self.labels: Optional[List[str]] = None
+            self.issuelinks: List[IssueLink] = []
+            self.labels: List[str] = []
             self.project: Optional[Project] = None
-            self.worklog: Optional[List[Worklog]] = None
+            self.worklog = self._Worklog()
 
     def __init__(
         self,
@@ -560,13 +568,13 @@ class Issue(Resource):
     ):
         Resource.__init__(self, "issue/{0}", options, session)
 
-        self.fields: Optional[Issue._IssueFields] = None
-        self.id: Optional[int] = None
-        self.key: Optional[str] = None
+        self.fields: Issue._IssueFields
+        self.id: str
+        self.key: str
         if raw:
             self._parse_raw(raw)
 
-    def update(  # type: ignore # incompatible supertype ignored
+    def update(  # type: ignore[override] # incompatible supertype ignored
         self,
         fields: Dict[str, Any] = None,
         update: Dict[str, Any] = None,

--- a/jira/utils/__init__.py
+++ b/jira/utils/__init__.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 """Jira utils used internally."""
 import threading
+from typing import Any, Optional, cast
+
+from requests import Response
 
 from jira.resilientsession import raise_on_error
 
@@ -28,7 +31,7 @@ class CaseInsensitiveDict(dict):
     of how the header name was originally stored.
 
     If the constructor, ``.update``, or equality comparison
-    operations are given keys that have equal ``.lower()``s, the
+    operations are given keys that have equal ``.lower()`` s, the
     behavior is undefined.
 
     """
@@ -71,8 +74,20 @@ def threaded_requests(requests):
             th.join()
 
 
-def json_loads(r):
-    raise_on_error(r)
+def json_loads(r: Optional[Response]) -> Any:
+    """Attempts to load json the result of a response
+
+    Args:
+        r (Optional[Response]): The Response object
+
+    Raises:
+        JIRAError: via :py:func:`jira.resilientsession.raise_on_error`
+
+    Returns:
+        Union[List[Dict[str, Any]], Dict[str, Any]]: the json
+    """
+    raise_on_error(r)  # if 'r' is None, will raise an error here
+    r = cast(Response, r)  # tell mypy only Response-like are here
     try:
         return r.json()
     except ValueError:

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,6 +79,9 @@ async =
 console_scripts =
     jirashell = jira.jirashell:main
 
+[options.package_data]
+jira = jira/py.typed
+
 [egg_info]
 egg_base = .
 


### PR DESCRIPTION
## Summary of Changes
1. Add typehints, coaxing mypy where required - i.e. `typing.cast` ,`isinstance()` and as a last resort `assert` 
2. Re-order `JIRAError` argument order to reflect how the base `Exception` class is used, i.e. first argument is a string, prevent misuse of `status_code` for a string of an error message
3. Allow "Google style" docstrings, allowing for more legible docstrings
4. The `basic_use.py` no longer worked, since GDPR the `emailAddress` property has been removed, changing the field used in the example to `.key` at least makes it run fine.
5. Partially (maybe fully?) address #1009 in order to satisfy mypy, refer to commit: "bugfix: respect logging argument" (https://github.com/pycontribs/jira/pull/1023/commits/cc504a1dc5a3975fc6ad1955b6fbf001577038c9).  
#329 review comments were checked, I don't feel the logging changes made here are particularly contentious - they didn't intend to be. I think a further PR should be raised if anything more needs to be done - as the changes here we mainly for the mypy fixes.
The implementation chosen imports `logging` as `_logging`, this should further prevent a developer accidentally using the raw logging module. Exposing the logger under `self.log` may also allow user to use the logger if they monkey patch or base class of the JIRA class.


~~This branch is currently based of the isort branch~~ now rebased

####  Todo:
- [x] ~~Document logging bug fixed on the client.py side, may need changes to the other classes, e.g.  resilient session~~ should be a separate PR if anything further is required than what was added to fix mypy
- [x] Document fix of JIRAError class, argument order causing misuse
- [x] ~~Convert `str = None` to `Optional[str] = None`  if the function has an actual none check~~ not required as inferred by mypy, could maybe check they are added to the docstrings, but might take that up in another PR, a bit burnt out as I severely under estimated the work required here haha
- [x] Check the actual docs build looks ok
- [x] do some more google style docstrings if you aren't tired of them yet, resources.py has a few left
- [x] where possible, convert assertions to properly typehinted variables
- [x] cleanup the commit history, no point separating by files as they all need to work together for mypy to be happy