### PR TITLE
fix(parse-errors): ensure if block execution

### DIFF
--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -105,11 +105,11 @@ def parse_errors(resp: Response) -> list[str]:
     if "message" in resp_data:
         # Jira 5.1 errors
         parsed_errors = [resp_data["message"]]
-    elif "errorMessage" in resp_data:
+    if "errorMessage" in resp_data:
         # Sometimes Jira returns `errorMessage` as a message error key
         # for example for the "Service temporary unavailable" error
         parsed_errors = [resp_data["errorMessage"]]
-    elif "errorMessages" in resp_data:
+    if "errorMessages" in resp_data:
         # Jira 5.0.x error messages sometimes come wrapped in this array
         # Sometimes this is present but empty
         error_messages = resp_data["errorMessages"]
@@ -118,7 +118,7 @@ def parse_errors(resp: Response) -> list[str]:
                 parsed_errors = list(error_messages)
             else:
                 parsed_errors = [error_messages]
-    elif "errors" in resp_data:
+    if "errors" in resp_data:
         resp_errors = resp_data["errors"]
         if len(resp_errors) > 0 and isinstance(resp_errors, dict):
             # Catching only 'errors' that are dict. See https://github.com/pycontribs/jira/issues/350

--- a/tests/test_resilientsession.py
+++ b/tests/test_resilientsession.py
@@ -159,6 +159,7 @@ errors_parsing_test_data = [
     (500, {}, '{"errorMessages": "err1"}', ["err1"]),
     (500, {}, '{"errorMessages": ["err1", "err2"]}', ["err1", "err2"]),
     (500, {}, '{"errors": {"code1": "err1", "code2": "err2"}}', ["err1", "err2"]),
+    (500, {}, '{"errorMessages": [], "errors": {"code1": "err1", "code2": "err2"}}', ["err1", "err2"]),
 ]
 
 

--- a/tests/test_resilientsession.py
+++ b/tests/test_resilientsession.py
@@ -159,7 +159,12 @@ errors_parsing_test_data = [
     (500, {}, '{"errorMessages": "err1"}', ["err1"]),
     (500, {}, '{"errorMessages": ["err1", "err2"]}', ["err1", "err2"]),
     (500, {}, '{"errors": {"code1": "err1", "code2": "err2"}}', ["err1", "err2"]),
-    (500, {}, '{"errorMessages": [], "errors": {"code1": "err1", "code2": "err2"}}', ["err1", "err2"]),
+    (
+        500,
+        {},
+        '{"errorMessages": [], "errors": {"code1": "err1", "code2": "err2"}}',
+        ["err1", "err2"],
+    ),
 ]
 
 


### PR DESCRIPTION
When error messages contains more than one object, ensure that they are all parsed.