### PR TITLE
Replace `pillow` with `filetype`

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -105,7 +105,7 @@ parso==0.8.3
     # via jedi
 pickleshare==0.7.5
     # via ipython
-pillow==10.2.0
+filetype==1.2.0
     # via jira (setup.cfg)
 pluggy==1.4.0
     # via pytest

--- a/jira/client.py
+++ b/jira/client.py
@@ -41,8 +41,8 @@ from typing import (
 from urllib.parse import parse_qs, quote, urlparse
 
 import requests
+from filetype import guess_mime
 from packaging.version import parse as parse_version
-from PIL import Image
 from requests import Response
 from requests.auth import AuthBase
 from requests.structures import CaseInsensitiveDict
@@ -4425,8 +4425,8 @@ class JIRA:
         if self._magic is not None:
             return self._magic.id_buffer(buff)
         try:
-            return mimetypes.guess_type("f." + Image.open(buff).format)[0]
-        except (OSError, TypeError):
+            return guess_mime(buff)
+        except TypeError:
             self.log.warning(
                 "Couldn't detect content type of avatar image"
                 ". Specify the 'contentType' parameter explicitly."

--- a/jira/client.py
+++ b/jira/client.py
@@ -14,7 +14,6 @@ import datetime
 import hashlib
 import json
 import logging as _logging
-import mimetypes
 import os
 import re
 import sys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ keywords = ["api", "atlassian", "jira", "rest", "web"]
 dependencies = [
     "defusedxml",
     "packaging",
-    "Pillow>=2.1.0",
+    "filetype>=1.2.0",
     "requests-oauthlib>=1.1.0",
     "requests>=2.10.0",
     "requests_toolbelt",


### PR DESCRIPTION
When this PR was merged, https://github.com/pycontribs/jira/pull/1680, we replaced `imghdr` with `Pillow`.

Albeit Pillow is a great library, it has many conflicts with different platform architectures, and too much overhead for the use we have for it (We just use it to [determine a MIME type for an image](https://github.com/pycontribs/jira/blob/eb0ec90e08ae24823e266b0128b852022d212982/jira/client.py#L4428))

Looking at [PEP 594](https://peps.python.org/pep-0594/#deprecated-modules), `filetype` is a reccommended replacement for `imghdr` and it is cross platform compatible.

This PR is replacing `Pillow` with `filetype`