### PR TITLE
Fix using str as issue type with create_issue when issue type with that name exists in many projects

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1498,18 +1498,17 @@ class JIRA:
 
         p = data["fields"]["project"]
 
+        project_id = None
         if isinstance(p, (str, int)):
             project_id = self.project(str(p)).id
             data["fields"]["project"] = {"id": project_id}
-        else:
-            project_id = None
 
         p = data["fields"]["issuetype"]
         if isinstance(p, int):
             data["fields"]["issuetype"] = {"id": p}
         elif isinstance(p, str):
             data["fields"]["issuetype"] = {
-                "id": self.issue_type_by_name(str(p), project=str(project_id)).id
+                "id": self.issue_type_by_name(str(p), project=str(project_id) if project_id else None).id
             }
 
         url = self._get_url("issue")

--- a/jira/client.py
+++ b/jira/client.py
@@ -1508,7 +1508,9 @@ class JIRA:
             data["fields"]["issuetype"] = {"id": p}
         elif isinstance(p, str):
             data["fields"]["issuetype"] = {
-                "id": self.issue_type_by_name(str(p), project=str(project_id) if project_id else None).id
+                "id": self.issue_type_by_name(
+                    str(p), project=str(project_id) if project_id else None
+                ).id
             }
 
         url = self._get_url("issue")

--- a/jira/client.py
+++ b/jira/client.py
@@ -1499,13 +1499,18 @@ class JIRA:
         p = data["fields"]["project"]
 
         if isinstance(p, (str, int)):
-            data["fields"]["project"] = {"id": self.project(str(p)).id}
+            project_id = self.project(str(p)).id
+            data["fields"]["project"] = {"id": project_id}
+        else:
+            project_id = None
 
         p = data["fields"]["issuetype"]
         if isinstance(p, int):
             data["fields"]["issuetype"] = {"id": p}
         elif isinstance(p, str):
-            data["fields"]["issuetype"] = {"id": self.issue_type_by_name(str(p)).id}
+            data["fields"]["issuetype"] = {
+                "id": self.issue_type_by_name(str(p), project=str(project_id)).id
+            }
 
         url = self._get_url("issue")
         r = self._session.post(url, data=json.dumps(data))
@@ -2518,15 +2523,21 @@ class JIRA:
         """
         return self._find_for_resource(IssueType, id)
 
-    def issue_type_by_name(self, name: str) -> IssueType:
+    def issue_type_by_name(self, name: str, project: Optional[str] = None) -> IssueType:
         """
         Args:
             name (str): Name of the issue type
+            project (str): Key or ID of the project. If set, only issue types available for that project will be looked up
 
         Returns:
             IssueType
         """
-        matching_issue_types = [it for it in self.issue_types() if it.name == name]
+        if project:
+            issue_types = self.project(project, expand="issueTypes").issueTypes
+        else:
+            issue_types = self.issue_types()
+
+        matching_issue_types = [it for it in issue_types if it.name == name]
         if len(matching_issue_types) == 1:
             return matching_issue_types[0]
         elif len(matching_issue_types) == 0:

--- a/tests/resources/test_issue.py
+++ b/tests/resources/test_issue.py
@@ -268,6 +268,17 @@ class IssueTests(JiraTestCase):
         )
         self.assertEqual(issue.get_field("issuetype").name, dyn_it.name)
 
+    def test_create_issue_with_issue_type_name(self):
+        issue_types_resolved = self.jira.issue_types()
+        dyn_it = issue_types_resolved[0]
+
+        issue = self.jira.create_issue(
+            summary="Test issue created using a str issuetype",
+            project=self.project_b,
+            issuetype=dyn_it.name,
+        )
+        self.assertEqual(issue.get_field("issuetype").name, dyn_it.name)
+
     def test_update_with_fieldargs(self):
         issue = self.jira.create_issue(
             summary="Test issue for updating with fieldargs",


### PR DESCRIPTION
Fixes #1444 

#1445 does solve the issue when providing the ID, but it is still not possible, as it was before, to provide a string like so:
```python
jira.create_issue(
    fields={
        "project": "PROJECTKEY",
        "issuetype": "User Story",
        "summary": "test",
    }
)
```

This is because [issue_type_by_name](https://github.com/pycontribs/jira/blob/00c37981511a923ee9cb41598118ceb04634fe0b/jira/client.py#L2521) does not take the project into consideration and thus will only work if the issuetype name exists only once across all projects in the Jira instance.

This situation is more frequent when using the team-managed projects that use their own issue types instead of sharing the standard ones.

I was not able to setup CI unfortunately, but I tested by calling my new code from another project which exhibited #1444