### PR TITLE
rename MyAny to a more meaningful name

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ autodoc_inherit_docstrings = False
 nitpick_ignore = [
     ("py:class", "JIRA"),  # in jira.resources we only import this class if type
     ("py:obj", "typing.ResourceType"),  # only Py36 has a problem with this reference
-    ("py:class", "jira.resources.MyAny"),  # Dummy subclass for type checking
+    ("py:class", "jira.resources.AnyLike"),  # Dummy subclass for type checking
     # From other packages
     ("py:mod", "filemagic"),
     ("py:mod", "ipython"),

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -18,10 +18,10 @@ from jira.utils import CaseInsensitiveDict, json_loads, threaded_requests
 if TYPE_CHECKING:
     from jira.client import JIRA
 
-    MyAny = Any
+    AnyLike = Any
 else:
 
-    class MyAny(object):
+    class AnyLike(object):
         """Dummy subclass of base object class for when type checker is not running."""
 
         pass
@@ -583,7 +583,7 @@ class Filter(Resource):
 class Issue(Resource):
     """A Jira issue."""
 
-    class _IssueFields(MyAny):
+    class _IssueFields(AnyLike):
         class _Comment(object):
             def __init__(self) -> None:
                 self.comments: List[Comment] = []


### PR DESCRIPTION
Following https://github.com/pycontribs/jira/pull/1063#issuecomment-866933056, rename the internally used dummy `Any` class 