### PR TITLE
fix verify not sent with request (#1573)

### DIFF
--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -184,6 +184,9 @@ class ResilientSession(Session):
             # but for people subclassing we should preserve old behaviour
             prepared_kwargs["data"] = json.dumps(data)
 
+        if "verify" not in prepared_kwargs:
+            prepared_kwargs["verify"] = self.verify
+
         return prepared_kwargs
 
     def request(  # type: ignore[override] # An intentionally different override

--- a/tests/test_resilientsession.py
+++ b/tests/test_resilientsession.py
@@ -197,3 +197,18 @@ def test_with_requests_tuple_timeout(mocked_request_method: Mock):
     session.get(url="mocked_url", data={"some": "fake-data"})
     kwargs = mocked_request_method.call_args.kwargs
     assert kwargs["data"] == '{"some": "fake-data"}'
+
+
+@patch("requests.Session.request")
+def test_verify_is_forwarded(mocked_request_method: Mock):
+    # Disable retries for this test.
+    session = jira.resilientsession.ResilientSession(max_retries=0)
+
+    session.get(url="mocked_url", data={"some": "fake-data"})
+    kwargs = mocked_request_method.call_args.kwargs
+    assert kwargs["verify"] == session.verify is True
+
+    session.verify = False
+    session.get(url="mocked_url", data={"some": "fake-data"})
+    kwargs = mocked_request_method.call_args.kwargs
+    assert kwargs["verify"] == session.verify is False


### PR DESCRIPTION
This commit fixes an issue where the `verify` option is not passed along with requests issued by the ResilientSession class. This commit adds the `verify` option into the request args inside the `_jira_prepare` function.

The commit includes a unit test that verifies that `session.verify` is correclty handed over to requests during subsequent Jira API calls.