### PR TITLE
Configurable batch size for `JIRA._fetch_pages()` and dependant methods

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -83,6 +83,8 @@ packaging==21.3
     #   pytest
     #   pytest-sugar
     #   sphinx
+parameterized==0.8.1
+    # via jira (setup.cfg)
 parso==0.8.3
     # via jedi
 pickleshare==0.7.5

--- a/jira/client.py
+++ b/jira/client.py
@@ -397,7 +397,7 @@ class JIRA:
         proxies: Any = None,
         timeout: Optional[Union[Union[float, int], Tuple[float, float]]] = None,
         auth: Tuple[str, str] = None,
-        default_batch_sizes: Optional[Dict[Type[ResourceType], Optional[int]]] = None,
+        default_batch_sizes: Optional[Dict[Type[Resource], Optional[int]]] = None,
     ):
         """Construct a Jira client instance.
 
@@ -473,7 +473,7 @@ class JIRA:
             proxies (Optional[Any]): Sets the proxies for the HTTP session.
             auth (Optional[Tuple[str,str]]): Set a cookie auth token if this is required.
             logging (bool): Determine whether or not logging should be enabled. (Default: True)
-            default_batch_sizes (Optional[Dict[Type[ResourceType], Optional[int]]]): Manually specify the batch-sizes for the paginated retrieval of different item types.
+            default_batch_sizes (Optional[Dict[Type[Resource], Optional[int]]]): Manually specify the batch-sizes for the paginated retrieval of different item types.
               `Resource` is used as a fallback for every item type not specified. If a item type is mapped to `None` no fallback occurs, instead the JIRA-Backend will use its default batch-size.
               By default Issues will be queried in batches of 500, all other item types (`Resource`-key) will be queried in batches of 100.
               Above standard configuration could be manually supplied by setting this parameter to: ``{Issue: 500, Resource: 100}``

--- a/jira/client.py
+++ b/jira/client.py
@@ -474,9 +474,9 @@ class JIRA:
             logging (bool): Determine whether or not logging should be enabled. (Default: True)
             default_batch_sizes (Optional[Dict[Type[Resource], Optional[int]]]): Manually specify the batch-sizes for
               the paginated retrieval of different item types. `Resource` is used as a fallback for every item type not
-              specified. If a item type is mapped to `None` no fallback occurs, instead the JIRA-Backend will use its
+              specified. If an item type is mapped to `None` no fallback occurs, instead the JIRA-backend will use its
               default batch-size. By default all Resources will be queried in batches of 100. E.g., setting this to
-              ``{Issue: 500, Resources: None}`` will make :py:meth:`search_issues` query Issues in batches of 500, while
+              ``{Issue: 500, Resource: None}`` will make :py:meth:`search_issues` query Issues in batches of 500, while
               every other item type's batch-size will be controlled by the backend. (Default: None)
 
         """

--- a/jira/client.py
+++ b/jira/client.py
@@ -3143,6 +3143,11 @@ class JIRA:
         Returns:
             ResultList
         """
+        if not username and not query:
+            raise ValueError(
+                "Either 'username' or 'query' arguments must be specified."
+            )
+
         if username is not None:
             params = {"username": username}
         if query is not None:
@@ -3153,11 +3158,6 @@ class JIRA:
             params["issueKey"] = issueKey
         if expand is not None:
             params["expand"] = expand
-
-        if not username and not query:
-            raise ValueError(
-                "Either 'username' or 'query' arguments must be specified."
-            )
 
         return self._fetch_pages(
             User,

--- a/jira/client.py
+++ b/jira/client.py
@@ -368,7 +368,6 @@ class JIRA:
         },
         "default_batch_size": {
             Resource: 100,
-            Issue: 500,
         },
     }
 
@@ -473,11 +472,12 @@ class JIRA:
             proxies (Optional[Any]): Sets the proxies for the HTTP session.
             auth (Optional[Tuple[str,str]]): Set a cookie auth token if this is required.
             logging (bool): Determine whether or not logging should be enabled. (Default: True)
-            default_batch_sizes (Optional[Dict[Type[Resource], Optional[int]]]): Manually specify the batch-sizes for the paginated retrieval of different item types.
-              `Resource` is used as a fallback for every item type not specified. If a item type is mapped to `None` no fallback occurs, instead the JIRA-Backend will use its default batch-size.
-              By default Issues will be queried in batches of 500, all other item types (`Resource`-key) will be queried in batches of 100.
-              Above standard configuration could be manually supplied by setting this parameter to: ``{Issue: 500, Resource: 100}``
-              (Default: None)
+            default_batch_sizes (Optional[Dict[Type[Resource], Optional[int]]]): Manually specify the batch-sizes for
+              the paginated retrieval of different item types. `Resource` is used as a fallback for every item type not
+              specified. If a item type is mapped to `None` no fallback occurs, instead the JIRA-Backend will use its
+              default batch-size. By default all Resources will be queried in batches of 100. E.g., setting this to
+              ``{Issue: 500, Resources: None}`` will make :py:meth:`search_issues` query Issues in batches of 500, while
+              every other item type's batch-size will be controlled by the backend. (Default: None)
 
         """
         # force a copy of the tuple to be used in __del__() because

--- a/jira/client.py
+++ b/jira/client.py
@@ -397,7 +397,7 @@ class JIRA:
         proxies: Any = None,
         timeout: Optional[Union[Union[float, int], Tuple[float, float]]] = None,
         auth: Tuple[str, str] = None,
-        default_batch_sizes: Optional[Dict[ResourceType, Optional[int]]] = None,
+        default_batch_sizes: Optional[Dict[Type[ResourceType], Optional[int]]] = None,
     ):
         """Construct a Jira client instance.
 
@@ -473,12 +473,12 @@ class JIRA:
             proxies (Optional[Any]): Sets the proxies for the HTTP session.
             auth (Optional[Tuple[str,str]]): Set a cookie auth token if this is required.
             logging (bool): Determine whether or not logging should be enabled. (Default: True)
-            default_batch_sizes (Optional[Dict[ResourceType, Optional[int]]]): Manually specify the batch-sizes for the paginated retrieval of different item types.
+            default_batch_sizes (Optional[Dict[Type[ResourceType], Optional[int]]]): Manually specify the batch-sizes for the paginated retrieval of different item types.
               `Resource` is used as a fallback for every item type not specified. If a item type is mapped to `None` no fallback occurs, instead the JIRA-Backend will use its default batch-size.
               By default Issues will be queried in batches of 500, all other item types (`Resource`-key) will be queried in batches of 100.
-              Above standard configuration could be manually supplied by setting this parameter:
-                ``{Issue: 500, Resource: 100}``
+              Above standard configuration could be manually supplied by setting this parameter to: ``{Issue: 500, Resource: 100}``
               (Default: None)
+
         """
         # force a copy of the tuple to be used in __del__() because
         # sys.version_info could have already been deleted in __del__()

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,6 +94,7 @@ test =
     wheel>=0.24.0  # MIT
     xmlrunner>=1.7.7  # LGPL
     yanc>=0.3.3  # GPL
+    parameterized>=0.8.1  # BSD-3-Clause
 
 [options.entry_points]
 console_scripts =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -343,3 +343,13 @@ def find_by_name(seq, name):
     for seq_item in seq:
         if seq_item["name"] == name:
             return seq_item
+
+
+@pytest.fixture()
+def no_fields(monkeypatch):
+    """When we want to test the __init__ method of the jira.client.JIRA
+    we don't need any external calls to get the fields.
+
+    We don't need the features of a MagicMock, hence we don't use it here.
+    """
+    monkeypatch.setattr(JIRA, "fields", lambda *args, **kwargs: [])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -52,16 +52,6 @@ def slug(request, cl_admin):
     return slug
 
 
-@pytest.fixture()
-def no_fields(monkeypatch):
-    """When we want to test the __init__ method of the jira.client.JIRA
-    we don't need any external calls to get the fields.
-
-    We don't need the features of a MagicMock, hence we don't use it here.
-    """
-    monkeypatch.setattr(jira.client.JIRA, "fields", lambda *args, **kwargs: [])
-
-
 def test_delete_project(cl_admin, cl_normal, slug):
 
     assert cl_admin.delete_project(slug)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -12,11 +12,12 @@ import logging
 import os
 import pickle
 from time import sleep
-from typing import cast
+from typing import Optional, cast
 from unittest import mock
 
 import pytest
 import requests
+from parameterized import parameterized
 
 from jira import JIRA, Issue, JIRAError
 from jira.client import ResultList
@@ -296,37 +297,74 @@ class AsyncTests(JiraTestCase):
             get_server_info=False,
         )
 
-    def test_fetch_pages(self):
+    @parameterized.expand(
+        [
+            (
+                0,
+                26,
+                None,
+                False,
+            ),  # original behaviour, fetch all with jira's original return size (here 10)
+            (0, 26, 20, False),  # set batch size to 20
+            (5, 26, 20, False),  # test start_at
+            (5, 26, 20, 50),  # test maxResults set (one request)
+        ]
+    )
+    def test_fetch_pages(
+        self, start_at: int, total: int, batch_size: Optional[int], max_results: int
+    ):
         """Tests that the JIRA._fetch_pages method works as expected."""
         params = {"startAt": 0}
-        total = 26
+        batch_size = batch_size or 10
+        expected_calls = _calculate_calls_for_fetch_pages(
+            "https://jira.atlassian.com/rest/api/2/search",
+            start_at,
+            total,
+            max_results,
+            batch_size,
+        )
         expected_results = []
         for i in range(0, total):
             result = _create_issue_result_json(i, "summary %s" % i, key="KEY-%s" % i)
             expected_results.append(result)
-        result_one = _create_issue_search_results_json(
-            expected_results[:10], max_results=10, total=total
-        )
-        result_two = _create_issue_search_results_json(
-            expected_results[10:20], max_results=10, total=total
-        )
-        result_three = _create_issue_search_results_json(
-            expected_results[20:], max_results=6, total=total
-        )
+
+        if not max_results:
+            mocked_api_results = []
+            for i in range(start_at, total, batch_size):
+                mocked_api_result = _create_issue_search_results_json(
+                    expected_results[i : i + batch_size],
+                    max_results=batch_size,
+                    total=total,
+                )
+                mocked_api_results.append(mocked_api_result)
+        else:
+            mocked_api_results = [
+                _create_issue_search_results_json(
+                    expected_results[start_at : max_results + start_at],
+                    max_results=max_results,
+                    total=total,
+                )
+            ]
+
         mock_session = mock.Mock(name="mock_session")
         responses = mock.Mock(name="responses")
         responses.content = "_filler_"
-        responses.json.side_effect = [result_one, result_two, result_three]
+        responses.json.side_effect = mocked_api_results
         responses.status_code = 200
         mock_session.request.return_value = responses
         mock_session.get.return_value = responses
         self.jira._session.close()
         self.jira._session = mock_session
-        items = self.jira._fetch_pages(Issue, "issues", "search", 0, False, params)
-        self.assertEqual(len(items), total)
+        items = self.jira._fetch_pages(
+            Issue, "issues", "search", start_at, max_results, batch_size, params=params
+        )
+
+        actual_calls = [[kall[1], kall[2]] for kall in self.jira._session.method_calls]
+        self.assertEqual(actual_calls, expected_calls)
+        self.assertEqual(len(items), total - start_at)
         self.assertEqual(
             {item.key for item in items},
-            {expected_r["key"] for expected_r in expected_results},
+            {expected_r["key"] for expected_r in expected_results[start_at:]},
         )
 
 
@@ -348,6 +386,23 @@ def _create_issue_search_results_json(issues, **kwargs):
         "total": kwargs.get("total", len(issues)),
         "issues": issues,
     }
+
+
+def _calculate_calls_for_fetch_pages(
+    url: str, start_at: int, total: int, max_results: int, batch_size: int
+):
+    """Returns expected query parameters for specified search-issues arguments."""
+
+    if not max_results:
+        call_list = []
+        for i in range(start_at, total, batch_size):
+            call_ = [(url,), {"params": {"startAt": i, "maxResults": batch_size}}]
+            call_list.append(call_)
+    else:
+        call_list = [
+            [(url,), {"params": {"startAt": start_at, "maxResults": max_results}}]
+        ]
+    return call_list
 
 
 class WebsudoTests(JiraTestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -383,10 +383,18 @@ class AsyncTests(JiraTestCase):
             {Resource: 1, Issue: None},
             Issue,
             None,
-        ),  # None -> backend determines batch-size
-        ({Resource: 1}, Dashboard, 1),  # fallback working correctly
-        ({}, Issue, 500),  # default value for Issue
-        ({}, Resource, 100),  # default value for everything else
+        ),
+        ({Resource: 1}, Dashboard, 1),
+        ({}, Issue, 100),
+        ({}, Resource, 100),
+    ],
+    ids=[
+        "modify Issue default",
+        "modify Resource default",
+        "let backend decide for Issue",
+        "fallback",
+        "default for Issue",
+        "default value for everything else",
     ],
 )
 def test_get_batch_size(default_batch_sizes, item_type, expected, no_fields):


### PR DESCRIPTION
Add `batch_size` argument to `JIRA._fetch_pages` and dependant methods.
This allows for  significant performance improvements when trying to retrieve a lot of items using `maxResults=False`.

fixes #1393

The program was tested solely for our own use cases, which might differ from yours.

---
<sub>Jannik Meinecke (<jannik.meinecke@mercedes-benz.com>) on behalf of MBition GmbH.
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)

Licensed under [BSD-2-Clause license](https://github.com/pycontribs/jira/blob/main/LICENSE)</sub>