### PR TITLE
Add method to get issues completed within a sprint

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -4735,6 +4735,19 @@ class JIRA:
 
         return issues
 
+    def completed_issues(self, board_id: str, sprint_id: str):
+        """Return the completed issues for the sprint."""
+        r_json: Dict[str, Any] = self._get_json(
+            f"rapid/charts/sprintreport?rapidViewId={board_id}&sprintId={sprint_id}",
+            base=self.AGILE_BASE_URL,
+        )
+        issues = [
+            Issue(self._options, self._session, raw_issues_json)
+            for raw_issues_json in r_json["contents"]["completedIssues"]
+        ]
+
+        return issues
+
     def removedIssuesEstimateSum(self, board_id: str, sprint_id: str):
         """Return the total incompleted points this sprint."""
         data: Dict[str, Any] = self._get_json(

--- a/jira/client.py
+++ b/jira/client.py
@@ -4723,7 +4723,7 @@ class JIRA:
         return data["contents"]["incompletedIssuesEstimateSum"]["value"]
 
     def removed_issues(self, board_id: str, sprint_id: str):
-        """Return the completed issues for the sprint."""
+        """Return the removed issues for the sprint."""
         r_json: Dict[str, Any] = self._get_json(
             f"rapid/charts/sprintreport?rapidViewId={board_id}&sprintId={sprint_id}",
             base=self.AGILE_BASE_URL,


### PR DESCRIPTION
I've added the ability to get a list of issues completed within a particular sprint. It works the same way `removed_issues()` does. I found `completedIssues` in the JSON which is used in the Sprint Report's 'Completed Issues' section.

While I was here, I fixed the misleading docstring which I stumbled across whilst trying to find the method to return the list of items I wanted (completed ones).