### PR TITLE
updated `jira.search_issues` default behaviour to include all fields

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2870,7 +2870,7 @@ class JIRA:
         startAt: int = 0,
         maxResults: int = 50,
         validate_query: bool = True,
-        fields: Optional[Union[str, List[str]]] = None,
+        fields: Optional[Union[str, List[str]]] = "*all",
         expand: Optional[str] = None,
         json_result: bool = False,
     ) -> Union[List[Dict[str, Any]], ResultList[Issue]]:
@@ -2895,8 +2895,6 @@ class JIRA:
         """
         if isinstance(fields, str):
             fields = fields.split(",")
-        else:
-            fields = list(fields or [])
 
         # this will translate JQL field names to REST API Name
         # most people do know the JQL names so this will help them use the API easier

--- a/tests/resources/test_issue.py
+++ b/tests/resources/test_issue.py
@@ -25,6 +25,27 @@ class IssueTests(JiraTestCase):
         issue = self.jira.issue(self.issue_1)
         self.assertEqual(issue.key, self.issue_1)
         self.assertEqual(issue.fields.summary, "issue 1 from %s" % self.project_b)
+    
+    def test_issue_search_field(self):
+        issues = self.jira.search_issues("key=%s" % self.issue_1)
+        self.assertEqual(self.issue_1, issues[0].key)
+        self.assertIsInstance(issues, list)
+        
+        issues = self.jira.search_issues("key=%s" % self.issue_1, json_result=True)
+        self.assertIsInstance(issues, dict)
+
+        issues = self.jira.search_issues("key=%s" % self.issue_1, fields="comment,assignee")
+        self.assertTrue(hasattr(issues[0].fields, "comment"))
+        self.assertTrue(hasattr(issues[0].fields, "assignee"))
+        self.assertFalse(hasattr(issues[0].fields, "reporter"))
+
+
+        issues = self.jira.search_issues("key=%s" % self.issue_1)
+        self.assertTrue(hasattr(issues[0].fields, "reporter"))
+        self.assertTrue(hasattr(issues[0].fields, "comment"))
+        
+        issues = self.jira.search_issues("key=%s" % self.issue_1, fields=[])
+        self.assertFalse(hasattr(issues[0].fields, "comment"))
 
     def test_issue_get_field(self):
         issue = self.jira.issue(self.issue_1)

--- a/tests/resources/test_issue.py
+++ b/tests/resources/test_issue.py
@@ -26,14 +26,17 @@ class IssueTests(JiraTestCase):
         self.assertEqual(issue.key, self.issue_1)
         self.assertEqual(issue.fields.summary, "issue 1 from %s" % self.project_b)
 
-    def test_issue_search_field(self):
+    def test_issue_search_finds_issue(self):
         issues = self.jira.search_issues("key=%s" % self.issue_1)
         self.assertEqual(self.issue_1, issues[0].key)
-        self.assertIsInstance(issues, list)
 
+    def test_issue_search_return_type(self):
+        issues = self.jira.search_issues("key=%s" % self.issue_1)
+        self.assertIsInstance(issues, list)
         issues = self.jira.search_issues("key=%s" % self.issue_1, json_result=True)
         self.assertIsInstance(issues, dict)
 
+    def test_issue_search_only_includes_provided_fields(self):
         issues = self.jira.search_issues(
             "key=%s" % self.issue_1, fields="comment,assignee"
         )
@@ -41,12 +44,10 @@ class IssueTests(JiraTestCase):
         self.assertTrue(hasattr(issues[0].fields, "assignee"))
         self.assertFalse(hasattr(issues[0].fields, "reporter"))
 
+    def test_issue_search_default_behaviour_included_fields(self):
         issues = self.jira.search_issues("key=%s" % self.issue_1)
         self.assertTrue(hasattr(issues[0].fields, "reporter"))
         self.assertTrue(hasattr(issues[0].fields, "comment"))
-
-        issues = self.jira.search_issues("key=%s" % self.issue_1, fields=[])
-        self.assertFalse(hasattr(issues[0].fields, "comment"))
 
     def test_issue_get_field(self):
         issue = self.jira.issue(self.issue_1)

--- a/tests/resources/test_issue.py
+++ b/tests/resources/test_issue.py
@@ -25,25 +25,26 @@ class IssueTests(JiraTestCase):
         issue = self.jira.issue(self.issue_1)
         self.assertEqual(issue.key, self.issue_1)
         self.assertEqual(issue.fields.summary, "issue 1 from %s" % self.project_b)
-    
+
     def test_issue_search_field(self):
         issues = self.jira.search_issues("key=%s" % self.issue_1)
         self.assertEqual(self.issue_1, issues[0].key)
         self.assertIsInstance(issues, list)
-        
+
         issues = self.jira.search_issues("key=%s" % self.issue_1, json_result=True)
         self.assertIsInstance(issues, dict)
 
-        issues = self.jira.search_issues("key=%s" % self.issue_1, fields="comment,assignee")
+        issues = self.jira.search_issues(
+            "key=%s" % self.issue_1, fields="comment,assignee"
+        )
         self.assertTrue(hasattr(issues[0].fields, "comment"))
         self.assertTrue(hasattr(issues[0].fields, "assignee"))
         self.assertFalse(hasattr(issues[0].fields, "reporter"))
 
-
         issues = self.jira.search_issues("key=%s" % self.issue_1)
         self.assertTrue(hasattr(issues[0].fields, "reporter"))
         self.assertTrue(hasattr(issues[0].fields, "comment"))
-        
+
         issues = self.jira.search_issues("key=%s" % self.issue_1, fields=[])
         self.assertFalse(hasattr(issues[0].fields, "comment"))
 


### PR DESCRIPTION
The `jira.search_issues` documentation states that when nothing is passed to the field parameter, all fields are returned.
https://jira.readthedocs.io/api.html?highlight=search_issues#jira.client.JIRA.search_issues
The "*all" has been set as the default field parameter to achieve this.

Same fix as #1354 
Resolves #1240 