### PR TITLE
fix to Client Class which no longer accepts the parameter "user" and instead requires accountid to find users by account id

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -1077,7 +1077,7 @@ class User(Resource):
         session: ResilientSession,
         raw: Dict[str, Any] = None,
     ):
-        Resource.__init__(self, "user?username={0}", options, session)
+        Resource.__init__(self, "user?accountId={0}", options, session)
         if raw:
             self._parse_raw(raw)
         self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)


### PR DESCRIPTION
this doesn't work due to changes on the restApi...
I'm not sure if this is the right fix, but it was the only way I could get jire.user(user_id) to work...
let me know what you guys think