### PR TITLE
fix assign issue behaviour and correct watcher functions docstrings

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -3226,7 +3226,7 @@ class JIRA(object):
         Returns:
             Optional[Response]
         """
-        if self.deploymentType != "Cloud":
+        if not self._is_cloud:
             url = self.server_url + "/rest/auth/1/websudo"
             return self._session.delete(url)
         return None
@@ -3507,7 +3507,7 @@ class JIRA(object):
         Returns:
             Union[str, int]
         """
-        if self.deploymentType == "Cloud":
+        if self._is_cloud:
             # Disabling users now needs cookie auth in the Cloud - see https://jira.atlassian.com/browse/ID-6230
             if "authCookie" not in vars(self):
                 user = self.session()
@@ -3622,7 +3622,7 @@ class JIRA(object):
     def backup(self, filename: str = "backup.zip", attachments: bool = False):
         """Will call jira export to backup as zipped xml. Returning with success does not mean that the backup process finished."""
         payload: Any  # _session.post is pretty open
-        if self.deploymentType == "Cloud":
+        if self._is_cloud:
             url = self.server_url + "/rest/backup/1/export/runbackup"
             payload = json.dumps({"cbAttachments": attachments})
             self._options["headers"]["X-Requested-With"] = "XMLHttpRequest"
@@ -3645,7 +3645,7 @@ class JIRA(object):
         Is there a way to get progress for Server version?
         """
         epoch_time = int(time.time() * 1000)
-        if self.deploymentType == "Cloud":
+        if self._is_cloud:
             url = self.server_url + "/rest/obm/1.0/getprogress?_=%i" % epoch_time
         else:
             self.log.warning("This functionality is not available in Server version")
@@ -3672,7 +3672,7 @@ class JIRA(object):
 
     def backup_complete(self) -> Optional[bool]:
         """Return boolean based on 'alternativePercentage' and 'size' returned from backup_progress (cloud only)."""
-        if self.deploymentType != "Cloud":
+        if not self._is_cloud:
             self.log.warning("This functionality is not available in Server version")
             return None
         status = self.backup_progress()
@@ -3685,7 +3685,7 @@ class JIRA(object):
 
     def backup_download(self, filename: str = None):
         """Download backup file from WebDAV (cloud only)."""
-        if self.deploymentType != "Cloud":
+        if not self._is_cloud:
             self.log.warning("This functionality is not available in Server version")
             return None
         remote_file = self.backup_progress()["fileName"]
@@ -4454,7 +4454,7 @@ class JIRA(object):
             project_ids = project_ids.split(",")  # type: ignore # re-use of variable
         payload["projectIds"] = project_ids
         payload["preset"] = preset
-        if self.deploymentType == "Cloud":
+        if self._is_cloud:
             payload["locationType"] = location_type
             payload["locationId"] = location_id
         url = self._get_url("rapidview/create/presets", base=self.AGILE_BASE_URL)

--- a/jira/client.py
+++ b/jira/client.py
@@ -2047,7 +2047,7 @@ class JIRA(object):
 
         Args:
             issue (str): ID or key of the issue affected
-            watcher (str): key of the user to add to the watchers list
+            watcher (str): name of the user to add to the watchers list
         """
         url = self._get_url("issue/" + str(issue) + "/watchers")
         return self._session.post(url, data=json.dumps(watcher))
@@ -2058,15 +2058,19 @@ class JIRA(object):
 
         Args:
             issue (str): ID or key of the issue affected
-            watcher (str): key of the user to remove from the watchers list
+            watcher (str): name of the user to remove from the watchers list
 
         Returns:
             Response
         """
         url = self._get_url("issue/" + str(issue) + "/watchers")
         # https://docs.atlassian.com/software/jira/docs/api/REST/8.13.6/#api/2/issue-removeWatcher
-        params = {"username": watcher}
-        result = self._session.delete(url, params=params)
+        user_id = self._get_user_id(watcher)
+        if self.deploymentType == "Cloud":
+            payload = {"accountId": user_id}
+        else:
+            payload = {"username": user_id}
+        result = self._session.delete(url, params=payload)
         return result
 
     @translate_resource_args

--- a/make_local_jira_user.py
+++ b/make_local_jira_user.py
@@ -17,8 +17,9 @@ def add_user_to_jira():
             CI_JIRA_URL,
             basic_auth=(environ["CI_JIRA_ADMIN"], environ["CI_JIRA_ADMIN_PASSWORD"]),
         ).add_user(
-            environ["CI_JIRA_USER"],
-            "user@example.com",
+            username=environ["CI_JIRA_USER"],
+            email="user@example.com",
+            fullname=environ["CI_JIRA_USER_FULL_NAME"],
             password=environ["CI_JIRA_USER_PASSWORD"],
         )
         print("user {}".format(environ["CI_JIRA_USER"]))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -303,6 +303,7 @@ class JiraTestManager(object):
             py.test.exit("FATAL: WTF!?")
 
         self.user_admin = self.jira_admin.search_users(self.CI_JIRA_ADMIN)[0]
+        self.user_normal = self.jira_admin.search_users(self.CI_JIRA_USER)[0]
         self.initialized = 1
 
 
@@ -667,6 +668,7 @@ class IssueTests(unittest.TestCase):
         self.jira = JiraTestManager().jira_admin
         self.jira_normal = JiraTestManager().jira_normal
         self.user_admin = self.jira.search_users(self.test_manager.CI_JIRA_ADMIN)[0]
+        self.user_normal = self.test_manager.user_normal
         self.project_b = self.test_manager.project_b
         self.project_a = self.test_manager.project_a
         self.issue_1 = self.test_manager.project_b_issue1
@@ -1037,17 +1039,17 @@ class IssueTests(unittest.TestCase):
         self.assertTrue("fields" in meta["projects"][0]["issuetypes"][0])
 
     def test_assign_issue(self):
-        self.assertTrue(self.jira.assign_issue(self.issue_1, self.user_admin.name))
+        self.assertTrue(self.jira.assign_issue(self.issue_1, self.user_normal.name))
         self.assertEqual(
-            self.jira.issue(self.issue_1).fields.assignee.name, self.user_admin.name
+            self.jira.issue(self.issue_1).fields.assignee.name, self.user_normal.name
         )
 
     def test_assign_issue_with_issue_obj(self):
         issue = self.jira.issue(self.issue_1)
-        x = self.jira.assign_issue(issue, self.user_admin.name)
+        x = self.jira.assign_issue(issue, self.user_normal.name)
         self.assertTrue(x)
         self.assertEqual(
-            self.jira.issue(self.issue_1).fields.assignee.name, self.user_admin.name
+            self.jira.issue(self.issue_1).fields.assignee.name, self.user_normal.name
         )
 
     def test_assign_to_bad_issue_raises(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1291,15 +1291,15 @@ class IssueTests(unittest.TestCase):
     def test_add_remove_watcher(self):
 
         # removing it in case it exists, so we know its state
-        self.jira.remove_watcher(self.issue_1, self.test_manager.user_admin.key)
+        self.jira.remove_watcher(self.issue_1, self.test_manager.user_normal.name)
         init_watchers = self.jira.watchers(self.issue_1).watchCount
 
         # adding a new watcher
-        self.jira.add_watcher(self.issue_1, self.test_manager.user_admin.key)
+        self.jira.add_watcher(self.issue_1, self.test_manager.user_normal.name)
         self.assertEqual(self.jira.watchers(self.issue_1).watchCount, init_watchers + 1)
 
         # now we verify that remove does indeed remove watchers
-        self.jira.remove_watcher(self.issue_1, self.test_manager.user_admin.key)
+        self.jira.remove_watcher(self.issue_1, self.test_manager.user_normal.name)
         new_watchers = self.jira.watchers(self.issue_1).watchCount
         self.assertEqual(init_watchers, new_watchers)
 

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ setenv =
     CI_JIRA_ADMIN=admin
     CI_JIRA_ADMIN_PASSWORD=admin
     CI_JIRA_USER=jira_user
+    CI_JIRA_USER_FULL_NAME=Newly Created CI User
     CI_JIRA_USER_PASSWORD=jira
     CI_JIRA_ISSUE=Task
 passenv =


### PR DESCRIPTION
Resolves #1049 

### Summary of Changes
1. Handle self-hosted vs cloud difference in assign issue and watcher functions
2. Update tests to use the created user instead of the admin user. The admin user has identical `key` and `name` values which allowed mistakes in tests where the API wants the username instead of the user key.


### Notable docs
#### Assign Issue
Cloud: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-issueidorkey-assignee-put
Self hosted: https://docs.atlassian.com/software/jira/docs/api/REST/8.13.6/#api/2/issue-assign

#### Watcher add/remove
Cloud: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-watchers/#api-rest-api-2-issue-issueidorkey-watchers-post
Self hosted: https://docs.atlassian.com/software/jira/docs/api/REST/8.13.6/#api/2/issue-addWatcher
