### PR TITLE
Fixing type hint to match documentation for move_to_backlog

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -4848,11 +4848,11 @@ class JIRA:
                 )
             raise
 
-    def move_to_backlog(self, issue_keys: str) -> Response:
+    def move_to_backlog(self, issue_keys: List[str]) -> Response:
         """Move issues in ``issue_keys`` to the backlog, removing them from all sprints that have not been completed.
 
         Args:
-            issue_keys (str): the issues to move to the backlog
+            issue_keys (List[str]): the issues to move to the backlog
 
         Raises:
             JIRAError: If moving issues to backlog fails


### PR DESCRIPTION
The type should be a list of strings rather than a string according to the documentation. https://developer.atlassian.com/cloud/jira/software/rest/api-group-backlog/#api-agile-1-0-backlog-issue-post

