### PR TITLE
username as default self-hosted field for `current_user()`

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -3828,15 +3828,15 @@ class JIRA:
         return None
 
     def current_user(self, field: Optional[str] = None) -> str:
-        """Returns the username or emailAddress of the current user. For anonymous
-        users it will return a value that evaluates as False.
+        """Return the `accountId` (Cloud) else `username` of the current user.
+        For anonymous users it will return a value that evaluates as False.
 
         Args:
             field (Optional[str]): the name of the identifier field.
-              Defaults to "accountId" for Jira Cloud, else "key"
+              Defaults to "accountId" for Jira Cloud, else "username"
 
         Returns:
-            str
+            str: User's `accountId` (Cloud) else `username`.
         """
         if not hasattr(self, "_myself"):
 
@@ -3847,7 +3847,7 @@ class JIRA:
             self._myself = r_json
 
         if field is None:
-            field = "accountId" if self._is_cloud else "key"
+            field = "accountId" if self._is_cloud else "username"
 
         return self._myself[field]
 

--- a/jira/client.py
+++ b/jira/client.py
@@ -3847,7 +3847,7 @@ class JIRA:
             self._myself = r_json
 
         if field is None:
-            # Note: For Self-Hosted 'displayName' can be changed, 
+            # Note: For Self-Hosted 'displayName' can be changed,
             # but 'name' and 'key' cannot, so should be identifying properties.
             field = "accountId" if self._is_cloud else "name"
 

--- a/jira/client.py
+++ b/jira/client.py
@@ -3847,7 +3847,9 @@ class JIRA:
             self._myself = r_json
 
         if field is None:
-            field = "accountId" if self._is_cloud else "username"
+            # Note: For Self-Hosted 'displayName' can be changed, 
+            # but 'name' and 'key' cannot, so should be identifying properties.
+            field = "accountId" if self._is_cloud else "name"
 
         return self._myself[field]
 


### PR DESCRIPTION
Replaces: #1165, aims to close #1164

FYI @hsekowski can you try installing this vs the release candidate and compare?

`pip install jira==3.1.0rc1`

vs

`pip install git+https://github.com/pycontribs/jira.git@bugfix/create_project_user`