### PR TITLE
Updating installation instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,13 +7,20 @@ The easiest (and best) way to install jira-python is through `pip <https://pip.p
 
 This will handle installation of the client itself as well as the requirements.
 
-If you're going to run the client standalone, we strongly recommend using a `virtualenv <https://virtualenv.pypa.io/>`_,
-which pip can also set up for you
+If you're going to run the client standalone, we strongly recommend using a `virtualenv <https://virtualenv.pypa.io/>`_:
 
 .. code-block:: bash
 
-    pip -E jira_python install jira
-    workon jira_python
+    python -m venv jira_python
+    source jira_python/bin/activate
+    pip install 'jira[cli]'
+
+or:
+
+.. code-block:: bash
+
+    python -m venv jira_python
+    jira_python/bin/pip install 'jira[cli]'
 
 Doing this creates a private Python "installation" that you can freely upgrade, degrade or break without putting
 the critical components of your system at risk.


### PR DESCRIPTION
`pip -E` was removed in pip 1.1 (2012-02-16). https://pip.pypa.io/en/stable/news/#v1-1

Since the previous paragraph mentions running the client standalone, let's install `jira[cli]` instead of the plain `jira`.