### PR TITLE
Remove setup_requires for setuptools_scm_git_archive

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,6 @@ zip_safe = False
 # These are required during `setup.py` run:
 setup_requires =
     setuptools_scm >= 1.15.0
-    setuptools_scm_git_archive >= 1.0
 install_requires =
     defusedxml
     packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ include_package_data = True
 zip_safe = False
 # These are required during `setup.py` run:
 setup_requires =
-    setuptools_scm >= 1.15.0
+    setuptools_scm >= 7.0.0
 install_requires =
     defusedxml
     packaging


### PR DESCRIPTION
This dependency is not needed.

The documentation at https://github.com/Changaco/setuptools_scm_git_archive
states that there are two files needed for this to work .git_archival.txt and
.gitattributes. Both files are missing in this repository.

See also https://github.com/pycontribs/jira/discussions/1365