### PR TITLE
Add skipUserResolution for assign_issue to decide whether to skip user resolution or not

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1876,10 +1876,8 @@ class JIRA:
     # non-resource
     @translate_resource_args
     def assign_issue(
-            self,
-            issue: int | str,
-            assignee: str | None,
-            skipUserResolution: bool = False) -> bool:
+        self, issue: int | str, assignee: str | None, skipUserResolution: bool = False
+    ) -> bool:
         """Assign an issue to a user.
 
         Args:

--- a/jira/client.py
+++ b/jira/client.py
@@ -1875,18 +1875,23 @@ class JIRA:
 
     # non-resource
     @translate_resource_args
-    def assign_issue(self, issue: int | str, assignee: str | None) -> bool:
+    def assign_issue(
+            self,
+            issue: int | str,
+            assignee: str | None,
+            skipUserResolution: bool = False) -> bool:
         """Assign an issue to a user.
 
         Args:
             issue (Union[int, str]): the issue ID or key to assign
             assignee (str): the user to assign the issue to. None will set it to unassigned. -1 will set it to Automatic.
+            skipUserResolution (bool): when true, use the username from caller side directly to assign issue
 
         Returns:
             bool
         """
         url = self._get_latest_url(f"issue/{issue}/assignee")
-        user_id = self._get_user_id(assignee)
+        user_id = assignee if skipUserResolution else self._get_user_id(assignee)
         payload = {"accountId": user_id} if self._is_cloud else {"name": user_id}
         self._session.put(url, data=json.dumps(payload))
         return True


### PR DESCRIPTION
Fix the issue I described at Apache/spark https://github.com/apache/spark/pull/42496. 

The assignee from the spark merge PR script is trustworthy, while calling assign_issue here may use a different user as we only search 20 candidates. 