### PR TITLE
client: Cache raw field information

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -672,6 +672,14 @@ class JIRA:
             JIRA.checked_version = True
 
         self._fields_cache_value: dict[str, str] = {}  # access via self._fields_cache
+        self._fields_cache_value_raw: list[dict[str, Any]] = []  # access via self._fields_cache_raw
+
+    @property
+    def _fields_cache_raw(self) -> list[dict[str, Any]]:
+        """Cached raw dictionary of of /field endpoint. Lazy loaded."""
+        if not self._fields_cache_value_raw:
+            self._fields_cache_value_raw = self.fields()
+        return self._fields_cache_value_raw
 
     @property
     def _fields_cache(self) -> dict[str, str]:
@@ -683,7 +691,7 @@ class JIRA:
     def _update_fields_cache(self):
         """Update the cache used for `self._fields_cache`."""
         self._fields_cache_value = {}
-        for f in self.fields():
+        for f in self._fields_cache_raw:
             if "clauseNames" in f:
                 for name in f["clauseNames"]:
                     self._fields_cache_value[name] = f["id"]

--- a/jira/client.py
+++ b/jira/client.py
@@ -672,7 +672,9 @@ class JIRA:
             JIRA.checked_version = True
 
         self._fields_cache_value: dict[str, str] = {}  # access via self._fields_cache
-        self._fields_cache_value_raw: list[dict[str, Any]] = []  # access via self._fields_cache_raw
+        self._fields_cache_value_raw: list[
+            dict[str, Any]
+        ] = []  # access via self._fields_cache_raw
 
     @property
     def _fields_cache_raw(self) -> list[dict[str, Any]]:


### PR DESCRIPTION
The field JSON from the JIRA server contains important information, such as schemas, which can be used by applications building on this library. Since it's generally preferred, whenever possible, to reduce unnecessary calls to JIRA API endpoints, we can keep this information in the client object.