### PR TITLE
Export resource_class_map and fix bug in Role.add_user()

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -46,6 +46,7 @@ __all__ = (
     "Customer",
     "ServiceDesk",
     "RequestType",
+    "resource_class_map",
 )
 
 logging.getLogger("jira").addHandler(logging.NullHandler())
@@ -938,7 +939,7 @@ class Role(Resource):
         if groups is not None and isinstance(groups, str):
             groups = (groups,)
 
-        data = {"user": users}  # FIXME: groups is not used.
+        data = {"user": users, "group": groups}
         self._session.post(self.self, data=json.dumps(data))
 
 


### PR DESCRIPTION
The reason for exporting resource_class_map is to allow an external module to support additional resource types without the need to edit resources.py (I had edited it previously but this became a maintenance nightmare).

The Role.add_user() bug is (I hope) an obvious one: the groups argument was ignored.

(This is a duplicate of PR #1002.)