### PR TITLE
Handle unnecessary api call to /rest/api/2/field when all fields are requested

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -3550,7 +3550,7 @@ class JIRA:
         # this will translate JQL field names to REST API Name
         # most people do know the JQL names so this will help them use the API easier
         untranslate = {}  # use to add friendly aliases when we get the results back
-        if self._fields_cache:
+        if fields != ["*all"] and self._fields_cache:
             for i, field in enumerate(fields):
                 if field in self._fields_cache:
                     untranslate[self._fields_cache[field]] = fields[i]


### PR DESCRIPTION
- Previously, an unnecessary API call to fetch fields` /rest/api/2/field ` was made even when all fields were requested `(fields = ["*all"]).`

- Introduced an extra check to prevent redundant API calls when the default case for all fields is specified.