### PR TITLE
Improve handling of Jira's retry-after handling

### DIFF
--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -315,7 +315,7 @@ class ResilientSession(Session):
             if response.status_code in recoverable_error_codes:
                 retry_after = response.headers.get("Retry-After")
                 if retry_after:
-                    suggested_delay = int(retry_after)  # Do as told
+                    suggested_delay = 2 * int(retry_after)  # Do as told
                 elif response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
                     suggested_delay = 10 * 2**counter  # Exponential backoff
 
@@ -326,7 +326,9 @@ class ResilientSession(Session):
         is_recoverable = suggested_delay > 0
         if is_recoverable:
             # Apply jitter to prevent thundering herd
-            delay = min(self.max_retry_delay, suggested_delay) * random.random()
+            delay = min(self.max_retry_delay, suggested_delay) * random.uniform(
+                0.5, 1.0
+            )
             LOG.warning(
                 f"Got recoverable error from {request_method} {url}, will retry [{counter}/{self.max_retries}] in {delay}s. Err: {msg}"  # type: ignore[str-bytes-safe]
             )

--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -315,7 +315,9 @@ class ResilientSession(Session):
             if response.status_code in recoverable_error_codes:
                 retry_after = response.headers.get("Retry-After")
                 if retry_after:
-                    suggested_delay = 2 * int(retry_after)  # Do as told
+                    suggested_delay = 2 * max(
+                        int(retry_after), 1
+                    )  # Do as told but always wait at least a little
                 elif response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
                     suggested_delay = 10 * 2**counter  # Exponential backoff
 

--- a/tests/test_resilientsession.py
+++ b/tests/test_resilientsession.py
@@ -106,7 +106,8 @@ def test_status_codes_retries(
     with_retry_after_header: bool,
     retry_expected: bool,
 ):
-    RETRY_AFTER_HEADER = {"Retry-After": "1"}
+    RETRY_AFTER_SECONDS = 1 if with_retry_after_header else 0
+    RETRY_AFTER_HEADER = {"Retry-After": f"{RETRY_AFTER_SECONDS}"}
     RATE_LIMIT_HEADERS = {
         "X-RateLimit-FillRate": "1",
         "X-RateLimit-Interval-Seconds": "1",
@@ -140,6 +141,11 @@ def test_status_codes_retries(
 
     assert mocked_request_method.call_count == expected_number_of_requests
     assert mocked_sleep_method.call_count == expected_number_of_sleep_invocations
+
+    for actual_sleep in (
+        call_args.args[0] for call_args in mocked_sleep_method.call_args_list
+    ):
+        assert actual_sleep >= RETRY_AFTER_SECONDS
 
 
 errors_parsing_test_data = [


### PR DESCRIPTION
As reported in  #1805, while 3.6.0 brought a beneficial change in evaluating Jira's retry-after header, in some scenarios it actually degraded the success rate of requests when hitting rate-limits due to two issues:
1. Jira intends the retry-after header to be a minimum backoff but the code treats it as a maximum backoff, and
2. Jira sometimes sends a retry-after value of 0 seconds which the existing code implicitly treated as a failed request.

To address this, this PR changes the back-off behaviour to treat the retry-after time as a minimum backoff, at least as long as our maximum back-off time does allow this, and clips the retry-after header, if specified, to a minimum of one second.

I have extended the existing tests for the retry logic to assert this behaviour. If you would prefer a separate set of tests or see other changes to the approach, let me know and I'll adjust the PR.