### PR TITLE
change the branch of the pypi publisher release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Publish to test.pypi.org
       if: >-  # "create" workflows run separately from "push" & "pull_request"
         github.event_name == 'release'
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.testpypi_password }}
         repository_url: https://test.pypi.org/legacy/
@@ -44,6 +44,6 @@ jobs:
     - name: Publish to pypi.org
       if: >-  # "create" workflows run separately from "push" & "pull_request"
         github.event_name == 'release'
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
fixes `Unable to resolve action 'pypa/gh-action-pypi-publish@v1', unable to find version 'v1'`
seen [here ](https://github.com/pycontribs/jira/actions/runs/11513320097)
by changing it to the url in the [readme](https://github.com/pypa/gh-action-pypi-publish#:~:text=PyPI%0A%20%20%20%20%20%20uses%3A-,pypa/gh%2Daction%2Dpypi%2Dpublish%40release/v1,-Note)