### PR TITLE
adding version to documentation to help out on #1016

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,6 +26,11 @@ Comment
 
 .. autoclass:: Comment
 
+Version
+=======
+
+.. autoclass:: jira.resources.Version
+
 Worklog
 =======
 

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -906,6 +906,21 @@ class Version(Resource):
         Refer to Atlassian REST API `documentation`_.
 
         .. _documentation: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-project-versions/#api-rest-api-2-version-id-put
+
+        :Example:
+
+            .. code-block:: python
+
+                >> version_id = "10543"
+                >> version = JIRA("https://atlassian.org").version(version_id)
+                >> print(version.name)
+                "some_version_name"
+                >> version.update(name="another_name")
+                >> print(version.name)
+                "another_name"
+                >> version.update(archived=True)
+                >> print(version.archived)
+                True
         """
         data = {}
         for field in kwargs:

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -879,10 +879,11 @@ class Version(Resource):
             self._parse_raw(raw)
 
     def delete(self, moveFixIssuesTo=None, moveAffectedIssuesTo=None):
-        """Delete this project version from the server.
+        """
+        Delete this project version from the server.
 
-        If neither of the arguments are specified, the version is
-            removed from all issues it is attached to.
+        If neither of the arguments are specified, the version is removed from all
+        issues it is attached to.
 
         :param moveFixIssuesTo: in issues for which this version is a fix
             version, add this argument version to the fix version list
@@ -899,7 +900,13 @@ class Version(Resource):
         return super(Version, self).delete(params)
 
     def update(self, **args):
-        """Update this project version from the server. It is prior used to archive versions."""
+        """
+        Update this project version from the server. It is prior used to archive versions.
+
+        Refer to Atlassian REST API `documentation`_.
+
+        .. _documentation: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-project-versions/#api-rest-api-2-version-id-put
+        """
         data = {}
         for field in args:
             data[field] = args[field]

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -899,7 +899,7 @@ class Version(Resource):
 
         return super(Version, self).delete(params)
 
-    def update(self, **args):
+    def update(self, **kwargs):
         """
         Update this project version from the server. It is prior used to archive versions.
 
@@ -908,8 +908,8 @@ class Version(Resource):
         .. _documentation: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-project-versions/#api-rest-api-2-version-id-put
         """
         data = {}
-        for field in args:
-            data[field] = args[field]
+        for field in kwargs:
+            data[field] = kwargs[field]
 
         super(Version, self).update(**data)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1596,6 +1596,17 @@ class ProjectTests(unittest.TestCase):
         i.update(fields={"fixVersions": [{"id": version.id}]})
         version.delete()
 
+    def test_update_project_version(self):
+        # given
+        name = "version-%s" % rndstr()
+        version = self.jira.create_version(name, self.project_b, "will be deleted soon")
+        updated_name = "version-%s" % rndstr()
+        # when
+        version.update(name=updated_name)
+        # then
+        self.assertEqual(updated_name, version.name)
+        version.delete()
+
     def test_get_project_version_by_name(self):
         name = "version-%s" % rndstr()
         version = self.jira.create_version(name, self.project_b, "will be deleted soon")


### PR DESCRIPTION
#1016 suggested a rename version feature.
although not implemented yet it seems possible with the Version.update functionality

This addition to the documentation will at least make it more clear where to look for such solutions