### PR TITLE
Use user_id when adding watcher

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2342,7 +2342,9 @@ class JIRA:
             Response
         """
         url = self._get_url("issue/" + str(issue) + "/watchers")
-        return self._session.post(url, data=json.dumps(watcher))
+        # Use user_id when adding watcher
+        watcher_id = self._get_user_id(watcher)
+        return self._session.post(url, data=json.dumps(watcher_id))
 
     @translate_resource_args
     def remove_watcher(self, issue: str | int, watcher: str) -> Response:


### PR DESCRIPTION
I believe this is related to #1431 

The `add_watcher` method is failing when using a user name. I tried with v2 and v3 of the Cloud API. It worked with the user ID though. I believe this is related to Jira's GDPR issues.

Added a simple fix to retrieve the ID before adding the watcher. This is already done in the `delete_watcher` method.