### PR TITLE
use importlib.metadata instead of pkg_resources

### DIFF
--- a/jira/__init__.py
+++ b/jira/__init__.py
@@ -1,8 +1,8 @@
 """The root of JIRA package namespace."""
 try:
-    import pkg_resources
+    import importlib.metadata
 
-    __version__ = pkg_resources.get_distribution("jira").version
+    __version__ = importlib.metadata.version("jira")
 except Exception:
     __version__ = "unknown"
 

--- a/jira/client.py
+++ b/jira/client.py
@@ -41,7 +41,7 @@ from typing import (
 from urllib.parse import parse_qs, quote, urlparse
 
 import requests
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 from requests import Response
 from requests.auth import AuthBase
 from requests.structures import CaseInsensitiveDict

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ setup_requires =
 install_requires =
     defusedxml
     keyring
+    packaging
     requests-oauthlib>=1.1.0
     requests>=2.10.0
     requests_toolbelt


### PR DESCRIPTION
# Summary of Changes
1. Remove `pkg_resources` to set `__version__` instead using `importlib.metadata`
2. Remove `pkg_resources` wrapper for parsing version, and directly use `packaging` (note: comes with `setuptools` install, but added to requirements for completeness)

Closes #1248 