### PR TITLE
fix pickling and hashability

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -374,6 +374,15 @@ class UniversalResourceTests(unittest.TestCase):
         self.assertEqual(resource.key, unpickled.key)
         self.assertEqual(resource, unpickled)
 
+    def test_pickling_issue_class(self):
+        resource = self.test_manager.project_b_issue1_obj
+
+        pickled = pickle.dumps(resource)
+        unpickled = pickle.loads(pickled)
+
+        self.assertEqual(resource.key, unpickled.key)
+        self.assertEqual(resource, unpickled)
+
     def test_bad_attribute(self):
         resource = self.jira.find("issue/{0}", self.test_manager.project_b_issue1)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -363,6 +363,14 @@ class UniversalResourceTests(unittest.TestCase):
         self.assertEqual(resource.key, unpickled_instance.key)
         self.assertTrue(resource == unpickled_instance)
 
+    def test_pickling_resource_class(self):
+        resource = self.jira.find("issue/{0}", self.test_manager.project_b_issue1)
+
+        pickled = pickle.dumps(resource)
+        unpickled = pickle.loads(pickled)
+
+        self.assertEqual(resource.key, unpickled.key)
+        self.assertEqual(resource.raw, unpickled.raw)
 
 @flaky
 class ResourceTests(unittest.TestCase):


### PR DESCRIPTION
## Summary of Changes
1. Add default hash and equality functions to the Resource base class, so all inherited members benefit from hashability
2. Fixed pickle work around to a more robust (and now tested) solution

resolves #842 
resolves #790 

Possibly obsoletes #863 