### PR TITLE
As the keyring dependency is only used by jirashell, have it be part of the cli extras requirement.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,6 @@ setup_requires =
     setuptools_scm_git_archive >= 1.0
 install_requires =
     defusedxml
-    keyring
     packaging
     requests-oauthlib>=1.1.0
     requests>=2.10.0
@@ -64,6 +63,7 @@ install_requires =
 [options.extras_require]
 cli =
     ipython>=4.0.0
+    keyring
 docs =
     Sphinx>=2.2.0
     sphinx_rtd_theme>=0.4.3

--- a/tox.ini
+++ b/tox.ini
@@ -74,6 +74,7 @@ commands =
 
 [testenv:docs]
 extras =
+    cli
     docs
 # changedir=docs
 usedevelop = False


### PR DESCRIPTION


Signed-off-by: David Black <dblack@atlassian.com>