### PR TITLE
Add (some) missing type hints for `_IssueFields`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ autodoc_inherit_docstrings = False
 nitpick_ignore = [
     ("py:class", "JIRA"),  # in jira.resources we only import this class if type
     ("py:obj", "typing.ResourceType"),  # only Py36 has a problem with this reference
-    ("py:class", "jira.resources.MyAny")  # Dummy subclass for type checking
+    ("py:class", "jira.resources.MyAny"),  # Dummy subclass for type checking
     # From other packages
     ("py:mod", "filemagic"),
     ("py:mod", "ipython"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ nitpick_ignore = [
     ("py:class", "Response"),
     ("py:mod", "requests-kerberos"),
     ("py:mod", "requests-oauthlib"),
-    ("py:class", "jira.resources.MyAny")
+    ("py:class", "jira.resources.MyAny"),
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,7 @@ autodoc_inherit_docstrings = False
 nitpick_ignore = [
     ("py:class", "JIRA"),  # in jira.resources we only import this class if type
     ("py:obj", "typing.ResourceType"),  # only Py36 has a problem with this reference
+    ("py:class", "jira.resources.MyAny")  # Dummy subclass for type checking
     # From other packages
     ("py:mod", "filemagic"),
     ("py:mod", "ipython"),
@@ -69,7 +70,6 @@ nitpick_ignore = [
     ("py:class", "Response"),
     ("py:mod", "requests-kerberos"),
     ("py:mod", "requests-oauthlib"),
-    ("py:class", "jira.resources.MyAny"),
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,6 +69,7 @@ nitpick_ignore = [
     ("py:class", "Response"),
     ("py:mod", "requests-kerberos"),
     ("py:mod", "requests-oauthlib"),
+    ("py:class", "jira.resources.MyAny")
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
 else:
 
     class MyAny(object):
+        """Dummy subclass of base object class for when type checker is not running.
+        """
         pass
 
 

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -22,8 +22,8 @@ if TYPE_CHECKING:
 else:
 
     class MyAny(object):
-        """Dummy subclass of base object class for when type checker is not running.
-        """
+        """Dummy subclass of base object class for when type checker is not running."""
+
         pass
 
 

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -18,6 +18,13 @@ from jira.utils import CaseInsensitiveDict, json_loads, threaded_requests
 if TYPE_CHECKING:
     from jira.client import JIRA
 
+    MyAny = Any
+else:
+
+    class MyAny(object):
+        pass
+
+
 __all__ = (
     "Resource",
     "Issue",
@@ -574,7 +581,7 @@ class Filter(Resource):
 class Issue(Resource):
     """A Jira issue."""
 
-    class _IssueFields(object):
+    class _IssueFields(MyAny):
         class _Comment(object):
             def __init__(self) -> None:
                 self.comments: List[Comment] = []

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -592,7 +592,7 @@ class Issue(Resource):
             self.project: Project
             self.reporter: UnknownResource
             self.resolution: Optional[Resolution] = None
-            self.security: Optional[Security] = None
+            self.security: Optional[SecurityLevel] = None
             self.status: Status
             self.statuscategorychangedate: Optional[str] = None
             self.summary: str

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -1255,6 +1255,7 @@ class Customer(Resource):
         )
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class ServiceDesk(Resource):
@@ -1275,6 +1276,7 @@ class ServiceDesk(Resource):
         )
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class RequestType(Resource):
@@ -1288,6 +1290,7 @@ class RequestType(Resource):
     ):
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
         Resource.__init__(
             self,
@@ -1404,6 +1407,7 @@ class UnknownResource(Resource):
         Resource.__init__(self, "unknown{0}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 def cls_for_resource(resource_literal: str) -> Type[Resource]:

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -486,6 +486,7 @@ class Attachment(Resource):
         Resource.__init__(self, "attachment/{0}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
     def get(self):
         """Return the file content as a string."""
@@ -510,6 +511,7 @@ class Component(Resource):
         Resource.__init__(self, "component/{0}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
     def delete(self, moveIssuesTo: Optional[str] = None):  # type: ignore[override]
         """Delete this component from the server.
@@ -536,6 +538,7 @@ class CustomFieldOption(Resource):
         Resource.__init__(self, "customFieldOption/{0}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class Dashboard(Resource):
@@ -550,6 +553,7 @@ class Dashboard(Resource):
         Resource.__init__(self, "dashboard/{0}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class Filter(Resource):
@@ -564,6 +568,7 @@ class Filter(Resource):
         Resource.__init__(self, "filter/{0}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class Issue(Resource):
@@ -615,9 +620,7 @@ class Issue(Resource):
         self.key: str
         if raw:
             self._parse_raw(raw)
-        self.raw: Dict[str, Any] = cast(
-            Dict[str, Any], self.raw
-        )  # _parse_raw will error if raw is None
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
     def update(  # type: ignore[override] # incompatible supertype ignored
         self,
@@ -722,6 +725,7 @@ class Comment(Resource):
         Resource.__init__(self, "issue/{0}/comment/{1}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
     def update(self, fields=None, async_=None, jira=None, body="", visibility=None):
         """Update a comment"""
@@ -745,6 +749,7 @@ class RemoteLink(Resource):
         Resource.__init__(self, "issue/{0}/remotelink/{1}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
     def update(self, object, globalId=None, application=None, relationship=None):
         """Update a RemoteLink. 'object' is required.
@@ -781,6 +786,7 @@ class Votes(Resource):
         Resource.__init__(self, "issue/{0}/votes", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class Watchers(Resource):
@@ -795,6 +801,7 @@ class Watchers(Resource):
         Resource.__init__(self, "issue/{0}/watchers", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
     def delete(self, username):
         """Remove the specified user from the watchers list."""
@@ -812,6 +819,7 @@ class TimeTracking(Resource):
         self.remainingEstimate = None
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class Worklog(Resource):
@@ -826,6 +834,7 @@ class Worklog(Resource):
         Resource.__init__(self, "issue/{0}/worklog/{1}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
     def delete(  # type: ignore[override]
         self, adjustEstimate: Optional[str] = None, newEstimate=None, increaseBy=None
@@ -862,6 +871,7 @@ class IssueLink(Resource):
         Resource.__init__(self, "issueLink/{0}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class IssueLinkType(Resource):
@@ -876,6 +886,7 @@ class IssueLinkType(Resource):
         Resource.__init__(self, "issueLinkType/{0}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class IssueType(Resource):
@@ -890,6 +901,7 @@ class IssueType(Resource):
         Resource.__init__(self, "issuetype/{0}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class Priority(Resource):
@@ -904,6 +916,7 @@ class Priority(Resource):
         Resource.__init__(self, "priority/{0}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class Project(Resource):
@@ -918,6 +931,7 @@ class Project(Resource):
         Resource.__init__(self, "project/{0}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class Role(Resource):
@@ -932,6 +946,7 @@ class Role(Resource):
         Resource.__init__(self, "project/{0}/role/{1}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
     def update(  # type: ignore[override]
         self,
@@ -995,6 +1010,7 @@ class Resolution(Resource):
         Resource.__init__(self, "resolution/{0}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class SecurityLevel(Resource):
@@ -1009,6 +1025,7 @@ class SecurityLevel(Resource):
         Resource.__init__(self, "securitylevel/{0}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class Status(Resource):
@@ -1023,6 +1040,7 @@ class Status(Resource):
         Resource.__init__(self, "status/{0}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class StatusCategory(Resource):
@@ -1037,6 +1055,7 @@ class StatusCategory(Resource):
         Resource.__init__(self, "statuscategory/{0}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class User(Resource):
@@ -1051,6 +1070,7 @@ class User(Resource):
         Resource.__init__(self, "user?username={0}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class Group(Resource):
@@ -1065,6 +1085,7 @@ class Group(Resource):
         Resource.__init__(self, "group?groupname={0}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class Version(Resource):
@@ -1079,6 +1100,7 @@ class Version(Resource):
         Resource.__init__(self, "version/{0}", options, session)
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
     def delete(self, moveFixIssuesTo=None, moveAffectedIssuesTo=None):
         """
@@ -1162,6 +1184,7 @@ class GreenHopperResource(Resource):
             # Old GreenHopper API did not contain self - create it for backward compatibility.
             if not self.self:
                 self.self = self._get_url(path.format(raw["id"]))
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class Sprint(GreenHopperResource):

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -615,7 +615,9 @@ class Issue(Resource):
         self.key: str
         if raw:
             self._parse_raw(raw)
-        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)  # _parse_raw will error if raw is None
+        self.raw: Dict[str, Any] = cast(
+            Dict[str, Any], self.raw
+        )  # _parse_raw will error if raw is None
 
     def update(  # type: ignore[override] # incompatible supertype ignored
         self,

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -594,7 +594,7 @@ class Issue(Resource):
             self.resolution: Optional[Resolution] = None
             self.security: Optional[Security] = None
             self.status: Status
-            self.statuscategorychangedate: Optinal[str] = None
+            self.statuscategorychangedate: Optional[str] = None
             self.summary: str
             self.timetracking: TimeTracking
             self.versions: List[Version] = []
@@ -613,9 +613,9 @@ class Issue(Resource):
         self.fields: Issue._IssueFields
         self.id: str
         self.key: str
-        self.raw: Dict[Any, Any] = {}
         if raw:
             self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)  # _parse_raw will error if raw is None
 
     def update(  # type: ignore[override] # incompatible supertype ignored
         self,

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -579,12 +579,27 @@ class Issue(Resource):
                 self.worklogs: List[Worklog] = []
 
         def __init__(self):
+            self.assignee: Optional[UnknownResource] = None
             self.attachment: List[Attachment] = []
             self.comment = self._Comment()
+            self.created: str
             self.description: Optional[str] = None
+            self.duedate: Optional[str] = None
             self.issuelinks: List[IssueLink] = []
+            self.issuetype: IssueType
             self.labels: List[str] = []
-            self.project: Optional[Project] = None
+            self.priority: Priority
+            self.project: Project
+            self.reporter: UnknownResource
+            self.resolution: Optional[Resolution] = None
+            self.security: Optional[Security] = None
+            self.status: Status
+            self.statuscategorychangedate: Optinal[str] = None
+            self.summary: str
+            self.timetracking: TimeTracking
+            self.versions: List[Version] = []
+            self.votes: Votes
+            self.watchers: Watchers
             self.worklog = self._Worklog()
 
     def __init__(
@@ -598,6 +613,7 @@ class Issue(Resource):
         self.fields: Issue._IssueFields
         self.id: str
         self.key: str
+        self.raw: Dict[Any, Any] = {}
         if raw:
             self._parse_raw(raw)
 


### PR DESCRIPTION
## Description

Tested with mypy 0.782.

Pull request https://github.com/pycontribs/jira/pull/1023 added some type hints, which is great, but didn't define all of them, which now makes mypy unhappy about it.

**Note**: this PR probably doesn't add all of them either, but it does add some of them that do exist (most notably, fields like `summary` or `created`). I haven't found in the Jira REST API documentation a specific list of the fields that have a required value, so the types added by this PR are based in the errors of our codebase, intuition and requests examples provided by Jira docs. I'd be happy to add more fields if necessary.

## Rationale

Because mypy assumes the type `Any` for when there's no type hint, the solution should be to either to define every class attribute with its type, or define no types at all. This design by mypy is intentional for backwards compatibility (among other reasons). Having partially defined types can only break existing set ups.

## Minimal reproducible example

```python
from jira import JIRA


jira_client = JIRA('http://jira.test')
issue = jira_client.issue('TEST-1')
print(issue.fields.summary)
```

```
venv ❯❯❯ mypy script.py
script.py:7: error: "_IssueFields" has no attribute "summary"
Found 1 error in 1 file (checked 1 source file)
```