### PR TITLE
Provide page-aware access to createmeta issuetypes

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -60,6 +60,7 @@ from jira.resources import (
     Customer,
     CustomFieldOption,
     Dashboard,
+    Field,
     Filter,
     Group,
     Issue,
@@ -1722,6 +1723,21 @@ class JIRA:
         else:
             return Issue(self._options, self._session, raw=raw_issue_json)
 
+    def _check_createmeta_issuetypes(self) -> None:
+        """Check whether Jira deployment supports the createmeta issuetypes endpoint.
+
+        Raises:
+            JIRAError: If the deployment does not support the API endpoint.
+
+        Returns:
+            None
+        """
+        if self._is_cloud or self._version < (8, 4, 0):
+            raise JIRAError(
+                f"Unsupported JIRA deployment type: {self.deploymentType} or version: {self._version}. "
+                "Use 'createmeta' instead."
+            )
+
     def createmeta_issuetypes(
         self,
         projectIdOrKey: str | int,
@@ -1737,12 +1753,7 @@ class JIRA:
         Returns:
             Dict[str, Any]
         """
-        if self._is_cloud or self._version < (8, 4, 0):
-            raise JIRAError(
-                f"Unsupported JIRA deployment type: {self.deploymentType} or version: {self._version}. "
-                "Use 'createmeta' instead."
-            )
-
+        self._check_createmeta_issuetypes()
         return self._get_json(f"issue/createmeta/{projectIdOrKey}/issuetypes")
 
     def createmeta_fieldtypes(
@@ -1762,12 +1773,7 @@ class JIRA:
         Returns:
             Dict[str, Any]
         """
-        if self._is_cloud or self._version < (8, 4, 0):
-            raise JIRAError(
-                f"Unsupported JIRA deployment type: {self.deploymentType} or version: {self._version}. "
-                "Use 'createmeta' instead."
-            )
-
+        self._check_createmeta_issuetypes()
         return self._get_json(
             f"issue/createmeta/{projectIdOrKey}/issuetypes/{issueTypeId}"
         )
@@ -2618,6 +2624,60 @@ class JIRA:
             for raw_type_json in r_json
         ]
         return issue_types
+
+    def project_issue_types(
+        self,
+        project: str,
+        startAt: int = 0,
+        maxResults: int = 50,
+    ) -> ResultList[IssueType]:
+        """Get a list of issue type Resources available in a given project from the server.
+
+        Args:
+            project (str): ID or key of the project to query issue types from.
+            startAt (int): Index of first issue type to return. (Default: ``0``)
+            maxResults (int): Maximum number of issue types to return. (Default: ``50``)
+
+        Returns:
+            ResultList[IssueType]
+        """
+        self._check_createmeta_issuetypes()
+        issue_types = self._fetch_pages(
+            IssueType,
+            "values",
+            f"issue/createmeta/{project}/issuetypes",
+            startAt=startAt,
+            maxResults=maxResults,
+        )
+        return issue_types
+
+    def project_issue_fields(
+        self,
+        project: str,
+        issue_type: str,
+        startAt: int = 0,
+        maxResults: int = 50,
+    ) -> ResultList[Field]:
+        """Get a list of field type Resources available for a project and issue type from the server.
+
+        Args:
+            project (str): ID or key of the project to query field types from.
+            issue_type (str): ID of the issue type to query field types from.
+            startAt (int): Index of first issue type to return. (Default: ``0``)
+            maxResults (int): Maximum number of issue types to return. (Default: ``50``)
+
+        Returns:
+            ResultList[Issue._IssueFields]
+        """
+        self._check_createmeta_issuetypes()
+        fields = self._fetch_pages(
+            Field,
+            "values",
+            f"issue/createmeta/{project}/issuetypes/{issue_type}",
+            startAt=startAt,
+            maxResults=maxResults,
+        )
+        return fields
 
     def issue_type(self, id: str) -> IssueType:
         """Get an issue type Resource from the server.

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -560,14 +560,14 @@ class Field(Resource):
 
     def __init__(
         self,
-        options: Dict[str, str],
+        options: dict[str, str],
         session: ResilientSession,
-        raw: Dict[str, Any] = None,
+        raw: dict[str, Any] = None,
     ):
         Resource.__init__(self, "field/{0}", options, session)
         if raw:
             self._parse_raw(raw)
-        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
+        self.raw: dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
 class Filter(Resource):

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -552,6 +552,24 @@ class Dashboard(Resource):
         self.raw: dict[str, Any] = cast(Dict[str, Any], self.raw)
 
 
+class Field(Resource):
+    """An issue field.
+
+    A field cannot be fetched from the Jira APi individually, but paginated lists of fields are returned by some endpoints.
+    """
+
+    def __init__(
+        self,
+        options: Dict[str, str],
+        session: ResilientSession,
+        raw: Dict[str, Any] = None,
+    ):
+        Resource.__init__(self, "field/{0}", options, session)
+        if raw:
+            self._parse_raw(raw)
+        self.raw: Dict[str, Any] = cast(Dict[str, Any], self.raw)
+
+
 class Filter(Resource):
     """An issue navigator filter."""
 


### PR DESCRIPTION
Version 3.5.0 of the client library introduced the createmeta_issuetypes() and createmeta_fieldtypes() client member functions to replace the deprecated form of the createmeta Jira endpoint. However, these functions return the raw JSON of a single response, and do not handle pagination that may be applied to the endpoints, such as when an issue type within a project has more than 50 associated fields. I recently encountered a Jira deployment where this case occurred, rendering
createmeta_fieldtypes() unuseful.

Because the functions added in 3.5.0 have a different return type than these new functions, instead of changing the behavior of those functions this commit creates two new client member functions: project_issue_types()  and project_issue_fields().

I opened this commit after I had to query project issue type fields in a case where there were more than 50.

I am open to constructive criticism if anyone can think of a more elegant solution than creating a new `Resource` subclass for something that cannot be individually queried in the Jira API.