### PR TITLE
Provide overload type hints for search_issues variants

### DIFF
--- a/examples/auth.py
+++ b/examples/auth.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections import Counter
-from typing import cast
 
 from jira import JIRA
 from jira.client import ResultList
@@ -25,9 +24,7 @@ myself = jira.myself()
 props = jira.application_properties()
 
 # Find all issues reported by the admin
-# Note: we cast() for mypy's benefit, as search_issues can also return the raw json !
-#   This is if the following argument is used: `json_result=True`
-issues = cast(ResultList[Issue], jira.search_issues("assignee=admin"))
+issues: ResultList[Issue] = jira.search_issues("assignee=admin")
 
 # Find the top three projects containing issues reported by admin
 top_three = Counter([issue.fields.project.key for issue in issues]).most_common(3)

--- a/jira/client.py
+++ b/jira/client.py
@@ -3490,6 +3490,7 @@ class JIRA:
         fields: str | list[str] | None = "*all",
         expand: str | None = None,
         properties: str | None = None,
+        *,
         json_result: Literal[False] = False,
         use_post: bool = False,
     ) -> ResultList[Issue]: ...
@@ -3504,7 +3505,8 @@ class JIRA:
         fields: str | list[str] | None = "*all",
         expand: str | None = None,
         properties: str | None = None,
-        json_result: Literal[True] = True,
+        *,
+        json_result: Literal[True],
         use_post: bool = False,
     ) -> dict[str, Any]: ...
 
@@ -3517,6 +3519,7 @@ class JIRA:
         fields: str | list[str] | None = "*all",
         expand: str | None = None,
         properties: str | None = None,
+        *,
         json_result: bool = False,
         use_post: bool = False,
     ) -> dict[str, Any] | ResultList[Issue]:

--- a/jira/client.py
+++ b/jira/client.py
@@ -3480,6 +3480,34 @@ class JIRA:
 
     # Search
 
+    @overload
+    def search_issues(
+        self,
+        jql_str: str,
+        startAt: int = 0,
+        maxResults: int = 50,
+        validate_query: bool = True,
+        fields: str | list[str] | None = "*all",
+        expand: str | None = None,
+        properties: str | None = None,
+        json_result: Literal[False] = False,
+        use_post: bool = False,
+    ) -> ResultList[Issue]: ...
+
+    @overload
+    def search_issues(
+        self,
+        jql_str: str,
+        startAt: int = 0,
+        maxResults: int = 50,
+        validate_query: bool = True,
+        fields: str | list[str] | None = "*all",
+        expand: str | None = None,
+        properties: str | None = None,
+        json_result: Literal[True] = True,
+        use_post: bool = False,
+    ) -> dict[str, Any]: ...
+
     def search_issues(
         self,
         jql_str: str,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -23,7 +23,6 @@ import requests
 from parameterized import parameterized
 
 from jira import JIRA, Issue, JIRAError
-from jira.client import ResultList
 from jira.resources import Dashboard, Resource, cls_for_resource
 from tests.conftest import JiraTestCase, allow_on_cloud, rndpassword
 
@@ -231,7 +230,6 @@ class SearchTests(JiraTestCase):
 
     def test_search_issues(self):
         issues = self.jira.search_issues(f"project={self.project_b}")
-        issues = cast(ResultList[Issue], issues)
         self.assertLessEqual(len(issues), 50)  # default maxResults
         for issue in issues:
             self.assertTrue(issue.key.startswith(self.project_b))
@@ -243,7 +241,6 @@ class SearchTests(JiraTestCase):
             issues = self.jira.search_issues(
                 f"project={self.project_b}", maxResults=False
             )
-            issues = cast(ResultList[Issue], issues)
             self.assertEqual(len(issues), issues.total)
             for issue in issues:
                 self.assertTrue(issue.key.startswith(self.project_b))
@@ -263,7 +260,6 @@ class SearchTests(JiraTestCase):
 
     def test_search_issues_field_limiting(self):
         issues = self.jira.search_issues(f"key={self.issue}", fields="summary,comment")
-        issues = cast(ResultList[Issue], issues)
         self.assertTrue(hasattr(issues[0].fields, "summary"))
         self.assertTrue(hasattr(issues[0].fields, "comment"))
         self.assertFalse(hasattr(issues[0].fields, "reporter"))
@@ -271,7 +267,6 @@ class SearchTests(JiraTestCase):
 
     def test_search_issues_expand(self):
         issues = self.jira.search_issues(f"key={self.issue}", expand="changelog")
-        issues = cast(ResultList[Issue], issues)
         # self.assertTrue(hasattr(issues[0], 'names'))
         self.assertEqual(len(issues), 1)
         self.assertFalse(hasattr(issues[0], "editmeta"))
@@ -283,7 +278,6 @@ class SearchTests(JiraTestCase):
         with pytest.raises(JIRAError):
             self.jira.search_issues(long_jql)
         issues = self.jira.search_issues(long_jql, use_post=True)
-        issues = cast(ResultList[Issue], issues)
         self.assertEqual(len(issues), 1)
         self.assertEqual(issues[0].key, self.issue)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -234,6 +234,13 @@ class SearchTests(JiraTestCase):
         for issue in issues:
             self.assertTrue(issue.key.startswith(self.project_b))
 
+    def test_search_issues_json(self):
+        result = self.jira.search_issues(f"project={self.project_b}", json_result=True)
+        issues = result["issues"]
+        self.assertLessEqual(len(issues), 50)  # default maxResults
+        for issue in issues:
+            self.assertTrue(issue["key"].startswith(self.project_b))
+
     def test_search_issues_async(self):
         original_val = self.jira._options["async"]
         try:


### PR DESCRIPTION
search_issues can return either a dictionary (if json_result) or a list of Issues under default behavior.

This change provides separate hints using overload so that type checked code doesn't need to cast unnecessarily when dealing with output.

Tests have been added, and cases where casting was used have been removed.

Fixes #1608.