### PR TITLE
Add goal field to update/create sprint

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -5073,7 +5073,7 @@ class JIRA:
         if goal:
             payload["goal"] = goal
 
-        raw_issue_json: dict[str, Any]
+        raw_sprint_json: dict[str, Any]
         url = self._get_url("sprint", base=self.AGILE_BASE_URL)
         payload["originBoardId"] = board_id
         r = self._session.post(url, data=json.dumps(payload))

--- a/jira/client.py
+++ b/jira/client.py
@@ -4896,6 +4896,7 @@ class JIRA:
         startDate: Any | None = None,
         endDate: Any | None = None,
         state: str | None = None,
+        goal: str | None = None,
     ) -> dict[str, Any]:
         """Updates the sprint with the given values.
 
@@ -4904,7 +4905,8 @@ class JIRA:
             name (Optional[str]): The name to update your sprint to
             startDate (Optional[Any]): The start date for the sprint
             endDate (Optional[Any]): The start date for the sprint
-            state: (Optional[str]): The start date for the sprint
+            state: (Optional[str]): The state of the sprint
+            goal: (Optiona[str]): The goal of the sprint
 
         Returns:
             Dict[str, Any]
@@ -4918,6 +4920,8 @@ class JIRA:
             payload["endDate"] = endDate
         if state:
             payload["state"] = state
+        if goal:
+            payload["goal"] = goal
 
         url = self._get_url(f"sprint/{id}", base=self.AGILE_BASE_URL)
         r = self._session.put(url, data=json.dumps(payload))
@@ -5047,6 +5051,7 @@ class JIRA:
         board_id: int,
         startDate: Any | None = None,
         endDate: Any | None = None,
+        goal: str | None = None,
     ) -> Sprint:
         """Create a new sprint for the ``board_id``.
 
@@ -5055,6 +5060,7 @@ class JIRA:
             board_id (int): Which board the sprint should be assigned.
             startDate (Optional[Any]): Start date for the sprint.
             endDate (Optional[Any]): End date for the sprint.
+            goal (Optional[string]): Goal for the sprint.
 
         Returns:
             Sprint: The newly created Sprint
@@ -5064,6 +5070,8 @@ class JIRA:
             payload["startDate"] = startDate
         if endDate:
             payload["endDate"] = endDate
+        if goal:
+            payload["goal"] = goal
 
         raw_issue_json: dict[str, Any]
         url = self._get_url("sprint", base=self.AGILE_BASE_URL)

--- a/jira/client.py
+++ b/jira/client.py
@@ -4906,7 +4906,7 @@ class JIRA:
             startDate (Optional[Any]): The start date for the sprint
             endDate (Optional[Any]): The start date for the sprint
             state: (Optional[str]): The state of the sprint
-            goal: (Optiona[str]): The goal of the sprint
+            goal: (Optional[str]): The goal of the sprint
 
         Returns:
             Dict[str, Any]

--- a/jira/client.py
+++ b/jira/client.py
@@ -5077,9 +5077,9 @@ class JIRA:
         url = self._get_url("sprint", base=self.AGILE_BASE_URL)
         payload["originBoardId"] = board_id
         r = self._session.post(url, data=json.dumps(payload))
-        raw_issue_json = json_loads(r)
+        raw_sprint_json = json_loads(r)
 
-        return Sprint(self._options, self._session, raw=raw_issue_json)
+        return Sprint(self._options, self._session, raw=raw_sprint_json)
 
     def add_issues_to_sprint(self, sprint_id: int, issue_keys: list[str]) -> Response:
         """Add the issues in ``issue_keys`` to the ``sprint_id``.

--- a/jira/client.py
+++ b/jira/client.py
@@ -5060,7 +5060,7 @@ class JIRA:
             board_id (int): Which board the sprint should be assigned.
             startDate (Optional[Any]): Start date for the sprint.
             endDate (Optional[Any]): End date for the sprint.
-            goal (Optional[string]): Goal for the sprint.
+            goal (Optional[str]): Goal for the sprint.
 
         Returns:
             Sprint: The newly created Sprint

--- a/tests/resources/test_sprint.py
+++ b/tests/resources/test_sprint.py
@@ -89,7 +89,7 @@ class SprintTests(JiraTestCase):
     def test_update_sprint(self):
         # GIVEN: The sprint ID
         # WHEN: we update the sprint
-       sprint = self.jira.create_sprint(self.sprint_name, self.board.id, goal=self.sprint_goal)
+        sprint = self.jira.create_sprint(self.sprint_name, self.board.id, goal=self.sprint_goal)
         assert isinstance(sprint.id, int)
         assert sprint.name == self.sprint_name
         assert sprint.goal == self.sprint_goal
@@ -100,7 +100,6 @@ class SprintTests(JiraTestCase):
             startDate="2015-04-11T15:22:00.000+10:00",
             endDate="2015-04-20T01:22:00.000+10:00")
         assert updated_sprint["name"] == "new_name"
->>>>>>> b490515 (Fix up tests)
 
     def test_add_issue_to_sprint(self):
         # GIVEN: The sprint

--- a/tests/resources/test_sprint.py
+++ b/tests/resources/test_sprint.py
@@ -1,4 +1,4 @@
-tests/resources/test_sprint.pyfrom __future__ import annotations
+from __future__ import annotations
 
 from contextlib import contextmanager
 from functools import lru_cache

--- a/tests/resources/test_sprint.py
+++ b/tests/resources/test_sprint.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+tests/resources/test_sprint.pyfrom __future__ import annotations
 
 from contextlib import contextmanager
 from functools import lru_cache
@@ -22,6 +22,7 @@ class SprintTests(JiraTestCase):
         self.board_name = f"board-{uniq}"
         self.sprint_name = f"sprint-{uniq}"
         self.filter_name = f"filter-{uniq}"
+        self.goal = f"goal-{uniq}"
 
         self.board, self.filter = self._create_board_and_filter()
 
@@ -75,6 +76,28 @@ class SprintTests(JiraTestCase):
             assert sprint.name == self.sprint_name
             assert sprint.state.upper() == "FUTURE"
         # THEN: the sprint .delete() is called successfully
+
+    def test_create_with_goal(self):
+        # GIVEN: The board, sprint name, and goal
+        # WHEN: we create the sprint
+        with self._create_sprint() as sprint:
+            sprint = self.jira.create_sprint(self.sprint_name, self.board.id, goal=self.goal)
+            # THEN: we create the sprint with a goal
+            assert isinstance(sprint.id, int)
+            assert sprint.name == self.sprint_name
+            assert sprint.goal == self.sprint_goal
+
+    def test_update_sprint(self):
+        # GIVEN: The sprint ID
+        # WHEN: we update the sprint
+        with self._create_sprint() as sprint:
+            sprint = self.jira.create_sprint(self.sprint_name, self.board.id, goal=self.goal)
+            assert isinstance(sprint.id, int)
+            assert sprint.name == self.sprint_name
+            assert sprint.goal == self.sprint_goal
+            # THEN: the name changes
+            updated_sprint = self.jira.update_sprint(sprint.id, "new_name")
+            assert sprint["name"] == "new_name"
 
     def test_add_issue_to_sprint(self):
         # GIVEN: The sprint

--- a/tests/resources/test_sprint.py
+++ b/tests/resources/test_sprint.py
@@ -80,7 +80,9 @@ class SprintTests(JiraTestCase):
     def test_create_with_goal(self):
         # GIVEN: The board, sprint name, and goal
         # WHEN: we create the sprint
-        sprint = self.jira.create_sprint(self.sprint_name, self.board.id, goal=self.sprint_goal)
+        sprint = self.jira.create_sprint(
+            self.sprint_name, self.board.id, goal=self.sprint_goal
+        )
         # THEN: we create the sprint with a goal
         assert isinstance(sprint.id, int)
         assert sprint.name == self.sprint_name
@@ -89,16 +91,20 @@ class SprintTests(JiraTestCase):
     def test_update_sprint(self):
         # GIVEN: The sprint ID
         # WHEN: we update the sprint
-        sprint = self.jira.create_sprint(self.sprint_name, self.board.id, goal=self.sprint_goal)
+        sprint = self.jira.create_sprint(
+            self.sprint_name, self.board.id, goal=self.sprint_goal
+        )
         assert isinstance(sprint.id, int)
         assert sprint.name == self.sprint_name
         assert sprint.goal == self.sprint_goal
         # THEN: the name changes
         updated_sprint = self.jira.update_sprint(
-            sprint.id, "new_name",
+            sprint.id,
+            "new_name",
             state="future",
             startDate="2015-04-11T15:22:00.000+10:00",
-            endDate="2015-04-20T01:22:00.000+10:00")
+            endDate="2015-04-20T01:22:00.000+10:00",
+        )
         assert updated_sprint["name"] == "new_name"
 
     def test_add_issue_to_sprint(self):

--- a/tests/resources/test_sprint.py
+++ b/tests/resources/test_sprint.py
@@ -80,28 +80,27 @@ class SprintTests(JiraTestCase):
     def test_create_with_goal(self):
         # GIVEN: The board, sprint name, and goal
         # WHEN: we create the sprint
-        with self._create_sprint() as sprint:
-            sprint = self.jira.create_sprint(
-                self.sprint_name, self.board.id, goal=self.goal
-            )
-            # THEN: we create the sprint with a goal
-            assert isinstance(sprint.id, int)
-            assert sprint.name == self.sprint_name
-            assert sprint.goal == self.sprint_goal
+        sprint = self.jira.create_sprint(self.sprint_name, self.board.id, goal=self.sprint_goal)
+        # THEN: we create the sprint with a goal
+        assert isinstance(sprint.id, int)
+        assert sprint.name == self.sprint_name
+        assert sprint.goal == self.sprint_goal
 
     def test_update_sprint(self):
         # GIVEN: The sprint ID
         # WHEN: we update the sprint
-        with self._create_sprint() as sprint:
-            sprint = self.jira.create_sprint(
-                self.sprint_name, self.board.id, goal=self.goal
-            )
-            assert isinstance(sprint.id, int)
-            assert sprint.name == self.sprint_name
-            assert sprint.goal == self.sprint_goal
-            # THEN: the name changes
-            updated_sprint = self.jira.update_sprint(sprint.id, "new_name")
-            assert sprint["name"] == "new_name"
+       sprint = self.jira.create_sprint(self.sprint_name, self.board.id, goal=self.sprint_goal)
+        assert isinstance(sprint.id, int)
+        assert sprint.name == self.sprint_name
+        assert sprint.goal == self.sprint_goal
+        # THEN: the name changes
+        updated_sprint = self.jira.update_sprint(
+            sprint.id, "new_name",
+            state="future",
+            startDate="2015-04-11T15:22:00.000+10:00",
+            endDate="2015-04-20T01:22:00.000+10:00")
+        assert updated_sprint["name"] == "new_name"
+>>>>>>> b490515 (Fix up tests)
 
     def test_add_issue_to_sprint(self):
         # GIVEN: The sprint

--- a/tests/resources/test_sprint.py
+++ b/tests/resources/test_sprint.py
@@ -81,7 +81,9 @@ class SprintTests(JiraTestCase):
         # GIVEN: The board, sprint name, and goal
         # WHEN: we create the sprint
         with self._create_sprint() as sprint:
-            sprint = self.jira.create_sprint(self.sprint_name, self.board.id, goal=self.goal)
+            sprint = self.jira.create_sprint(
+                self.sprint_name, self.board.id, goal=self.goal
+            )
             # THEN: we create the sprint with a goal
             assert isinstance(sprint.id, int)
             assert sprint.name == self.sprint_name
@@ -91,7 +93,9 @@ class SprintTests(JiraTestCase):
         # GIVEN: The sprint ID
         # WHEN: we update the sprint
         with self._create_sprint() as sprint:
-            sprint = self.jira.create_sprint(self.sprint_name, self.board.id, goal=self.goal)
+            sprint = self.jira.create_sprint(
+                self.sprint_name, self.board.id, goal=self.goal
+            )
             assert isinstance(sprint.id, int)
             assert sprint.name == self.sprint_name
             assert sprint.goal == self.sprint_goal

--- a/tests/resources/test_sprint.py
+++ b/tests/resources/test_sprint.py
@@ -22,7 +22,7 @@ class SprintTests(JiraTestCase):
         self.board_name = f"board-{uniq}"
         self.sprint_name = f"sprint-{uniq}"
         self.filter_name = f"filter-{uniq}"
-        self.goal = f"goal-{uniq}"
+        self.sprint_goal = f"goal-{uniq}"
 
         self.board, self.filter = self._create_board_and_filter()
 


### PR DESCRIPTION
https://github.com/pycontribs/jira/pull/1586 seems like it stalled out after you asked for tests so I created a separate PR.

This adds goal as a field to create/update sprint and adds test cases. There weren't any existing test cases for update_sprint so I extended that.

I'm still working on getting the local dev setup but I figure I can see how the tests run in CI