### PR TITLE
Fix bug preventing use of an int for `issuetype` in `def create_issue(`

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1462,7 +1462,7 @@ class JIRA:
         p = data["fields"]["issuetype"]
         if isinstance(p, int):
             data["fields"]["issuetype"] = {"id": p}
-        if isinstance(p, (str, int)):
+        if isinstance(p, str):
             data["fields"]["issuetype"] = {"id": self.issue_type_by_name(str(p)).id}
 
         url = self._get_url("issue")


### PR DESCRIPTION
At some point a bug was introduced which prevents us from using `def create_issue(` to create an
issue of a specific `issuetype`, when you want to indicate the issue type using an `int`.  This is
especially problematic for issue types where the string `issuetype` doesn't unambiguously identify
the necessary issue type.  This causes `def issue_type_by_name(` to raise a KeyError.

There's currently a workaround (to use `def create_issues(`, which doesn't contain this bug.)