### PR TITLE
add required parameter field 'permissions' to my_permissions method

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -112,7 +112,7 @@ pyjwt==2.4.0
     #   requests-jwt
 pyparsing==3.0.7
     # via packaging
-pyspnego==0.5.3
+pyspnego==0.5.4
     # via requests-kerberos
 pytest==7.1.1
     # via

--- a/jira/client.py
+++ b/jira/client.py
@@ -2630,6 +2630,7 @@ class JIRA:
         projectId: Optional[str] = None,
         issueKey: Optional[str] = None,
         issueId: Optional[str] = None,
+        permissions: Optional[str] = None,
     ) -> Dict[str, Dict[str, Dict[str, str]]]:
         """Get a dict of all available permissions on the server.
 
@@ -2638,6 +2639,7 @@ class JIRA:
             projectId (Optional[str]): limit returned permissions to the specified project
             issueKey (Optional[str]): limit returned permissions to the specified issue
             issueId (Optional[str]): limit returned permissions to the specified issue
+            permissions (Optional[str]): limit returned permissions to the specified csv permission keys (cloud required field)
 
         Returns:
             Dict[str, Dict[str, Dict[str, str]]]
@@ -2651,6 +2653,9 @@ class JIRA:
             params["issueKey"] = issueKey
         if issueId is not None:
             params["issueId"] = issueId
+        if permissions is not None:
+            params["permissions"] = permissions
+
         return self._get_json("mypermissions", params=params)
 
     # Priorities

--- a/jira/client.py
+++ b/jira/client.py
@@ -2634,6 +2634,10 @@ class JIRA:
     ) -> Dict[str, Dict[str, Dict[str, str]]]:
         """Get a dict of all available permissions on the server.
 
+        ``permissions`` is a comma-separated value list of permission keys that is
+        required in Jira Cloud. For possible and allowable permission values, see
+        https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-permission-schemes/#built-in-permissions
+
         Args:
             projectKey (Optional[str]): limit returned permissions to the specified project
             projectId (Optional[str]): limit returned permissions to the specified project

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -214,6 +214,10 @@ class MyPermissionsCloudTests(JiraTestCase):
         )
         self.assertEqual(len(perms["permissions"]), 3)
 
+    def test_missing_required_param_my_permissions_raises_exception(self):
+        with self.assertRaises(JIRAError):
+            self.jira.my_permissions()
+
     def test_invalid_param_my_permissions_raises_exception(self):
         with self.assertRaises(JIRAError):
             self.jira.my_permissions("INVALID_PERMISSION")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -22,7 +22,7 @@ from parameterized import parameterized
 from jira import JIRA, Issue, JIRAError
 from jira.client import ResultList
 from jira.resources import Dashboard, Resource, cls_for_resource
-from tests.conftest import JiraTestCase, rndpassword
+from tests.conftest import JiraTestCase, allow_on_cloud, rndpassword
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -180,6 +180,7 @@ class MyPermissionsServerTests(JiraTestCase):
         self.assertGreaterEqual(len(perms["permissions"]), 10)
 
 
+@allow_on_cloud
 class MyPermissionsCloudTests(JiraTestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
As per Jira announcement:

_In order to guarantee stability and performance of Jira Cloud, we are constantly reviewing Jira REST APIs to make sure their design enables and encourages good practices. Starting 1 February 2019, we will require that you provide the permissions query parameter in all requests to the [Get my permissions](https://developer.atlassian.com/cloud/jira/platform/rest/#api-rest-api-2-mypermissions-get) resource._

Reference:
https://developer.atlassian.com/cloud/jira/platform/change-notice-get-my-permissions-requires-permissions-query-parameter/