### PR TITLE
use "agile" endpoint over now removed "greenhopper"

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -293,7 +293,7 @@ class JIRA:
         "context_path": "/",
         "rest_path": "api",
         "rest_api_version": "2",
-        "agile_rest_path": GreenHopperResource.GREENHOPPER_REST_PATH,
+        "agile_rest_path": GreenHopperResource.AGILE_BASE_REST_PATH,
         "agile_rest_api_version": "1.0",
         "verify": True,
         "resilient": True,


### PR DESCRIPTION
The "greenhopper" endpoint is deprecated in Jira version ~6, our test instances don't support those endpoints any more and it is causing troubles to our users: #1146 and also with ranking #1160 .

Some details about deprecation can be found here:
https://community.atlassian.com/t5/Jira-Core-Server-questions/Greenhooper-REST-API/qaq-p/816504

https://web.archive.org/web/20131022032352/http://blogs.atlassian.com/2013/08/renaming-greenhopper-and-bonfire/

We also have this documented in our code:

https://github.com/pycontribs/jira/blob/fa5dea15675ddd60bd4784f2b7155883bc53b0c0/jira/resources.py#L1187-L1192