### PR TITLE
add jira-version to job matrix

### DIFF
--- a/.github/workflows/jira_server_ci.yml
+++ b/.github/workflows/jira_server_ci.yml
@@ -12,17 +12,18 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.os }} / ${{ matrix.python-version }}
+    name: ${{ matrix.os }} / Python ${{ matrix.python-version }} / Jira ${{ matrix.jira-version }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
         os: [Ubuntu]
         python-version: [3.6, 3.7, 3.8, 3.9]
+        jira-version: [8.17.1]
 
     steps:
       - uses: actions/checkout@master
       - name: Start Jira docker instance
-        run: docker run -dit -p 2990:2990 --name jira addono/jira-software-standalone
+        run: docker run -dit -p 2990:2990 --name jira addono/jira-software-standalone --version ${{ matrix.jira-version }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2


### PR DESCRIPTION
Specify the version argument to the Jira docker container in the CI matrix - based on discussion in https://github.com/Addono/docker-jira-software-standalone/issues/5 (thanks @Addono)

Bumping the self-hosted Jira version used in CI from 8.90 (default) to 8.17.1, this also allows #991 to create a test that generates a PAT token and uses it as an authentication method (introduced in 8.14).

Also allows the potential for testing different versions of self-hosted Jira in the future.