### PR TITLE
Revert "Bump codecov/codecov-action from 3.1.4 to 4.1.0"

### DIFF
--- a/.github/workflows/jira_cloud_ci.yml
+++ b/.github/workflows/jira_cloud_ci.yml
@@ -50,7 +50,7 @@ jobs:
           CI_JIRA_CLOUD_USER_TOKEN: ${{ secrets.CLOUD_USER_TOKEN }}
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.1.0
+        uses: codecov/codecov-action@v3.1.4
         with:
           file: ./coverage.xml
           name: ${{ runner.os }}-${{ matrix.python-version }}-Cloud

--- a/.github/workflows/jira_server_ci.yml
+++ b/.github/workflows/jira_server_ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: tox
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.1.0
+        uses: codecov/codecov-action@v3.1.4
         with:
           file: ./coverage.xml
           name: ${{ runner.os }}-${{ matrix.python-version }}


### PR DESCRIPTION
This reverts commit eb0ec90e08ae24823e266b0128b852022d212982.

Refer to: https://github.com/codecov/codecov-action/issues/1292