### PR TITLE
Switch from SIGNATURE_RSA to SIGNATURE_HMAC_SHA1

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -3702,13 +3702,13 @@ class JIRA:
     def _create_oauth_session(
         self, oauth, timeout: float | int | tuple[float, float] | None
     ):
-        from oauthlib.oauth1 import SIGNATURE_RSA
+        from oauthlib.oauth1 import SIGNATURE_HMAC_SHA1
         from requests_oauthlib import OAuth1
 
         oauth_instance = OAuth1(
             oauth["consumer_key"],
             rsa_key=oauth["key_cert"],
-            signature_method=SIGNATURE_RSA,
+            signature_method=SIGNATURE_HMAC_SHA1,
             resource_owner_key=oauth["access_token"],
             resource_owner_secret=oauth["access_token_secret"],
         )

--- a/jira/jirashell.py
+++ b/jira/jirashell.py
@@ -15,7 +15,7 @@ from urllib.parse import parse_qsl
 
 import keyring
 import requests
-from oauthlib.oauth1 import SIGNATURE_RSA
+from oauthlib.oauth1 import SIGNATURE_HMAC_SHA1
 from requests_oauthlib import OAuth1
 
 from jira import JIRA, __version__
@@ -29,7 +29,7 @@ def oauth_dance(server, consumer_key, key_cert_data, print_tokens=False, verify=
         verify = server.startswith("https")
 
     # step 1: get request tokens
-    oauth = OAuth1(consumer_key, signature_method=SIGNATURE_RSA, rsa_key=key_cert_data)
+    oauth = OAuth1(consumer_key, signature_method=SIGNATURE_HMAC_SHA1, rsa_key=key_cert_data)
     r = requests.post(
         server + "/plugins/servlet/oauth/request-token", verify=verify, auth=oauth
     )
@@ -71,7 +71,7 @@ def oauth_dance(server, consumer_key, key_cert_data, print_tokens=False, verify=
     # step 3: get access tokens for validated user
     oauth = OAuth1(
         consumer_key,
-        signature_method=SIGNATURE_RSA,
+        signature_method=SIGNATURE_HMAC_SHA1,
         rsa_key=key_cert_data,
         resource_owner_key=request_token,
         resource_owner_secret=request_token_secret,

--- a/jira/jirashell.py
+++ b/jira/jirashell.py
@@ -29,7 +29,9 @@ def oauth_dance(server, consumer_key, key_cert_data, print_tokens=False, verify=
         verify = server.startswith("https")
 
     # step 1: get request tokens
-    oauth = OAuth1(consumer_key, signature_method=SIGNATURE_HMAC_SHA1, rsa_key=key_cert_data)
+    oauth = OAuth1(
+        consumer_key, signature_method=SIGNATURE_HMAC_SHA1, rsa_key=key_cert_data
+    )
     r = requests.post(
         server + "/plugins/servlet/oauth/request-token", verify=verify, auth=oauth
     )


### PR DESCRIPTION
RHEL 9 has a policy of deprecating SHA1 and has removed it from python-oauthlib via the addition of locally added patch.

Switching to SIGNATURE_RSA_HMAC_SHA1 allows this module to be used on RHEL9 when the system package python3-oauthlib-3.1.1-2.el9.noarch.rpm is used.

Here is the patch form RHEL9 python-oauthlib.
[0001-Rip-out-RSA-SHA1.patch.txt](https://github.com/pycontribs/jira/files/11132574/0001-Rip-out-RSA-SHA1.patch.txt)
