### PR TITLE
implement SHA fallback behaviour

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -3711,9 +3711,14 @@ class JIRA:
             self._session.auth = oauth_instance
             try:
                 self.myself()
+                _logging.debug(f"OAuth1 succeeded with signature_method={sha_type}")
                 return  # successful response, return with happy session
             except JIRAError:
-                _logging.exception(f"Failed to create OAuth session with {sha_type}")
+                _logging.exception(
+                    f"Failed to create OAuth session with signature_method={sha_type}.\n"
+                    + "Attempting fallback method(s)."
+                    + "Consider specifying the signature via oauth['signature_method']."
+                )
                 if sha_type is FALLBACK_SHA:
                     raise  # We have exhausted our options, bubble up exception
 

--- a/jira/client.py
+++ b/jira/client.py
@@ -3693,7 +3693,7 @@ class JIRA:
         from requests_oauthlib import OAuth1
 
         try:
-            from oauthlib.oauth1 import SIGNATURE_RSA_SHA1 as FALLBACK_SHA
+            from oauthlib.oauth1 import SIGNATURE_RSA as FALLBACK_SHA
         except ImportError:
             FALLBACK_SHA = DEFAULT_SHA
             _logging.debug("Fallback SHA 'SIGNATURE_RSA_SHA1' could not be imported.")

--- a/jira/client.py
+++ b/jira/client.py
@@ -3715,7 +3715,7 @@ class JIRA:
             except JIRAError:
                 _logging.exception(f"Failed to create OAuth session with {sha_type}")
                 if sha_type is FALLBACK_SHA:
-                    raise # We have exhausted our options, bubble up exception
+                    raise  # We have exhausted our options, bubble up exception
 
     def _create_kerberos_session(
         self,

--- a/jira/client.py
+++ b/jira/client.py
@@ -3714,6 +3714,8 @@ class JIRA:
                 return  # successful response, return with happy session
             except JIRAError:
                 _logging.exception(f"Failed to create OAuth session with {sha_type}")
+                if sha_type is FALLBACK_SHA:
+                    raise # We have exhausted our options, bubble up exception
 
     def _create_kerberos_session(
         self,


### PR DESCRIPTION
# Summary of changes
1. try multiple SHAs with OAuth1, going from: user choice, most secure default, known working fallback

- [ ] should try and get some tests
- [x] need to confirm behaviour of RHEL