### PR TITLE
#1435 - recommend installing jira[cli] to get jirashell deps

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,9 +3,10 @@ Installation
 
 The easiest (and best) way to install jira-python is through `pip <https://pip.pypa.io/>`_::
 
-    pip install jira
+    pip install 'jira[cli]'
 
-This will handle installation of the client itself as well as the requirements.
+This will handle installation of the client itself as well as the requirements. The `[cli]` part installs
+dependencies for the `jirashell` binary, and may be omitted if you just need the library.
 
 If you're going to run the client standalone, we strongly recommend using a `virtualenv <https://virtualenv.pypa.io/>`_:
 


### PR DESCRIPTION
`pip install jira` used to result in a working `jirashell`, but nowadays there is a missing dependency (see #1435), and `pip install 'jira[cli]'` is necessary. The [installation doc](https://github.com/pycontribs/jira/blob/main/docs/installation.rst) has been updated, but is inconsistent -- the first reference says `pip install jira`, and next paragraph says `pip install 'jira[cli]'`.

The attached patch fixes the inconsistency to always recommend `pip install 'jira[cli]'`, and adds a sentence explaining what `[cli]` does.