### PR TITLE
Repair release-drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,2 @@
+# see https://github.com/ansible-community/devtools
+_extends: ansible-community/devtools


### PR DESCRIPTION
Moving to reusable action was incomplete as we needed to keep the
config "link" file.

Fixes: https://github.com/ansible-community/devtools/issues/17
