### PR TITLE
Remove unnecessary shebang lines

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
 This module implements a friendly (well, friendlier) interface between the raw JSON
 responses from Jira and the Resource/dict abstractions provided by this library. Users

--- a/jira/config.py
+++ b/jira/config.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 This module allows people to keep their jira server credentials outside their script, in a configuration file that is not saved in the source control.
 

--- a/jira/jirashell.py
+++ b/jira/jirashell.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """Starts an interactive Jira session in an ipython terminal.
 
 Script arguments support changing the server and a persistent authentication


### PR DESCRIPTION
None of these files are marked or installed as executables, so having a
shebang line is not required.

This will simplify Fedora packaging. Fedora Packaging Guidelines require
files which are not installed as executables to not to have shebang
lines.
https://docs.fedoraproject.org/en-US/packaging-guidelines/#_shebang_lines

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>