### PR TITLE
Update createmeta warning with new method names

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1776,12 +1776,12 @@ class JIRA:
             if self._version >= (9, 0, 0):
                 raise JIRAError(
                     f"Unsupported JIRA version: {self._version}. "
-                    "Use 'createmeta_issuetypes' and 'createmeta_fieldtypes' instead."
+                    "Use 'project_issue_types' and 'project_issue_fields' instead."
                 )
             elif self._version >= (8, 4, 0):
                 warnings.warn(
                     "This API have been deprecated in JIRA 8.4 and is removed in JIRA 9.0. "
-                    "Use 'createmeta_issuetypes' and 'createmeta_fieldtypes' instead.",
+                    "Use 'project_issue_types' and 'project_issue_fields' instead.",
                     DeprecationWarning,
                     stacklevel=2,
                 )


### PR DESCRIPTION
The warning message that comes up when calling `createmeta()` on Jira Server 9.x refers to methods that have since been renamed. This branch fixes the warning message.