### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -101,6 +101,7 @@ jobs:
         with:
           name: logs-${{ matrix.name }}.zip
           if-no-files-found: error
+          include-hidden-files: true
           path: |
             .tox/**/log/
             .tox/**/coverage.xml


### PR DESCRIPTION
the upload artifacts stopped uploading hidden files
the uploaded artifacts are stored in the .tox folder which is hidden 
fix => allow hidden files to be uploaded as artifacts