### PR TITLE
add the `.verify` property correctly

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -496,7 +496,7 @@ class JIRA:
         # Add the client authentication certificate to the request if configured
         self._add_client_cert_to_session()
         # Add the SSL Cert to the request if configured
-        self._add_ssl_cert_to_session()
+        self._add_ssl_cert_verif_strategy_to_session()
 
         self._session.headers.update(self._options["headers"])
 
@@ -3389,17 +3389,25 @@ class JIRA:
         )
 
     def _add_client_cert_to_session(self):
+        """Adds the client certificate to the session.
+        If configured through the constructor.
+
+        https://docs.python-requests.org/en/master/user/advanced/#client-side-certificates
+        - str: a single file (containing the private key and the certificate)
+        - Tuple[str,str] a tuple of both files’ paths
         """
-        Adds the client certificate to the request if configured through the constructor.
-        """
-        client_cert: Tuple[str, str] = self._options["client_cert"]  # to help mypy
+        client_cert: Union[str, Tuple[str, str]] = self._options["client_cert"]
         self._session.cert = client_cert
 
-    def _add_ssl_cert_to_session(self):
+    def _add_ssl_cert_verif_strategy_to_session(self):
+        """Adds verification strategy for host SSL certificates.
+        If configured through the constructor.
+
+        https://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
+        - str: Path to a `CA_BUNDLE` file or directory with certificates of trusted CAs.
+        - bool: True/False
         """
-        Adds the client certificate to the request if configured through the constructor.
-        """
-        ssl_cert: Union[bool, str] = self._options["verify"]  # to help mypy
+        ssl_cert: Union[bool, str] = self._options["verify"]
         self._session.verify = ssl_cert
 
     @staticmethod

--- a/jira/client.py
+++ b/jira/client.py
@@ -379,7 +379,10 @@ class JIRA:
                 * agile_rest_path - the REST path to use for Jira Agile requests. Defaults to ``greenhopper`` (old, private
                   API). Check :py:class:`jira.resources.GreenHopperResource` for other supported values.
                 * verify (Union[bool, str]) -- Verify SSL certs. Defaults to ``True``.
-                * client_cert -- a tuple of (cert,key) for the requests library for client side SSL
+                  Or path to to a CA_BUNDLE file or directory with certificates of trusted CAs,
+                  for the `requests` library to use.
+                * client_cert (Union[str, Tuple[str,str]]) -- Path to file with both cert and key or
+                  a tuple of (cert,key), for the `requests` library to use for client side SSL.
                 * check_update -- Check whether using the newest python-jira library version.
                 * headers -- a dict to update the default headers the session uses for all API requests.
 

--- a/jira/client.py
+++ b/jira/client.py
@@ -480,7 +480,6 @@ class JIRA:
             self._create_oauth_session(oauth, timeout)
         elif basic_auth:
             self._create_http_basic_session(*basic_auth, timeout=timeout)
-            self._session.headers.update(self._options["headers"])
         elif jwt:
             self._create_jwt_session(jwt, timeout)
         elif token_auth:


### PR DESCRIPTION
Addressed the concerns raised by #339 

http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification

`pip install git+https://github.com/pycontribs/jira.git@bugfix/correctly_add_ssl_cert`