### PR TITLE
Added warning log if issue link type not present

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2524,7 +2524,7 @@ class JIRA:
         issue_link_types = self.issue_link_types()
 
         if type not in issue_link_types:
-            LOG.warning(
+            self.log.warning(
                 "Warning: Specified issue link type is not present in the list of link types"
             )
             for lt in issue_link_types:

--- a/jira/client.py
+++ b/jira/client.py
@@ -2524,6 +2524,7 @@ class JIRA:
         issue_link_types = self.issue_link_types()
 
         if type not in issue_link_types:
+            LOG.warning("Warning: Specified issue link type is not present in the list of link types")
             for lt in issue_link_types:
                 if lt.outward == type:
                     # we are smart to figure it out what he meant

--- a/jira/client.py
+++ b/jira/client.py
@@ -2524,7 +2524,9 @@ class JIRA:
         issue_link_types = self.issue_link_types()
 
         if type not in issue_link_types:
-            LOG.warning("Warning: Specified issue link type is not present in the list of link types")
+            LOG.warning(
+                "Warning: Specified issue link type is not present in the list of link types"
+            )
             for lt in issue_link_types:
                 if lt.outward == type:
                     # we are smart to figure it out what he meant


### PR DESCRIPTION
This error correction created problems for me, resulting in numerous issues to have inverted links (i.e. Blocks / Is Blocked By was inverted). 
Debugging the issue was difficult and required to look into this code to determine what actually happened, if a log message was present, it would have simplified my debugging, so I've added it!