### PR TITLE
Handle when jira is behind a proxy

### DIFF
--- a/jira/resources.py
+++ b/jira/resources.py
@@ -293,17 +293,8 @@ class Resource:
         options.update({"path": path})
         return self._base_url.format(**options)
 
-    def _validate_self_self_url(self):
-        """In the case of a proxy, use the configured base URL
-            and not the one returned from JIRA.
-
-        Args:
-            self (Resource): self
-
-        Returns:
-            None
-
-        """
+    def _validate_self_self_url(self) -> None:
+        """In the case of a proxy, use the configured option server URL."""
         self_parsed = urlparse(self.self)
         server_parsed = urlparse(self._options["server"])
         if self_parsed.netloc != server_parsed.netloc:

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -11,10 +11,10 @@ import logging
 import re
 import time
 from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import ParseResult, urlparse, urlunparse
 
 from requests import Response
 from requests.structures import CaseInsensitiveDict
-from urllib.parse import urlparse, urlunparse, ParseResult  
 
 from jira.resilientsession import ResilientSession, parse_errors
 from jira.utils import json_loads, remove_empty_attributes, threaded_requests
@@ -296,17 +296,16 @@ class Resource:
     def _validate_self_self_url(self):
         """In the case of a proxy, use the configured base URL
             and not the one returned from JIRA.
-        
+
         Args:
             self (Resource): self
 
         Returns:
             None
-        
-        """
 
+        """
         self_parsed = urlparse(self.self)
-        server_parsed = urlparse(self._options['server'])
+        server_parsed = urlparse(self._options["server"])
         if self_parsed.netloc != server_parsed.netloc:
             self.self = urlunparse(
                 ParseResult(
@@ -314,8 +313,8 @@ class Resource:
                     netloc=server_parsed.netloc,
                     path=self_parsed.path,
                     params=self_parsed.params,
-                    query=self_parsed.query, 
-                    fragment= self_parsed.fragment
+                    query=self_parsed.query,
+                    fragment=self_parsed.fragment,
                 )
             )
 
@@ -448,7 +447,6 @@ class Resource:
         Returns:
             Optional[Response]: Returns None if async
         """
-
         self._validate_self_self_url()
         if self._options["async"]:
             # FIXME: mypy doesn't think this should work

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -295,19 +295,21 @@ class Resource:
 
     def _validate_self_self_url(self) -> None:
         """In the case of a proxy, use the configured option server URL."""
-        self_parsed = urlparse(self.self)
-        server_parsed = urlparse(self._options["server"])
-        if self_parsed.netloc != server_parsed.netloc:
-            self.self = urlunparse(
-                ParseResult(
-                    scheme=server_parsed.scheme,
-                    netloc=server_parsed.netloc,
-                    path=self_parsed.path,
-                    params=self_parsed.params,
-                    query=self_parsed.query,
-                    fragment=self_parsed.fragment,
+        if getattr(self, "self", None):
+            self.self: str
+            self_parsed = urlparse(self.self)
+            server_parsed = urlparse(self._options["server"])
+            if self_parsed.netloc != server_parsed.netloc:
+                self.self = urlunparse(
+                    ParseResult(
+                        scheme=server_parsed.scheme,
+                        netloc=server_parsed.netloc,
+                        path=self_parsed.path,
+                        params=self_parsed.params,
+                        query=self_parsed.query,
+                        fragment=self_parsed.fragment,
+                    )
                 )
-            )
 
     def update(
         self,
@@ -1523,7 +1525,7 @@ class AgileResource(Resource):
         session: ResilientSession,
         raw: dict[str, Any] | None = None,
     ):
-        self.self = None
+        self.self = ""
 
         Resource.__init__(self, path, options, session, self.AGILE_BASE_URL)
         if raw:

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -309,7 +309,7 @@ class Resource:
         if self_parsed.netloc != server_parsed.netloc:
             self.self = urlunparse(
                 ParseResult(
-                    scheme=self_parsed.scheme,
+                    scheme=server_parsed.scheme,
                     netloc=server_parsed.netloc,
                     path=self_parsed.path,
                     params=self_parsed.params,

--- a/tests/resources/test_issue.py
+++ b/tests/resources/test_issue.py
@@ -337,6 +337,20 @@ class IssueTests(JiraTestCase):
         issue.update(fields=fields)
         self.assertEqual(issue.fields.labels, ["testLabel"])
 
+    def test_update_label_with_proxy(self):
+        issue = self.jira.create_issue(
+            summary="Test issue for updating labels",
+            project=self.project_b,
+            description="Label testing",
+            issuetype=self.test_manager.CI_JIRA_ISSUE,
+        )
+
+        labelarray = ["testLabel"]
+        fields = {"labels": labelarray}
+        issue.self = f"http://foo.bar/jira/rest/api/2/issue/{issue.id}"
+        issue.update(fields=fields)
+        self.assertEqual(issue.fields.labels, ["testLabel"])
+
     def test_update_with_bad_label(self):
         issue = self.jira.create_issue(
             summary="Test issue for updating bad labels",
@@ -370,6 +384,18 @@ class IssueTests(JiraTestCase):
             issuetype=self.test_manager.CI_JIRA_ISSUE,
         )
         key = issue.key
+        issue.delete()
+        self.assertRaises(JIRAError, self.jira.issue, key)
+
+    def test_delete_with_proxy(self):
+        issue = self.jira.create_issue(
+            summary="Test issue created",
+            project=self.project_b,
+            description="Not long for this world",
+            issuetype=self.test_manager.CI_JIRA_ISSUE,
+        )
+        key = issue.key
+        issue.self = f"http://foo.bar/jira/rest/api/2/issue/{issue.id}"
         issue.delete()
         self.assertRaises(JIRAError, self.jira.issue, key)
 

--- a/tests/resources/test_issue.py
+++ b/tests/resources/test_issue.py
@@ -347,6 +347,8 @@ class IssueTests(JiraTestCase):
 
         labelarray = ["testLabel"]
         fields = {"labels": labelarray}
+        #This simulates when your Jira server is behind a proxy
+        #The self address returned will be different from the configured server
         issue.self = f"https://foo.bar/jira/rest/api/2/issue/{issue.id}"
         issue.update(fields=fields)
         self.assertEqual(issue.fields.labels, ["testLabel"])
@@ -395,6 +397,8 @@ class IssueTests(JiraTestCase):
             issuetype=self.test_manager.CI_JIRA_ISSUE,
         )
         key = issue.key
+        #This simulates when your Jira server is behind a proxy
+        #The self address returned will be different from the configured server
         issue.self = f"https://foo.bar/jira/rest/api/2/issue/{issue.id}"
         issue.delete()
         self.assertRaises(JIRAError, self.jira.issue, key)

--- a/tests/resources/test_issue.py
+++ b/tests/resources/test_issue.py
@@ -347,7 +347,7 @@ class IssueTests(JiraTestCase):
 
         labelarray = ["testLabel"]
         fields = {"labels": labelarray}
-        issue.self = f"http://foo.bar/jira/rest/api/2/issue/{issue.id}"
+        issue.self = f"https://foo.bar/jira/rest/api/2/issue/{issue.id}"
         issue.update(fields=fields)
         self.assertEqual(issue.fields.labels, ["testLabel"])
 
@@ -395,7 +395,7 @@ class IssueTests(JiraTestCase):
             issuetype=self.test_manager.CI_JIRA_ISSUE,
         )
         key = issue.key
-        issue.self = f"http://foo.bar/jira/rest/api/2/issue/{issue.id}"
+        issue.self = f"https://foo.bar/jira/rest/api/2/issue/{issue.id}"
         issue.delete()
         self.assertRaises(JIRAError, self.jira.issue, key)
 

--- a/tests/resources/test_issue.py
+++ b/tests/resources/test_issue.py
@@ -347,8 +347,8 @@ class IssueTests(JiraTestCase):
 
         labelarray = ["testLabel"]
         fields = {"labels": labelarray}
-        #This simulates when your Jira server is behind a proxy
-        #The self address returned will be different from the configured server
+        # This simulates when your Jira server is behind a proxy
+        # The self address returned will be different from the configured server
         issue.self = f"https://foo.bar/jira/rest/api/2/issue/{issue.id}"
         issue.update(fields=fields)
         self.assertEqual(issue.fields.labels, ["testLabel"])
@@ -397,8 +397,8 @@ class IssueTests(JiraTestCase):
             issuetype=self.test_manager.CI_JIRA_ISSUE,
         )
         key = issue.key
-        #This simulates when your Jira server is behind a proxy
-        #The self address returned will be different from the configured server
+        # This simulates when your Jira server is behind a proxy
+        # The self address returned will be different from the configured server
         issue.self = f"https://foo.bar/jira/rest/api/2/issue/{issue.id}"
         issue.delete()
         self.assertRaises(JIRAError, self.jira.issue, key)


### PR DESCRIPTION
Fixes https://github.com/pycontribs/jira/issues/1913

When your JIRA is behind a proxy, the urls returned in `self.self` on a Resource use the non-proxied URL which causes certain actions to timeout/fail. 

This new helper function compares the base URL of the returned `self.self` with the configured `server` parameter in the options. If they are different, the server parameter wins. 