### PR TITLE
Avoid always passing on an empty body even if not given

### DIFF
--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -159,7 +159,7 @@ class ResilientSession(Session):
         request_headers.update(original_kwargs.get("headers", {}))
         prepared_kwargs["headers"] = request_headers
 
-        data = original_kwargs.get("data", {})
+        data = original_kwargs.get("data", None)
         if isinstance(data, dict):
             # mypy ensures we don't do this,
             # but for people subclassing we should preserve old behaviour

--- a/tests/test_resilientsession.py
+++ b/tests/test_resilientsession.py
@@ -107,3 +107,22 @@ def test_passthrough_class():
     # WHEN: the dict of request args are prepared
     # THEN: The exact same dict is returned
     assert passthrough_class.prepare(my_kwargs) is my_kwargs
+
+
+@patch("requests.Session.request")
+def test_unspecified_body_remains_unspecified(mocked_request_method: Mock):
+    # Disable retries for this test.
+    session = jira.resilientsession.ResilientSession(max_retries=0)
+    # Data is not specified here.
+    session.get(url="mocked_url")
+    kwargs = mocked_request_method.call_args.kwargs
+    assert "data" not in kwargs
+
+
+@patch("requests.Session.request")
+def test_nonempty_body_is_forwarded(mocked_request_method: Mock):
+    # Disable retries for this test.
+    session = jira.resilientsession.ResilientSession(max_retries=0)
+    session.get(url="mocked_url", data={"some": "fake-data"})
+    kwargs = mocked_request_method.call_args.kwargs
+    assert kwargs["data"] == '{"some": "fake-data"}'


### PR DESCRIPTION
This PR suggest a small change to the `ResilientSession` class that avoids sending a request body in cases where none was specified.

I have checked issues and PRs in the repository but could not find one that relates to this change.

# Motivation

Not all requests contain request bodies. For GET requests, for example, a request body can simply be ignored (please also see [this comprehensive answer on StackOverflow](https://stackoverflow.com/a/15656853)). However, there are instances of Jira that fail a GET request if it has a non-empty request body.

Up until the current `main`, all requests have a body (please also see [here](https://github.com/pycontribs/jira/blob/main/jira/resilientsession.py#L162-L166)). Those that do not specify one will have an empty JSON object `"{}"` as body. As far as I could determine, this change was introduced in commit c6d59a1b.

# Tests

I have run all the tests for the `ResilientSession` class and they passed. I've also added tests for the new behaviour. I could not get the full test suite running, neither for the current state of `main` nor for the feature branch.

I would be very thankful if you could consider incorporating this pull request. In case you have any questions or would like some changes, I am happy to answer or incorporate them.