### PR TITLE
debug: run a verbose test pypi release to see the errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
         github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
+        verbose: true
         password: ${{ secrets.testpypi_password }}
         repository_url: https://test.pypi.org/legacy/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       with:
         verbose: true
         password: ${{ secrets.testpypi_password }}
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/
 
     - name: Publish to pypi.org
       if: >-  # "create" workflows run separately from "push" & "pull_request"


### PR DESCRIPTION
no idea on how to debug this without creds
running verbose to see the error, im quite sure GHA will keep the pw's hidden in the logs but i dont see any other way than debugging through CI

https://github.com/pycontribs/jira/actions/runs/11983022866/job/33412046787#step:7:700