### PR TITLE
Add 'add_filter_share_permissions' method and support in create_filter()

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -35,6 +35,7 @@ from typing import (
     Literal,
     SupportsIndex,
     TypeVar,
+    Union,
     no_type_check,
     overload,
 )
@@ -1233,6 +1234,7 @@ class JIRA:
         description: str = None,
         jql: str = None,
         favourite: bool = None,
+        share_permissions: Union[List[dict], dict] = None
     ) -> Filter:
         """Create a new filter and return a filter Resource for it.
 
@@ -1241,6 +1243,8 @@ class JIRA:
             description (str): Useful human-readable description of the new filter
             jql (str): query string that defines the filter
             favourite (Optional[bool]): True adds this filter to the current user's favorites (Default: ``None``)
+            share_permissions (Optional[Union[List[dict], dict]]): Ddds the provided share permissions to the newly
+                created filter. Check `add share permission` documentation for specific fields. (Default: ``None``)
 
         Returns:
             Filter
@@ -1258,11 +1262,16 @@ class JIRA:
         r = self._session.post(url, data=json.dumps(data))
 
         raw_filter_json: dict[str, Any] = json_loads(r)
+
+        # If share permissions information provided, add permissions to newly created filter
+        if share_permissions:
+            self.add_filter_share_permission(raw_filter_json["id"], share_permissions)
+
         return Filter(self._options, self._session, raw=raw_filter_json)
 
     def update_filter(
         self,
-        filter_id,
+        filter_id: str,
         name: str = None,
         description: str = None,
         jql: str = None,
@@ -1293,6 +1302,32 @@ class JIRA:
 
         raw_filter_json = json.loads(r.text)
         return Filter(self._options, self._session, raw=raw_filter_json)
+
+    def add_filter_share_permission(
+        self,
+        filter_id: str,
+        permission_fields: Union[List[dict], dict],
+    ) -> bool:
+        """Add a share permission to a given filter.
+
+        Adding a global permission removes all previous permissions from the filter.
+
+        Args:
+            filter_id (str): the ID of the filter to add permissions for.
+            permission_fields (Union[List[dict], dict]): necessary permission fields to add the share permission.
+                If adding single permission, provide a dictionary. If adding multiple permissions, provide a list of
+                dictionaries.
+
+        Returns:
+            (bool): Return True if request successful.
+        """
+
+        url = self._get_latest_url(f"filter/{filter_id}/permission")
+        payload = json.dumps(permission_fields)
+
+        self._session.post(url, data=payload)
+
+        return True
 
     # Groups
 


### PR DESCRIPTION
Addresses issue #1629 

This PR adds a `add_filter_share_permissions` method to the client, supporting the `filter/{id}/permission` endpoint (https://docs.atlassian.com/software/jira/docs/api/REST/9.3.1/#api/2/filter-addSharePermission).

Also add support for it in the `create_filter()` method, allowing users to pass on permissions to add when creating a new filters.