### PR TITLE
Remove .idea folder as it messes up pycharm checkouts (intelij idea folder structure has changed since end 2017)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,0 @@
-# EditorConfig is awesome: https://editorconfig.org/
-
-# top-most EditorConfig file
-root = true
-
-[*]
-max_line_length = 160

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
-# See https://stackoverflow.com/questions/5533050/gitignore-exclude-folder-but-include-specific-subfolder
-# to understand pattern used to include .idea/codeStyleSettings.xml but not the rest of .idea/
-!.idea/
-.idea/*
-!.idea/codeStyleSettings.xml
+.idea
 *.bak
 *.egg
 *.egg-info/
@@ -23,7 +19,6 @@ reports
 reports/
 setenv.sh
 settings.py
-test-quick
 tests/settings.py
 tests/test-reports-*/*
 **/*.log

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectCodeStyleSettingsManager">
-    <option name="PER_PROJECT_SETTINGS">
-      <value />
-    </option>
-    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
-  </component>
-</project>


### PR DESCRIPTION
whenever i checked out the project in pycharm I only saw top project files.

intelij seems to have changed the way they structured their .idea folder

the contents of that deleted file were not really that helpful anyway => we don't have everyone working via pycharm so lets not add this info here anyhow

i also saw a file dictating 160 line length which is overruled by the 88 of black => thought removing it would be better too