### PR TITLE
Add notify to comment

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -332,7 +332,8 @@ Adding, editing and deleting comments is similarly straightforward::
     comment = jira.add_comment('JRA-1330', 'new comment')    # no Issue object required
     comment = jira.add_comment(issue, 'new comment', visibility={'type': 'role', 'value': 'Administrators'})  # for admins only
 
-    comment.update(body = 'updated comment body')
+    comment.update(body='updated comment body')
+    comment.update(body='updated comment body but no mail notification', notify=False)
     comment.delete()
 
 Transitions

--- a/jira/client.py
+++ b/jira/client.py
@@ -4330,16 +4330,16 @@ class JIRA:
             directoryId (int): The directory ID the new user should be a part of (Default: 1)
             password (Optional[str]): Optional, the password for the new user
             fullname (Optional[str]): Optional, the full name of the new user
-            notify (bool): Whether or not to send a notification to the new user. (Default: False)
-            active (bool): Whether or not to make the new user active upon creation. (Default: True)
-            ignore_existing (bool): Whether or not to ignore and existing user. (Default: False)
-            applicationKeys (Optional[list]): Keys of products user should have access to
+            notify (bool): Whether to send a notification to the new user. (Default: False)
+            active (bool): Whether to make the new user active upon creation. (Default: True)
+            ignore_existing (bool): Whether to ignore and existing user. (Default: False)
+            application_keys (Optional[list]): Keys of products user should have access to
 
         Raises:
             JIRAError:  If username already exists and `ignore_existing` has not been set to `True`.
 
         Returns:
-            bool: Whether or not the user creation was successful.
+            bool: Whether the user creation was successful.
 
 
         """

--- a/jira/client.py
+++ b/jira/client.py
@@ -1852,22 +1852,16 @@ class JIRA:
         data: Dict[str, Any] = {"body": body}
 
         if is_internal:
-            data.update(
-                {
-                    "properties": [
-                        {"key": "sd.public.comment", "value": {"internal": is_internal}}
-                    ]
-                }
-            )
-
+            data["properties"] = [
+                {"key": "sd.public.comment", "value": {"internal": is_internal}}
+            ]
         if visibility is not None:
             data["visibility"] = visibility
 
         url = self._get_url("issue/" + str(issue) + "/comment")
         r = self._session.post(url, data=json.dumps(data))
 
-        comment = Comment(self._options, self._session, raw=json_loads(r))
-        return comment
+        return Comment(self._options, self._session, raw=json_loads(r))
 
     # non-resource
     @translate_resource_args

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,6 @@ requires = [
   "setuptools_scm_git_archive >= 1.0",
   "wheel",
 ]
-requires-python = ">=3.8"
 build-backend = "setuptools.build_meta"
+[project]
+requires-python = ">=3.8"

--- a/tests/resources/test_comment.py
+++ b/tests/resources/test_comment.py
@@ -4,12 +4,17 @@ from tests.conftest import JiraTestCase
 class CommentTests(JiraTestCase):
     def setUp(self):
         JiraTestCase.setUp(self)
-        self.issue_1 = self.test_manager.project_b_issue1
-        self.issue_2 = self.test_manager.project_b_issue2
-        self.issue_3 = self.test_manager.project_b_issue3
+        self.issue_1_key = self.test_manager.project_b_issue1
+        self.issue_2_key = self.test_manager.project_b_issue2
+        self.issue_3_key = self.test_manager.project_b_issue3
+
+    def tearDown(self) -> None:
+        for issue in [self.issue_1_key, self.issue_2_key, self.issue_3_key]:
+            for comment in self.jira.comments(issue):
+                comment.delete()
 
     def test_comments(self):
-        for issue in [self.issue_1, self.jira.issue(self.issue_2)]:
+        for issue in [self.issue_1_key, self.jira.issue(self.issue_2_key)]:
             self.jira.issue(issue)
             comment1 = self.jira.add_comment(issue, "First comment")
             comment2 = self.jira.add_comment(issue, "Second comment")
@@ -22,24 +27,24 @@ class CommentTests(JiraTestCase):
             assert len(comments) == 0
 
     def test_expanded_comments(self):
-        comment1 = self.jira.add_comment(self.issue_1, "First comment")
-        comment2 = self.jira.add_comment(self.issue_1, "Second comment")
-        comments = self.jira.comments(self.issue_1, expand="renderedBody")
+        comment1 = self.jira.add_comment(self.issue_1_key, "First comment")
+        comment2 = self.jira.add_comment(self.issue_1_key, "Second comment")
+        comments = self.jira.comments(self.issue_1_key, expand="renderedBody")
         self.assertTrue(hasattr(comments[0], "renderedBody"))
         ret_comment1 = self.jira.comment(
-            self.issue_1, comment1.id, expand="renderedBody"
+            self.issue_1_key, comment1.id, expand="renderedBody"
         )
-        ret_comment2 = self.jira.comment(self.issue_1, comment2.id)
+        ret_comment2 = self.jira.comment(self.issue_1_key, comment2.id)
         comment1.delete()
         comment2.delete()
         self.assertTrue(hasattr(ret_comment1, "renderedBody"))
         self.assertFalse(hasattr(ret_comment2, "renderedBody"))
-        comments = self.jira.comments(self.issue_1)
+        comments = self.jira.comments(self.issue_1_key)
         assert len(comments) == 0
 
     def test_add_comment(self):
         comment = self.jira.add_comment(
-            self.issue_3,
+            self.issue_3_key,
             "a test comment!",
             visibility={"type": "role", "value": "Administrators"},
         )
@@ -49,7 +54,7 @@ class CommentTests(JiraTestCase):
         comment.delete()
 
     def test_add_comment_with_issue_obj(self):
-        issue = self.jira.issue(self.issue_3)
+        issue = self.jira.issue(self.issue_3_key)
         comment = self.jira.add_comment(
             issue,
             "a new test comment!",
@@ -61,9 +66,15 @@ class CommentTests(JiraTestCase):
         comment.delete()
 
     def test_update_comment(self):
-        comment = self.jira.add_comment(self.issue_3, "updating soon!")
+        comment = self.jira.add_comment(self.issue_3_key, "updating soon!")
         comment.update(body="updated!")
-        self.assertEqual(comment.body, "updated!")
+        assert comment.body == "updated!"
         # self.assertEqual(comment.visibility.type, 'role')
         # self.assertEqual(comment.visibility.value, 'Administrators')
+        comment.delete()
+
+    def test_update_comment_with_notify(self):
+        comment = self.jira.add_comment(self.issue_3_key, "updating soon!")
+        comment.update(body="updated! without notification", notify=False)
+        assert comment.body == "updated! without notification"
         comment.delete()


### PR DESCRIPTION
my own implementation of https://github.com/pycontribs/jira/pull/1008

I didn't want to add the functionality to `jira.add_comment` since I'm not sure if it has the same way of adding the notification as add_user => `data["notification"]='false'` OR `data["notifyUsers"] = "false"`