### PR TITLE
Allow disabling searching for user on assign_issue

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -590,6 +590,15 @@ class JIRA:
         good username across multiple operations, such as one returned by
         :py:meth:`JIRA.search_users`.
 
+        :Example:
+            .. code-block::python
+                # Bulk assigning tickets to a known user, saving internal lookup time
+                my_user_id = "user_x"
+                issue_list = ... # Some list of issues
+                with jira_client.disable_internal_user_lookup():
+                    for issue in issue_list:
+                        jira_client.assign_issue(issue, my_user_id)
+
         An example usage would be to search for a given user, then bulk assign
         tickets to them using :py:meth:`JIRA.assign_issue`.
 
@@ -598,7 +607,7 @@ class JIRA:
         """
         self._internal_user_lookup = False
         try:
-            yield True
+            yield
         finally:
             self._internal_user_lookup = True
 

--- a/jira/client.py
+++ b/jira/client.py
@@ -580,7 +580,7 @@ class JIRA:
             JIRA.checked_version = True
 
         self._fields_cache_value: Dict[str, str] = {}  # access via self._fields_cache
-    
+
     @contextlib.contextmanager
     def disable_internal_user_lookup(self):
         self._internal_user_lookup = False

--- a/jira/client.py
+++ b/jira/client.py
@@ -582,7 +582,7 @@ class JIRA:
         self._fields_cache_value: Dict[str, str] = {}  # access via self._fields_cache
 
     @contextlib.contextmanager
-    def disable_internal_user_lookup(self):
+    def disable_internal_user_lookup(self) -> Iterable[None]:
         """Return a context manager which disables internal username searches.
 
         This creates a context which turns off the internal username search
@@ -598,9 +598,6 @@ class JIRA:
                 with jira_client.disable_internal_user_lookup():
                     for issue in issue_list:
                         jira_client.assign_issue(issue, my_user_id)
-
-        An example usage would be to search for a given user, then bulk assign
-        tickets to them using :py:meth:`JIRA.assign_issue`.
 
         Return
             contextlib._GeneratorContextManager

--- a/jira/client.py
+++ b/jira/client.py
@@ -583,6 +583,19 @@ class JIRA:
 
     @contextlib.contextmanager
     def disable_internal_user_lookup(self):
+        """Return a context manager which disables internal username searches.
+
+        This creates a context which turns off the internal username search
+        that various methods of the client use. This allows re-using a known
+        good username across multiple operations, such as one returned by
+        :py:meth:`JIRA.search_users`.
+
+        An example usage would be to search for a given user, then bulk assign
+        tickets to them using :py:meth:`JIRA.assign_issue`.
+
+        Return
+            contextlib._GeneratorContextManager
+        """
         self._internal_user_lookup = False
         try:
             yield True

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -62,6 +62,18 @@ def no_fields(monkeypatch):
     monkeypatch.setattr(jira.client.JIRA, "fields", lambda *args, **kwargs: [])
 
 
+def test_disable_internal_user_lookup(cl_normal: jira.client.JIRA):
+    # GIVEN: a username which may or may not exist
+    username: str = "a"
+
+    # WHEN: We attempt to look it up with the disable_internal_user_lookup() context
+    with cl_normal.disable_internal_user_lookup():
+        result = cl_normal._get_user_id()
+
+    # THEN: The original username is returned without attempting to look it up
+    assert result == username
+
+
 def test_delete_project(cl_admin, cl_normal, slug):
 
     assert cl_admin.delete_project(slug)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -68,7 +68,7 @@ def test_disable_internal_user_lookup(cl_normal: jira.client.JIRA):
 
     # WHEN: We attempt to look it up with the disable_internal_user_lookup() context
     with cl_normal.disable_internal_user_lookup():
-        result = cl_normal._get_user_id()
+        result = cl_normal._get_user_id(username)
 
     # THEN: The original username is returned without attempting to look it up
     assert result == username


### PR DESCRIPTION
This adds a parameter to the `_get_user_id()` method which allows for
selectively disabling the search for the user that said method performs.
This allows for code to perform it's own user search prior to calling
methods which use this method (e.g. `assign_issue`). This fixes an issue
where the search would return the wrong user due to the ordering of
users, and prevents the code from issuing duplicate search calls to the
Jira server when the user has already done so.

Closes #1284