### PR TITLE
fix: fix release by using proper toxenv

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       FORCE_COLOR: 1
       PY_COLORS: 1
-      TOXENV: packaging
+      TOXENV: pkg
       TOX_PARALLEL_NO_SPINNER: 1
 
     steps:


### PR DESCRIPTION
Noticed that pkg is what probably is needed as that is what is defined in tox.ini, whereas packaging is not defined which is why the release workflow is currently failing