### PR TITLE
update default behaviour of `jira.search_issues`

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2896,7 +2896,7 @@ class JIRA:
         if isinstance(fields, str):
             fields = fields.split(",")
         else:
-            fields = list(fields or [])
+            fields = list(fields or ["*all"])
 
         # this will translate JQL field names to REST API Name
         # most people do know the JQL names so this will help them use the API easier


### PR DESCRIPTION
The search_issues documentation states that when nothing is passed to the field parameter, all fields are returned. 
https://jira.readthedocs.io/api.html?highlight=search_issues#jira.client.JIRA.search_issues
The "*all" is used as the field parameter when nothing is passed to achieve this.

Fixes #1240 