### PR TITLE
Client Certificate Authentication for All Auth Types

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -477,6 +477,9 @@ class JIRA:
             self._session = ResilientSession(timeout=timeout)
             self._session.verify = verify
 
+        # Add the client authentication certificate to the request if configured
+        self._add_client_cert_to_session()
+
         self._session.headers.update(self._options["headers"])
 
         if "cookies" in self._options:
@@ -539,8 +542,6 @@ class JIRA:
         self._session = ResilientSession(timeout=timeout)
         self._session.auth = JiraCookieAuth(self._session, self.session, auth)
         self._session.verify = bool(self._options["verify"])
-        client_cert: Tuple[str, str] = self._options["client_cert"]  # to help mypy
-        self._session.cert = client_cert
 
     def _check_update_(self):
         """Check if the current version of the library is outdated."""
@@ -3325,8 +3326,6 @@ class JIRA:
         self._session = ResilientSession(timeout=timeout)
         self._session.verify = verify
         self._session.auth = (username, password)
-        client_cert: Tuple[str, str] = self._options["client_cert"]  # to help mypy
-        self._session.cert = client_cert
 
     def _create_oauth_session(
         self, oauth, timeout: Optional[Union[Union[float, int], Tuple[float, float]]]
@@ -3346,8 +3345,6 @@ class JIRA:
         self._session = ResilientSession(timeout)
         self._session.verify = verify
         self._session.auth = oauth_instance
-        client_cert: Tuple[str, str] = self._options["client_cert"]  # to help mypy
-        self._session.cert = client_cert
 
     def _create_kerberos_session(
         self,
@@ -3375,6 +3372,11 @@ class JIRA:
         self._session.auth = HTTPKerberosAuth(
             mutual_authentication=mutual_authentication
         )
+
+    def _add_client_cert_to_session(self):
+        """
+        Adds the client certificate to the request if configured through the constructor.
+        """
         client_cert: Tuple[str, str] = self._options["client_cert"]  # to help mypy
         self._session.cert = client_cert
 
@@ -3405,8 +3407,6 @@ class JIRA:
         self._session = ResilientSession(timeout=timeout)
         self._session.verify = bool(self._options["verify"])
         self._session.auth = jwt_auth
-        client_cert: Tuple[str, str] = self._options["client_cert"]  # to help mypy
-        self._session.cert = client_cert
 
     def _set_avatar(self, params, url, avatar):
         data = {"id": avatar}


### PR DESCRIPTION
Add the client certificate authentication to the following authentication methods
- OAuth Session 
- Kerberos Session
- JWT Session

Closes #1192