### PR TITLE
adding sprint goal

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -4698,7 +4698,9 @@ class JIRA:
                 )
         return sprints
 
-    def update_sprint(self, id, name=None, startDate=None, endDate=None, state=None, goal=None):
+    def update_sprint(
+        self, id, name=None, startDate=None, endDate=None, state=None, goal=None
+    ):
         payload = {}
         if name:
             payload["name"] = name
@@ -4709,7 +4711,7 @@ class JIRA:
         if state:
             payload["state"] = state
         if goal:
-            payload['goal'] = goal
+            payload["goal"] = goal
 
         url = self._get_url(f"sprint/{id}", base=self.AGILE_BASE_URL)
         r = self._session.put(url, data=json.dumps(payload))

--- a/jira/client.py
+++ b/jira/client.py
@@ -4698,7 +4698,7 @@ class JIRA:
                 )
         return sprints
 
-    def update_sprint(self, id, name=None, startDate=None, endDate=None, state=None):
+    def update_sprint(self, id, name=None, startDate=None, endDate=None, state=None, goal=None):
         payload = {}
         if name:
             payload["name"] = name
@@ -4708,6 +4708,8 @@ class JIRA:
             payload["endDate"] = endDate
         if state:
             payload["state"] = state
+        if goal:
+            payload['goal'] = goal
 
         url = self._get_url(f"sprint/{id}", base=self.AGILE_BASE_URL)
         r = self._session.put(url, data=json.dumps(payload))


### PR DESCRIPTION
The method `update_sprint` doesn't allow to update the sprint goal, as it is not included in method's parameter. Simply adding `goal` into function's argument, just like other arguments (e.g. `name`, `endDate`, `startDate`) fixes that.