### PR TITLE
improve ResultList types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,7 @@ repos:
         additional_dependencies:
           - types-requests
           - types-pkg_resources
+        args: [--no-strict-optional, --ignore-missing-imports, --show-error-codes]
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.29.0
     hooks:

--- a/jira/client.py
+++ b/jira/client.py
@@ -182,6 +182,10 @@ class ResultList(list, Generic[ResourceType]):
         return super().__iter__()
 
     # fmt: off
+    # The mypy error we ignore is about returning a contravariant type.
+    # As this class is a List of a generic 'Resource' class
+    # this is the right way to specify that the output is the same as which
+    # the class was initialized with.
     @overload
     def __getitem__(self, i: SupportsIndex) -> ResourceType: ...  # type:ignore[misc]
     @overload

--- a/jira/client.py
+++ b/jira/client.py
@@ -187,10 +187,10 @@ class ResultList(list, Generic[ResourceType]):
     # this is the right way to specify that the output is the same as which
     # the class was initialized with.
     @overload
-    def __getitem__(self, i: SupportsIndex) -> ResourceType: ...  # type:ignore[misc]
+    def __getitem__(self, i: SupportsIndex) -> ResourceType: ...  # type:ignore[misc]  # noqa: E704
     @overload
-    def __getitem__(self, s: slice) -> List[ResourceType]: ...  # type:ignore[misc]
-    def __getitem__(self, slice_or_index):
+    def __getitem__(self, s: slice) -> List[ResourceType]: ...  # type:ignore[misc]  # noqa: E704
+    def __getitem__(self, slice_or_index): # noqa: E301,E261
         return list.__getitem__(self, slice_or_index)
     # fmt: on
 

--- a/jira/client.py
+++ b/jira/client.py
@@ -142,7 +142,7 @@ ResourceType = TypeVar("ResourceType", contravariant=True, bound=Resource)
 class ResultList(list, Generic[ResourceType]):
     def __init__(
         self,
-        iterable: Iterable[ResourceType] = None,
+        iterable: Iterable = None,
         _startAt: int = 0,
         _maxResults: int = 0,
         _total: Optional[int] = None,

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ install_requires =
     requests>=2.10.0
     requests_toolbelt
     setuptools>=20.10.1
+    typing_extensions>=3.7.4.2
 
 [options.extras_require]
 cli =


### PR DESCRIPTION
`ResultList` typing was incomplete and resulted in the default `Any` typehint when the class was being used as a list.

For example the `examples/basic_auth.py` file could be edited like so (no additional imports required):

```python
issues = cast(ResultList[Issue], jira.search_issues("assignee=admin"))
i = issues[0]
reveal_type(i)
[reveal_type(i2) for i2 in issues]
i3 = next(issues)
reveal_type(i3)
reveal_type(i3.fields)
```
If `tox -e lint` was run mypy would tell us the types to be `Issue` instead of `Any`. This can also be seen in the VSCode hover menu / Pylance.
![image](https://user-images.githubusercontent.com/26027314/140627065-24c181bc-4868-4281-aa85-4f4e86b2eee3.png)

I've also added `typing_extensions` so that we can typehint this to match the `__getitem__` of the `list` class more closely.
