### PR TITLE
Locate the exact user by key if there are multiple users returned from query

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1663,7 +1663,7 @@ class JIRA(object):
                 users = self.search_users(query=user)
             else:
                 users = self.search_users(user=user)
-            
+
             if len(users) > 1:
                 matches = [u for u in users if u.key == user]
             user_obj = matches[0] if matches else users[0]

--- a/jira/client.py
+++ b/jira/client.py
@@ -1666,12 +1666,7 @@ class JIRA(object):
             
             if len(users) > 1:
                 matches = [u for u in users if u.key == user]
-                if len(matches) >= 1:
-                    user_obj = matches[0]
-                else:
-                    user_obj = users[0]               
-            else:
-                user_obj = users[0]
+            user_obj = matches[0] if matches else users[0]
 
         except Exception as e:
             raise JIRAError(str(e))

--- a/jira/client.py
+++ b/jira/client.py
@@ -1661,16 +1661,18 @@ class JIRA(object):
             user_obj: User
             if self._is_cloud:
                 users = self.search_users(query=user)
-                if len(users) > 1:
-                    matches = [u for u in users if u.key == user]
-                    if len(matches) >= 1:
-                        user_obj = matches[0]
-                    else:
-                        user_obj = users[0]               
-                else:
-                    user_obj = users[0]
             else:
-                user_obj = self.search_users(user=user, maxResults=1)[0]
+                users = self.search_users(user=user)
+            
+            if len(users) > 1:
+                matches = [u for u in users if u.key == user]
+                if len(matches) >= 1:
+                    user_obj = matches[0]
+                else:
+                    user_obj = users[0]               
+            else:
+                user_obj = users[0]
+
         except Exception as e:
             raise JIRAError(str(e))
         return self._get_user_identifier(user_obj)

--- a/jira/client.py
+++ b/jira/client.py
@@ -1660,9 +1660,9 @@ class JIRA(object):
         try:
             user_obj: User
             if self._is_cloud:
-                users = self.search_users(query=user)
+                users = self.search_users(query=user, maxResults=20)
             else:
-                users = self.search_users(user=user)
+                users = self.search_users(user=user, maxResults=20)
 
             if len(users) > 1:
                 matches = [u for u in users if u.key == user]

--- a/jira/client.py
+++ b/jira/client.py
@@ -1664,6 +1664,7 @@ class JIRA(object):
             else:
                 users = self.search_users(user=user, maxResults=20)
 
+            matches = []
             if len(users) > 1:
                 matches = [u for u in users if self._get_user_identifier(u) == user]
             user_obj = matches[0] if matches else users[0]

--- a/jira/client.py
+++ b/jira/client.py
@@ -1665,7 +1665,7 @@ class JIRA(object):
                 users = self.search_users(user=user, maxResults=20)
 
             if len(users) > 1:
-                matches = [u for u in users if u.key == user]
+                matches = [u for u in users if self._get_user_identifier(u) == user]
             user_obj = matches[0] if matches else users[0]
 
         except Exception as e:

--- a/jira/client.py
+++ b/jira/client.py
@@ -1660,7 +1660,15 @@ class JIRA(object):
         try:
             user_obj: User
             if self._is_cloud:
-                user_obj = self.search_users(query=user, maxResults=1)[0]
+                users = self.search_users(query=user)
+                if len(users) > 1:
+                    matches = [u for u in users if u.key == user]
+                    if len(matches) >= 1:
+                        user_obj = matches[0]
+                    else:
+                        user_obj = users[0]               
+                else:
+                    user_obj = users[0]
             else:
                 user_obj = self.search_users(user=user, maxResults=1)[0]
         except Exception as e:


### PR DESCRIPTION
Previously only the first user is taken when an issue is assigned, things would stop working when multiple user records are returned from server, and intended user is not listed at the head of result list.

A second filter is applied if multiple user records are returned, so if there is an exact match, it should be returned instead of the first one in original query list.