### PR TITLE
Revert pyupgrade and mypy for py36 compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
           - types-pkg_resources
         args: [--no-strict-optional, --ignore-missing-imports, --show-error-codes]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.1
+    rev: v2.31.0
     hooks:
       - id: pyupgrade
         args: [ --py36-plus ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
       - id: yamllint
         files: \.(yaml|yml)$
   - repo: https://github.com/pre-commit/mirrors-mypy.git
-    rev: v0.942
+    rev: v0.931
     hooks:
       - id: mypy
         additional_dependencies:


### PR DESCRIPTION
pyupgrade dropped py36 support in v2.31.1

https://github.com/asottile/pyupgrade/compare/v2.31.0...v2.31.1

mypy also seems to have dropped support somewhere:

https://github.com/python/mypy/compare/v0.931...v0.942