### PR TITLE
Properly parse errorMessage key in error response

### DIFF
--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -103,6 +103,10 @@ def parse_error_msg(resp: Response) -> str:
     if "message" in resp_data:
         # Jira 5.1 errors
         parsed_error = resp_data["message"]
+    if "errorMessage" in resp_data:
+        # Jira sometimes returns "errorMessage" as a message text key
+        # (for example for "Site temporary unavailable" message)
+        parsed_error = resp_data["message"]
     elif "errorMessages" in resp_data:
         # Jira 5.0.x error messages sometimes come wrapped in this array
         # Sometimes this is present but empty

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -79,6 +79,10 @@ def get_error_list(r: Response) -> List[str]:
                 if "message" in response:
                     # Jira 5.1 errors
                     error_list = [response["message"]]
+                if "errorMessage" in response:
+                    # Jira sometimes returns "errorMessage" as a message text key
+                    # (for example for "Site temporary unavailable" message)
+                    error_list = [response["errorMessage"]]
                 elif "errorMessages" in response and len(response["errorMessages"]) > 0:
                     # Jira 5.0.x error messages sometimes come wrapped in this array
                     # Sometimes this is present but empty


### PR DESCRIPTION
After [recent refactoring](https://github.com/pycontribs/jira/commit/c6d59a1b2fce536b9cb11139a38c474ce23ca416) of the resilientsession module, we started to get empty `text` field in the `JIRAError` instances for the "Site temporary unavailable" errors.

This PR adds proper processing of such error responses