### PR TITLE
chore: refresh release drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,18 +1,51 @@
+# Format and labels used aim to match those used by Ansible project
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
 categories:
-  - title: 'Features'
+  - title: 'Major Changes'
     labels:
-      - 'feature'
-      - 'enhancement'
-  - title: 'Bug Fixes'
+      - 'major'  # c6476b
+  - title: 'Minor Changes'
     labels:
-      - 'fix'
-      - 'bugfix'
-      - 'bug'
-  - title: 'Maintenance'
-    label: 'chore'
+      - 'feature'  # 006b75
+      - 'enhancement'  # ededed
+      - 'refactoring'
+  - title: 'Bugfixes'
+    labels:
+      - 'bug'  # fbca04
+  - title: 'Deprecations'
+    labels:
+      - 'deprecated'  # fef2c0
 exclude-labels:
   - 'skip-changelog'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - 'feature'
+      - 'enhancement'
+      - 'refactoring'
+  patch:
+    labels:
+      - 'patch'
+      - 'bug'
+      - 'deprecated'
+  default: patch
+autolabeler:
+  - label: 'skip-changelog'
+    title: '/chore/i'
+  - label: 'bug'
+    title: '/fix/i'
+  - label: 'enhancement'
+    title: '/(enhance|improve)/i'
+  - label: 'feature'
+    title: '/feature/i'
+  - label: 'dreprecated'
+    title: '/deprecat/i'
 template: |
-  ## Changes
-
   $CHANGES
+
+  Kudos goes to: $CONTRIBUTORS

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,21 @@
+# See https://github.com/jesusvasquez333/verify-pr-label-action
+name: labels
+on:
+  pull_request_target:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  check_pr_labels:
+    runs-on: ubuntu-latest
+    name: verify
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Verify PR label action
+        uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          valid-labels: 'bug, enhancement, feature, refactoring, major, deprecated, skip-changelog'
+          invalid-labels: 'help wanted, invalid, feedback-needed, incomplete'
+          pull-request-number: '${{ github.event.pull_request.number }}'
+          disable-reviews: true


### PR DESCRIPTION
* Ensures that correct labels are added
* Auto-add labels if pr is using semantic commits