### PR TITLE
derive attachment fname from BufferedReader object (#1437) 

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1005,8 +1005,8 @@ class JIRA:
                 )
 
         fname = filename
-        if not fname and isinstance(attachment, BufferedReader):
-            fname = os.path.basename(attachment.name)
+        if not fname and isinstance(attachment_io, BufferedReader):
+            fname = os.path.basename(attachment_io.name)
 
         def generate_multipartencoded_request_args() -> Tuple[
             MultipartEncoder, CaseInsensitiveDict

--- a/tests/resources/test_attachment.py
+++ b/tests/resources/test_attachment.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from tests.conftest import TEST_ATTACH_PATH, JiraTestCase
 
@@ -30,6 +31,14 @@ class AttachmentTests(JiraTestCase):
 
     def test_2_add_remove_attachment_using_filename(self):
         issue = self.jira.issue(self.issue_1)
+        attachment_no_filename_specified = self.jira.add_attachment(
+            issue,
+            TEST_ATTACH_PATH,
+        )
+        new_attachment = self.jira.attachment(attachment_no_filename_specified.id)
+        msg = f"attachment, no filename specified {new_attachment.__dict__} of issue {issue}"
+        self.assertEqual(new_attachment.filename, Path(TEST_ATTACH_PATH).name, msg=msg)
+        #
         attachment = self.jira.add_attachment(
             issue, TEST_ATTACH_PATH, "new test attachment"
         )

--- a/tests/resources/test_attachment.py
+++ b/tests/resources/test_attachment.py
@@ -28,12 +28,11 @@ class AttachmentTests(JiraTestCase):
             )
             # JIRA returns a HTTP 204 upon successful deletion
             self.assertEqual(attachment.delete().status_code, 204)
+
     def test_attach_with_no_filename(self):
         issue = self.jira.issue(self.issue_1)
         attachment_no_filename_specified = self.jira.add_attachment(
-            issue=issue.key,
-            attachment=TEST_ATTACH_PATH,
-            filename=None
+            issue=issue.key, attachment=TEST_ATTACH_PATH, filename=None
         )
         new_attachment = self.jira.attachment(attachment_no_filename_specified.id)
         msg = f"attachment, no filename specified {new_attachment.__dict__} of issue {issue}"

--- a/tests/resources/test_attachment.py
+++ b/tests/resources/test_attachment.py
@@ -28,17 +28,19 @@ class AttachmentTests(JiraTestCase):
             )
             # JIRA returns a HTTP 204 upon successful deletion
             self.assertEqual(attachment.delete().status_code, 204)
-
-    def test_2_add_remove_attachment_using_filename(self):
+    def test_attach_with_no_filename(self):
         issue = self.jira.issue(self.issue_1)
         attachment_no_filename_specified = self.jira.add_attachment(
-            issue,
-            TEST_ATTACH_PATH,
+            issue=issue.key,
+            attachment=TEST_ATTACH_PATH,
+            filename=None
         )
         new_attachment = self.jira.attachment(attachment_no_filename_specified.id)
         msg = f"attachment, no filename specified {new_attachment.__dict__} of issue {issue}"
-        self.assertEqual(new_attachment.filename, Path(TEST_ATTACH_PATH).name, msg=msg)
-        #
+        assert new_attachment.filename == Path(TEST_ATTACH_PATH).name, msg
+
+    def test_2_add_remove_attachment_using_filename(self):
+        issue = self.jira.issue(self.issue_1)
         attachment = self.jira.add_attachment(
             issue, TEST_ATTACH_PATH, "new test attachment"
         )


### PR DESCRIPTION
Offering a fix for #1437.