### PR TITLE
Support requesting board configuration Fixes #1242

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -58,6 +58,7 @@ from jira.resilientsession import ResilientSession, raise_on_error
 from jira.resources import (
     Attachment,
     Board,
+    BoardConfiguration,
     Comment,
     Component,
     Customer,
@@ -4429,6 +4430,22 @@ class JIRA:
                 params,
                 base=self.AGILE_BASE_URL,
             )
+
+    def board_configuration(
+        self,
+        board_id: int,
+    ) -> BoardConfiguration:
+        """Get configuration for a board.
+
+        Args:
+            board_id (int): the board to get sprints from
+
+        Returns:
+            BoardConfiguration: the board configuration
+        """
+        board_configuration = BoardConfiguration(self._options, self._session)
+        board_configuration.find(board_id)
+        return board_configuration
 
     @translate_resource_args
     def sprints(

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -1292,6 +1292,7 @@ class BoardConfiguration(GreenHopperResource):
             )
         Resource.find(self, id, params)
 
+
 # Service Desk
 
 

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -1266,6 +1266,32 @@ class Board(GreenHopperResource):
         Resource.delete(self, params)
 
 
+class BoardConfiguration(GreenHopperResource):
+    """Configuration for a Greenhopper board."""
+
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
+        if options["agile_rest_path"] == self.GREENHOPPER_REST_PATH:
+            raise NotImplementedError(
+                "Jira private API does not support Board Configuration"
+            )
+        path = "board/{0}/configuration"
+        GreenHopperResource.__init__(self, path, options, session, raw)
+
+    def find(self, id, params=None):
+        if (
+            self._options["agile_rest_path"]
+            == GreenHopperResource.GREENHOPPER_REST_PATH
+        ):
+            raise NotImplementedError(
+                "Jira private API does not support Board Configuration"
+            )
+        Resource.find(self, id, params)
+
 # Service Desk
 
 


### PR DESCRIPTION
It's previously not possible to get configuration (and hence the JQL) for a board. This PR adds that new resource and supports fetching configuration by board ID using the `/rest/agile/1.0/board/{boardId}/configuration` endpoint.