### PR TITLE
jira/client.py: Map IssueLinkType array to string array

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -2929,7 +2929,7 @@ class JIRA:
             Response
         """
         # let's see if we have the right issue link 'type' and fix it if needed
-        issue_link_types = self.issue_link_types()
+        issue_link_types = list(map(lambda x: x.name, self.issue_link_types()))
 
         if type not in issue_link_types:
             self.log.warning(


### PR DESCRIPTION
Equality check between IssueLinkType and string always returns false. Function decorator casts IssueLinkType parameters to string, so a warning is always logged. This fixes that issue.

Closes: #1875