### PR TITLE
Add subscriptable support for PropertyHolder

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -692,7 +692,7 @@ class Issue(Resource):
 
         super(Issue, self).update(async_=async_, jira=jira, notify=notify, fields=data)
 
-    def get_field(self, fieldName: str) -> Any:
+    def get_field(self, field_name: str) -> Any:
         """Obtain the (parsed) value from the Issue's field.
 
         Args:

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -696,7 +696,7 @@ class Issue(Resource):
         """Obtain the (parsed) value from the Issue's field.
 
         Args:
-            fieldName (str): The name of the field to get
+            field_name (str): The name of the field to get
 
         Raises:
             AttributeError: If the field does not exist or if the field starts with an ``_``
@@ -705,13 +705,13 @@ class Issue(Resource):
             Any: Returns the parsed data stored in the field. For example, "project" would be of class :py:class:`Project`
         """
 
-        if fieldName.startswith("_"):
+        if field_name.startswith("_"):
             raise AttributeError(
-                f"An issue field_name cannot start with underscore (_): {fieldName}",
-                fieldName,
+                f"An issue field_name cannot start with underscore (_): {field_name}",
+                field_name,
             )
         else:
-            return getattr(self.fields, fieldName)
+            return getattr(self.fields, field_name)
 
     def add_field_value(self, field: str, value: str):
         """Add a value to a field that supports multiple values, without resetting the existing values.

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -1431,3 +1431,9 @@ def cls_for_resource(resource_literal: str) -> Type[Resource]:
 class PropertyHolder(object):
     def __init__(self, raw):
         __bases__ = raw  # noqa
+        
+    def __getitem__(self, item)
+        if item.startswith("_"):
+            raise KeyError(item)
+        else:
+            return getattr(self, item)

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -692,6 +692,27 @@ class Issue(Resource):
 
         super(Issue, self).update(async_=async_, jira=jira, notify=notify, fields=data)
 
+    def get_field(self, fieldName: str) -> Any:
+        """Obtain the (parsed) value from the Issue's field.
+
+        Args:
+            fieldName (str): The name of the field to get
+
+        Raises:
+            AttributeError: If the field does not exist or if the field starts with an ``_``
+
+        Returns:
+            Any: Returns the parsed data stored in the field. For example, "project" would be of class :py:class:`Project`
+        """
+
+        if fieldName.startswith("_"):
+            raise AttributeError(
+                f"A issue field_name cannot start with underscore (_): {fieldName}",
+                fieldName,
+            )
+        else:
+            return getattr(self.fields, fieldName)
+
     def add_field_value(self, field: str, value: str):
         """Add a value to a field that supports multiple values, without resetting the existing values.
 
@@ -1431,9 +1452,3 @@ def cls_for_resource(resource_literal: str) -> Type[Resource]:
 class PropertyHolder(object):
     def __init__(self, raw):
         __bases__ = raw  # noqa
-        
-    def __getitem__(self, item)
-        if item.startswith("_"):
-            raise KeyError(item)
-        else:
-            return getattr(self, item)

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -707,7 +707,7 @@ class Issue(Resource):
 
         if fieldName.startswith("_"):
             raise AttributeError(
-                f"A issue field_name cannot start with underscore (_): {fieldName}",
+                f"An issue field_name cannot start with underscore (_): {fieldName}",
                 fieldName,
             )
         else:

--- a/tests/resources/test_issue.py
+++ b/tests/resources/test_issue.py
@@ -26,6 +26,18 @@ class IssueTests(JiraTestCase):
         self.assertEqual(issue.key, self.issue_1)
         self.assertEqual(issue.fields.summary, "issue 1 from %s" % self.project_b)
 
+    def test_issue_get_field(self):
+        issue = self.jira.issue(self.issue_1)
+        self.assertEqual(issue.fields.description, issue.get_field(fieldName="description"))
+
+        self.assertRaisesRegex(
+            AttributeError, ": _something", issue.get_field, "_something"
+        )
+
+        self.assertRaisesRegex(
+            AttributeError, "customfield_1234", issue.get_field, "customfield_1234"
+        )
+
     def test_issue_field_limiting(self):
         issue = self.jira.issue(self.issue_2, fields="summary,comment")
         self.assertEqual(issue.fields.summary, "issue 2 from %s" % self.project_b)

--- a/tests/resources/test_issue.py
+++ b/tests/resources/test_issue.py
@@ -32,13 +32,11 @@ class IssueTests(JiraTestCase):
             issue.fields.description, issue.get_field(fieldName="description")
         )
 
-        self.assertRaisesRegex(
-            AttributeError, ": _something", issue.get_field, "_something"
-        )
+        with self.assertRaisesRegex(AttributeError, ": _something"):
+            issue.get_field("_something")
 
-        self.assertRaisesRegex(
-            AttributeError, "customfield_1234", issue.get_field, "customfield_1234"
-        )
+        with self.assertRaisesRegex(AttributeError, "customfield_1234"):
+            issue.get_field("customfield_1234")
 
     def test_issue_field_limiting(self):
         issue = self.jira.issue(self.issue_2, fields="summary,comment")

--- a/tests/resources/test_issue.py
+++ b/tests/resources/test_issue.py
@@ -29,7 +29,7 @@ class IssueTests(JiraTestCase):
     def test_issue_get_field(self):
         issue = self.jira.issue(self.issue_1)
         self.assertEqual(
-            issue.fields.description, issue.get_field(fieldName="description")
+            issue.fields.description, issue.get_field(field_name="description")
         )
 
         with self.assertRaisesRegex(AttributeError, ": _something"):

--- a/tests/resources/test_issue.py
+++ b/tests/resources/test_issue.py
@@ -28,7 +28,9 @@ class IssueTests(JiraTestCase):
 
     def test_issue_get_field(self):
         issue = self.jira.issue(self.issue_1)
-        self.assertEqual(issue.fields.description, issue.get_field(fieldName="description"))
+        self.assertEqual(
+            issue.fields.description, issue.get_field(fieldName="description")
+        )
 
         self.assertRaisesRegex(
             AttributeError, ": _something", issue.get_field, "_something"


### PR DESCRIPTION
This would be a simple, nice to have feature for dealing with custom fields 😃 

It makes it possible to do
```python
some_custom_field = "customfield_15623"
value = issue.fields[some_custom_field]
```
instead of
```python
some_custom_field = "customfield_15623"
value = getattr(issue.fields, some_custom_field)
```


Alternatively, I will just keep patching it in
```python
from jira import resources as jira_resources

def _jira_issue_property_holder_get_item(cls, item):
    if item.startswith("_"):
        raise KeyError(item)
    else:
        return getattr(cls, item)

jira_resources.PropertyHolder._getitem__ = _jira_issue_property_holder_get_item
```