### PR TITLE
use requests.structures.CaseInsensitiveDict directly

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,6 +67,7 @@ nitpick_ignore = [
     ("py:class", "Request"),
     ("py:class", "requests.models.Response"),
     ("py:class", "requests.sessions.Session"),
+    ("py:class", "requests.structures.CaseInsensitiveDict"),
     ("py:class", "Response"),
     ("py:mod", "requests-kerberos"),
     ("py:mod", "requests-oauthlib"),

--- a/jira/client.py
+++ b/jira/client.py
@@ -44,6 +44,7 @@ import requests
 from pkg_resources import parse_version
 from requests import Response
 from requests.auth import AuthBase
+from requests.structures import CaseInsensitiveDict
 from requests.utils import get_netrc_auth
 
 from jira import __version__
@@ -86,7 +87,7 @@ from jira.resources import (
     Watchers,
     Worklog,
 )
-from jira.utils import CaseInsensitiveDict, json_loads, threaded_requests
+from jira.utils import json_loads, threaded_requests
 
 try:
     # noinspection PyUnresolvedReferences

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -11,9 +11,10 @@ import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union, cast
 
 from requests import Response
+from requests.structures import CaseInsensitiveDict
 
 from jira.resilientsession import ResilientSession
-from jira.utils import CaseInsensitiveDict, json_loads, threaded_requests
+from jira.utils import json_loads, threaded_requests
 
 if TYPE_CHECKING:
     from jira.client import JIRA

--- a/jira/utils/__init__.py
+++ b/jira/utils/__init__.py
@@ -1,15 +1,19 @@
 # -*- coding: utf-8 -*-
 """Jira utils used internally."""
 import threading
+import warnings
 from typing import Any, Optional, cast
 
 from requests import Response
+from requests.structures import CaseInsensitiveDict as _CaseInsensitiveDict
 
 from jira.resilientsession import raise_on_error
 
 
-class CaseInsensitiveDict(dict):
+class CaseInsensitiveDict(_CaseInsensitiveDict):
     """A case-insensitive ``dict``-like object.
+
+    DEPRECATED: use requests.structures.CaseInsensitiveDict directly.
 
     Implements all methods and operations of
     ``collections.MutableMapping`` as well as dict's ``copy``. Also
@@ -36,32 +40,11 @@ class CaseInsensitiveDict(dict):
 
     """
 
-    def __init__(self, *args, **kw):
-        super(CaseInsensitiveDict, self).__init__(*args, **kw)
-
-        self.itemlist = {}
-        for key, value in super(CaseInsensitiveDict, self).copy().items():
-            if key != key.lower():
-                self[key.lower()] = value
-                self.pop(key, None)
-
-        # self.itemlist[key.lower()] = value
-
-    def __setitem__(self, key, value):
-        """Overwrite [] implementation."""
-        super(CaseInsensitiveDict, self).__setitem__(key.lower(), value)
-
-    # def __iter__(self):
-    #    return iter(self.itemlist)
-
-    # def keys(self):
-    #    return self.itemlist
-
-    # def values(self):
-    #    return [self[key] for key in self]
-
-    # def itervalues(self):
-    #    return (self[key] for key in self)
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "Use requests.structures.CaseInsensitiveDict directly", DeprecationWarning
+        )
+        super().__init__(*args, **kwargs)
 
 
 def threaded_requests(requests):

--- a/tests/resources/test_attachment.py
+++ b/tests/resources/test_attachment.py
@@ -15,7 +15,7 @@ class AttachmentTests(JiraTestCase):
         # we have no control over server side upload limit
         self.assertIn("uploadLimit", meta)
 
-    def test_1_add_remove_attachment(self):
+    def test_1_add_remove_attachment_using_filestream(self):
         issue = self.jira.issue(self.issue_1)
         with open(TEST_ATTACH_PATH, "rb") as f:
             attachment = self.jira.add_attachment(issue, f, "new test attachment")
@@ -27,3 +27,17 @@ class AttachmentTests(JiraTestCase):
             )
             # JIRA returns a HTTP 204 upon successful deletion
             self.assertEqual(attachment.delete().status_code, 204)
+
+    def test_2_add_remove_attachment_using_filename(self):
+        issue = self.jira.issue(self.issue_1)
+        attachment = self.jira.add_attachment(
+            issue, TEST_ATTACH_PATH, "new test attachment"
+        )
+        new_attachment = self.jira.attachment(attachment.id)
+        msg = "attachment %s of issue %s" % (new_attachment.__dict__, issue)
+        self.assertEqual(new_attachment.filename, "new test attachment", msg=msg)
+        self.assertEqual(
+            new_attachment.size, os.path.getsize(TEST_ATTACH_PATH), msg=msg
+        )
+        # JIRA returns a HTTP 204 upon successful deletion
+        self.assertEqual(attachment.delete().status_code, 204)


### PR DESCRIPTION
Aims to replace #976 and #877 - as both of these reports had errors when attaching a file using a filename a test case has been added for that too.

Not sure why an in-house implementation was used back in the day, but `requests` is now a well established library I think it is safe to make the transition now.