### PR TITLE
Replace imghdr with Pillow's PIL

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -99,6 +99,8 @@ parso==0.8.3
     # via jedi
 pickleshare==0.7.5
     # via ipython
+pillow>=2.1.0
+    # via jira (setup.cfg)
 pluggy==1.0.0
     # via pytest
 prompt-toolkit==3.0.38

--- a/constraints.txt
+++ b/constraints.txt
@@ -99,7 +99,7 @@ parso==0.8.3
     # via jedi
 pickleshare==0.7.5
     # via ipython
-pillow>=2.1.0
+pillow==9.5.0
     # via jira (setup.cfg)
 pluggy==1.0.0
     # via pytest

--- a/jira/client.py
+++ b/jira/client.py
@@ -11,7 +11,6 @@ import calendar
 import copy
 import datetime
 import hashlib
-import imghdr
 import json
 import logging as _logging
 import mimetypes
@@ -42,6 +41,7 @@ from urllib.parse import parse_qs, quote, urlparse
 
 import requests
 from packaging.version import parse as parse_version
+from PIL import Image
 from requests import Response
 from requests.auth import AuthBase
 from requests.structures import CaseInsensitiveDict
@@ -3898,7 +3898,7 @@ class JIRA:
         if self._magic is not None:
             return self._magic.id_buffer(buff)
         try:
-            return mimetypes.guess_type("f." + str(imghdr.what(0, buff)))[0]
+            return mimetypes.guess_type("f." + Image.open(buff).format)[0]
         except (OSError, TypeError):
             self.log.warning(
                 "Couldn't detect content type of avatar image"

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ zip_safe = False
 install_requires =
     defusedxml
     packaging
-    Pillow>=9.5.0
+    Pillow>=2.1.0
     requests-oauthlib>=1.1.0
     requests>=2.10.0
     requests_toolbelt

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ zip_safe = False
 install_requires =
     defusedxml
     packaging
+    Pillow>=9.5.0
     requests-oauthlib>=1.1.0
     requests>=2.10.0
     requests_toolbelt


### PR DESCRIPTION
Addresses issue #1557 

The `imghdr` module will be deprecated in Python 3.13. Currently, it throws a deprecation warning.

This PR replaces `imghdr` with the `PIL` module.