### PR TITLE
fix: Wrong tox env for packaging after rename in 39d89ef2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       FORCE_COLOR: 1
       PY_COLORS: 1
-      TOXENV: packaging
+      TOXENV: pkg
       TOX_PARALLEL_NO_SPINNER: 1
 
     steps:


### PR DESCRIPTION
Hi, this PR fixes the wrong tox env name (which was not renamed with the rest of 39d89ef2) and which led to the latest release packaging failures, e.g. https://github.com/pycontribs/jira/actions/runs/11516626042