### PR TITLE
Add projectstatuses method to get project statuses (missing endpoint)

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2933,7 +2933,7 @@ class JIRA:
         Returns:
             List[Status]
         """
-        r_json = self._get_json("project/{projectIdOrKey}/statuses")
+        r_json = self._get_json(f"project/{projectIdOrKey}/statuses")
         statuses = [
             Status(self._options, self._session, raw_stat_json)
             for raw_stat_json in r_json

--- a/jira/client.py
+++ b/jira/client.py
@@ -2916,7 +2916,7 @@ class JIRA:
     def statuses(self) -> List[Status]:
         """Get a list of all status Resources from the server.
 
-        Refer to :py:meth:`JIRA.issue_types_for_project` for getting statuses 
+        Refer to :py:meth:`JIRA.issue_types_for_project` for getting statuses
         for a specific issue type within a specific project.
 
         Returns:

--- a/jira/client.py
+++ b/jira/client.py
@@ -2927,18 +2927,18 @@ class JIRA:
         ]
         return statuses
 
-    def project_statuses(self, projectIdOrKey: str) -> List[Status]:
-        """Get a list of statuses available within a project from the server.
+    def project_statuses_by_issue_type(self, projectIdOrKey: str) -> List[IssueType]:
+        """Get a list of issue types available within the project with available statuses within each issue type, as each project has a set of valid issue types and each issue type has a set of valid statuses.
 
         Returns:
-            List[Status]
+            List[IssueType]
         """
         r_json = self._get_json(f"project/{projectIdOrKey}/statuses")
-        statuses = [
-            Status(self._options, self._session, raw_stat_json)
+        issue_types = [
+            IssueType(self._options, self._session, raw_stat_json)
             for raw_stat_json in r_json
         ]
-        return statuses
+        return issue_types
 
     def status(self, id: str) -> Status:
         """Get a status Resource from the server.

--- a/jira/client.py
+++ b/jira/client.py
@@ -2916,6 +2916,9 @@ class JIRA:
     def statuses(self) -> List[Status]:
         """Get a list of all status Resources from the server.
 
+        Refer to :py:meth:`JIRA.issue_types_for_project` for getting statuses 
+        for a specific issue type within a specific project.
+
         Returns:
             List[Status]
         """
@@ -2926,8 +2929,11 @@ class JIRA:
         ]
         return statuses
 
-    def project_statuses_by_issue_type(self, projectIdOrKey: str) -> List[IssueType]:
-        """Get a list of issue types available within the project with available statuses within each issue type, as each project has a set of valid issue types and each issue type has a set of valid statuses.
+    def issue_types_for_project(self, projectIdOrKey: str) -> List[IssueType]:
+        """Get a list of issue types available within the project.
+
+        Each project has a set of valid issue types and each issue type has a set of valid statuses.
+        The valid statuses for a given issue type can be extracted via: `issue_type_x.statuses`
 
         Returns:
             List[IssueType]

--- a/jira/client.py
+++ b/jira/client.py
@@ -2927,7 +2927,7 @@ class JIRA:
         ]
         return statuses
 
-    def projectstatuses(self, projectIdOrKey: str) -> List[Status]:
+    def project_statuses(self, projectIdOrKey: str) -> List[Status]:
         """Get a list of statuses available within a project from the server.
 
         Returns:

--- a/jira/client.py
+++ b/jira/client.py
@@ -2915,12 +2915,25 @@ class JIRA:
     # Status
 
     def statuses(self) -> List[Status]:
-        """Get a list of status Resources from the server.
+        """Get a list of all status Resources from the server.
 
         Returns:
             List[Status]
         """
         r_json = self._get_json("status")
+        statuses = [
+            Status(self._options, self._session, raw_stat_json)
+            for raw_stat_json in r_json
+        ]
+        return statuses
+
+    def projectstatuses(self, projectIdOrKey: str) -> List[Status]:
+        """Get a list of statuses available within a project from the server.
+
+        Returns:
+            List[Status]
+        """
+        r_json = self._get_json("project/{projectIdOrKey}/statuses")
         statuses = [
             Status(self._options, self._session, raw_stat_json)
             for raw_stat_json in r_json

--- a/tests/resources/test_project_statuses.py
+++ b/tests/resources/test_project_statuses.py
@@ -2,8 +2,8 @@ from tests.conftest import JiraTestCase
 
 
 class ProjectStatusesByIssueTypeTests(JiraTestCase):
-    def test_project_statuses_by_issue_type(self):
-        issue_types = self.jira.project_statuses_by_issue_type(self.project_a)
+    def test_issue_types_for_project(self):
+        issue_types = self.jira.issue_types_for_project(self.project_a)
 
         # should have at least one issue type within the project
         self.assertGreater(len(issue_types), 0)

--- a/tests/resources/test_project_statuses.py
+++ b/tests/resources/test_project_statuses.py
@@ -1,18 +1,24 @@
 from tests.conftest import JiraTestCase
 
 
-class ProjectStatusesTests(JiraTestCase):
-    def test_project_statuses(self):
-        project_statuses = self.jira.project_statuses(self.project_a)
+class ProjectStatusesByIssueTypeTests(JiraTestCase):
+    def test_project_statuses_by_issue_type(self):
+        issue_types = self.jira.project_statuses_by_issue_type(self.project_a)
 
-        # project should have at least one status
-        self.assertGreater(len(project_statuses), 0)
+        # should have at least one issue type within the project
+        self.assertGreater(len(issue_types), 0)
 
-        # first project status
-        project_status = project_statuses[0]
-        # test statues id
-        self_status_id = self.jira.status(project_status.id).id
-        self.assertEqual(self_status_id, project_status.id)
-        # test statues name
-        self_status_name = self.jira.status(project_status.name).name
-        self.assertEqual(self_status_name, project_status.name)
+        # get unique statuses across all issue types
+        statuses = []
+        for issue_type in issue_types:
+            # should have at least one valid status within an issue type by endpoint documentation
+            self.assertGreater(len(issue_type.statuses), 0)
+            statuses.extend(issue_type.statuses)
+        unique_statuses = list(set(statuses))
+
+        # test status id and name for each status within the project
+        for status in unique_statuses:
+            self_status_id = self.jira.status(status.id).id
+            self.assertEqual(self_status_id, status.id)
+            self_status_name = self.jira.status(status.name).name
+            self.assertEqual(self_status_name, status.name)

--- a/tests/resources/test_project_statuses.py
+++ b/tests/resources/test_project_statuses.py
@@ -13,6 +13,6 @@ class ProjectStatusesTests(JiraTestCase):
         # test statues id
         self_status_id = self.jira.status(project_status.id).id
         self.assertEqual(self_status_id, project_status.id)
-        # test statues name 
+        # test statues name
         self_status_name = self.jira.status(project_status.name).name
         self.assertEqual(self_status_name, project_status.name)

--- a/tests/resources/test_project_statuses.py
+++ b/tests/resources/test_project_statuses.py
@@ -1,0 +1,18 @@
+from tests.conftest import JiraTestCase
+
+
+class ProjectStatusesTests(JiraTestCase):
+    def test_project_statuses(self):
+        project_statuses = self.jira.project_statuses(self.project_a)
+
+        # project should have at least one status
+        self.assertGreater(len(project_statuses), 0)
+
+        # first project status
+        project_status = project_statuses[0]
+        # test statues id
+        self_status_id = self.jira.status(project_status.id).id
+        self.assertEqual(self_status_id, project_status.id)
+        # test statues name 
+        self_status_name = self.jira.status(project_status.name).name
+        self.assertEqual(self_status_name, project_status.name)


### PR DESCRIPTION
Added `projectstatuses` method for `/project/{projectIdOrKey}/statuses`

Relevant issue: https://github.com/pycontribs/jira/issues/723

Atlassian Doc for this REST endpoint: 
* [Jira Cloud REST v3](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-projects/#api-rest-api-3-project-projectidorkey-statuses-get)
* [Jira Cloud REST v2](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-projects/#api-rest-api-2-project-projectidorkey-statuses-get)
* [Jira Server](https://docs.atlassian.com/software/jira/docs/api/REST/8.13.15/#project-getAllStatuses)