### PR TITLE
update sphinx to fix builds and update RTD config due to deprecations

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,10 +7,12 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.8"
+  jobs:
+    pre_install:
+      - export PIP_CONSTRAINT=constraints.txt
 
 python:
   install:
-    # PIP_CONSTRAINT has been set as env variable in the RTD web interface
     - method: pip
       path: .
       extra_requirements:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,8 +8,10 @@ build:
   tools:
     python: "3.8"
   jobs:
-    pre_install:
-      - export PIP_CONSTRAINT=constraints.txt
+    # Work-around to actually constrain dependencies
+    # https://github.com/readthedocs/readthedocs.org/issues/7258#issuecomment-1094978683
+    post_install:
+      - python -m pip install --upgrade --upgrade-strategy eager --no-cache-dir .[docs] -c constraints.txt
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,13 +7,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.8"
-  jobs:
-    # Work-around to actually constrain dependencies
-    # https://github.com/readthedocs/readthedocs.org/issues/7258#issuecomment-1094978683
-    post_install:
-      - python -m pip install --upgrade --upgrade-strategy eager --no-cache-dir .[docs] -c constraints.txt
 
 python:
+  # PIP_CONSTRAINT=constraints.txt set in the RTD web interface
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,3 +15,5 @@ python:
       path: .
       extra_requirements:
         - docs
+        # to autodoc jirashell
+        - cli

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,9 +7,13 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.8"
+  jobs:
+    # Work-around to actually constrain dependencies
+    # https://github.com/readthedocs/readthedocs.org/issues/7258#issuecomment-1094978683
+    post_install:
+      - python -m pip install --upgrade --upgrade-strategy eager --no-cache-dir .[docs,cli] -c constraints.txt
 
 python:
-  # PIP_CONSTRAINT=constraints.txt set in the RTD web interface
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,11 +4,13 @@ version: 2
 formats: all
 
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
 
 python:
-  version: 3.8
   install:
+    # PIP_CONSTRAINT has been set as env variable in the RTD web interface
     - method: pip
       path: .
       extra_requirements:

--- a/constraints.txt
+++ b/constraints.txt
@@ -37,7 +37,7 @@ decorator==5.1.1
     # via ipython
 defusedxml==0.7.1
     # via jira (setup.cfg)
-docutils==0.18.1
+docutils==0.17.1
     # via
     #   jira (setup.cfg)
     #   sphinx

--- a/constraints.txt
+++ b/constraints.txt
@@ -175,7 +175,7 @@ six==1.16.0
     #   requests-mock
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.0.2
+sphinx==5.1.1
     # via
     #   jira (setup.cfg)
     #   sphinx-rtd-theme

--- a/constraints.txt
+++ b/constraints.txt
@@ -175,7 +175,7 @@ six==1.16.0
     #   requests-mock
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.1.1
+sphinx==5.1.0
     # via
     #   jira (setup.cfg)
     #   sphinx-rtd-theme

--- a/constraints.txt
+++ b/constraints.txt
@@ -175,7 +175,7 @@ six==1.16.0
     #   requests-mock
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.1.0
+sphinx==5.1.1
     # via
     #   jira (setup.cfg)
     #   sphinx-rtd-theme


### PR DESCRIPTION
See the deprecation notice:
https://docs.readthedocs.io/en/stable/config-file/v2.html#python-version

Additionally used the constraints file for the rtd action