### PR TITLE
add backward compatibility for createmeta_issuetypes & createmeta_fieldtypes

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -1763,6 +1763,7 @@ class JIRA:
             maxResults (int): Maximum number of issues to return.
               Total number of results is available in the ``total`` attribute of the returned :class:`ResultList`.
               If maxResults evaluates to False, it will try to get all issues in batches. (Default: ``50``)
+
         Returns:
             Dict[str, Any]
         """
@@ -1792,6 +1793,7 @@ class JIRA:
             maxResults (int): Maximum number of issues to return.
               Total number of results is available in the ``total`` attribute of the returned :class:`ResultList`.
               If maxResults evaluates to False, it will try to get all issues in batches. (Default: ``50``)
+
         Returns:
             Dict[str, Any]
         """

--- a/jira/client.py
+++ b/jira/client.py
@@ -2126,7 +2126,7 @@ class JIRA:
 
         .. deprecated:: 3.6.0
             Use :func:`project_issue_fields` instead.
-        
+
         This API was introduced in JIRA Server / DC 8.4 as a replacement for the more general purpose API 'createmeta'.
         For details see: https://confluence.atlassian.com/jiracore/createmeta-rest-endpoint-to-be-removed-975040986.html
 

--- a/jira/client.py
+++ b/jira/client.py
@@ -1748,6 +1748,62 @@ class JIRA:
                 "Use 'createmeta' instead."
             )
 
+    def createmeta_issuetypes(
+        self,
+        projectIdOrKey: str | int,
+        startAt: int = 0,
+        maxResults: int = 50,
+    ) -> dict[str, Any]:
+        """Get the issue types metadata for a given project, required to create issues.
+        This API was introduced in JIRA Server / DC 8.4 as a replacement for the more general purpose API 'createmeta'.
+        For details see: https://confluence.atlassian.com/jiracore/createmeta-rest-endpoint-to-be-removed-975040986.html
+        Args:
+            projectIdOrKey (Union[str, int]): id or key of the project for which to get the metadata.
+            startAt (int): Index of the first issue to return. (Default: ``0``)
+            maxResults (int): Maximum number of issues to return.
+              Total number of results is available in the ``total`` attribute of the returned :class:`ResultList`.
+              If maxResults evaluates to False, it will try to get all issues in batches. (Default: ``50``)
+        Returns:
+            Dict[str, Any]
+        """
+        self._check_createmeta_issuetypes()
+        return self._get_json(
+            f"issue/createmeta/{projectIdOrKey}/issuetypes",
+            params={
+                "startAt": startAt,
+                "maxResults": maxResults,
+            },
+        )
+
+    def createmeta_fieldtypes(
+        self,
+        projectIdOrKey: str | int,
+        issueTypeId: str | int,
+        startAt: int = 0,
+        maxResults: int = 50,
+    ) -> dict[str, Any]:
+        """Get the field metadata for a given project and issue type, required to create issues.
+        This API was introduced in JIRA Server / DC 8.4 as a replacement for the more general purpose API 'createmeta'.
+        For details see: https://confluence.atlassian.com/jiracore/createmeta-rest-endpoint-to-be-removed-975040986.html
+        Args:
+            projectIdOrKey (Union[str, int]): id or key of the project for which to get the metadata.
+            issueTypeId (Union[str, int]): id of the issue type for which to get the metadata.
+            startAt (int): Index of the first issue to return. (Default: ``0``)
+            maxResults (int): Maximum number of issues to return.
+              Total number of results is available in the ``total`` attribute of the returned :class:`ResultList`.
+              If maxResults evaluates to False, it will try to get all issues in batches. (Default: ``50``)
+        Returns:
+            Dict[str, Any]
+        """
+        self._check_createmeta_issuetypes()
+        return self._get_json(
+            f"issue/createmeta/{projectIdOrKey}/issuetypes/{issueTypeId}",
+            params={
+                "startAt": startAt,
+                "maxResults": maxResults,
+            },
+        )
+
     def createmeta(
         self,
         projectKeys: tuple[str, str] | str | None = None,

--- a/jira/client.py
+++ b/jira/client.py
@@ -2083,8 +2083,13 @@ class JIRA:
         maxResults: int = 50,
     ) -> dict[str, Any]:
         """Get the issue types metadata for a given project, required to create issues.
+
+        .. deprecated:: 3.6.0
+            Use :func:`project_issue_types` instead.
+
         This API was introduced in JIRA Server / DC 8.4 as a replacement for the more general purpose API 'createmeta'.
         For details see: https://confluence.atlassian.com/jiracore/createmeta-rest-endpoint-to-be-removed-975040986.html
+
         Args:
             projectIdOrKey (Union[str, int]): id or key of the project for which to get the metadata.
             startAt (int): Index of the first issue to return. (Default: ``0``)
@@ -2096,7 +2101,7 @@ class JIRA:
             Dict[str, Any]
         """
         warnings.warn(
-            "'createmeta_issuetypes' is deprected and will be removed in future releases."
+            "'createmeta_issuetypes' is deprecated and will be removed in future releases."
             "Use 'project_issue_types' instead.",
             DeprecationWarning,
             stacklevel=2,
@@ -2118,8 +2123,13 @@ class JIRA:
         maxResults: int = 50,
     ) -> dict[str, Any]:
         """Get the field metadata for a given project and issue type, required to create issues.
+
+        .. deprecated:: 3.6.0
+            Use :func:`project_issue_fields` instead.
+        
         This API was introduced in JIRA Server / DC 8.4 as a replacement for the more general purpose API 'createmeta'.
         For details see: https://confluence.atlassian.com/jiracore/createmeta-rest-endpoint-to-be-removed-975040986.html
+
         Args:
             projectIdOrKey (Union[str, int]): id or key of the project for which to get the metadata.
             issueTypeId (Union[str, int]): id of the issue type for which to get the metadata.
@@ -2132,7 +2142,7 @@ class JIRA:
             Dict[str, Any]
         """
         warnings.warn(
-            "'createmeta_fieldtypes' is deprected and will be removed in future releases."
+            "'createmeta_fieldtypes' is deprecated and will be removed in future releases."
             "Use 'project_issue_fields' instead.",
             DeprecationWarning,
             stacklevel=2,

--- a/jira/client.py
+++ b/jira/client.py
@@ -2095,6 +2095,12 @@ class JIRA:
         Returns:
             Dict[str, Any]
         """
+        warnings.warn(
+            "'createmeta_issuetypes' is deprected and will be removed in future releases."
+            "Use 'project_issue_types' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._check_createmeta_issuetypes()
         return self._get_json(
             f"issue/createmeta/{projectIdOrKey}/issuetypes",
@@ -2125,6 +2131,12 @@ class JIRA:
         Returns:
             Dict[str, Any]
         """
+        warnings.warn(
+            "'createmeta_fieldtypes' is deprected and will be removed in future releases."
+            "Use 'project_issue_fields' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._check_createmeta_issuetypes()
         return self._get_json(
             f"issue/createmeta/{projectIdOrKey}/issuetypes/{issueTypeId}",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -265,4 +265,3 @@ def test_createmeta_fieldtypes_pagination(cl_normal, slug):
     )
     assert field_types_resp["startAt"] == 50
     assert field_types_resp["maxResults"] == 100
-

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -246,3 +246,23 @@ def test_cookie_auth_retry():
             )
     # THEN: We don't get a RecursionError and only call the reset_function once
     mock_reset_func.assert_called_once()
+
+
+def test_createmeta_issuetypes_pagination(cl_normal, slug):
+    """Test createmeta_issuetypes pagination kwargs"""
+    issue_types_resp = cl_normal.createmeta_issuetypes(slug, startAt=50, maxResults=100)
+    assert issue_types_resp["startAt"] == 50
+    assert issue_types_resp["maxResults"] == 100
+
+
+def test_createmeta_fieldtypes_pagination(cl_normal, slug):
+    """Test createmeta_fieldtypes pagination kwargs"""
+    issue_types = cl_normal.createmeta_issuetypes(slug)
+    assert issue_types["total"]
+    issue_type_id = issue_types["values"][-1]["id"]
+    field_types_resp = cl_normal.createmeta_fieldtypes(
+        projectIdOrKey=slug, issueTypeId=issue_type_id, startAt=50, maxResults=100
+    )
+    assert field_types_resp["startAt"] == 50
+    assert field_types_resp["maxResults"] == 100
+

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -336,7 +336,7 @@ def test_createmeta_fieldtypes_pagination(cl_normal, slug):
     assert field_types_resp["startAt"] == 50
     assert field_types_resp["maxResults"] == 100
 
- 
+
 @pytest.mark.parametrize(
     "mock_client_method", ["mock_cloud_only_method", "mock_experimental_method"]
 )


### PR DESCRIPTION
pr #1784 replaced `createmeta_issuetypes` & `createmeta_fieldtypes` with `project_issue_types` & `project_issue_fields`. This will break applications that use the library and utilize the `createmeta_*` methods.