### PR TITLE
Don't add empty json from default dictionary to GET payloads to avoid 403 from jira API.

### DIFF
--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -180,7 +180,7 @@ class ResilientSession(Session):
         prepared_kwargs["headers"] = request_headers
 
         data = original_kwargs.get("data", None)
-        if isinstance(data, dict):
+        if isinstance(data, dict) and data:
             # mypy ensures we don't do this,
             # but for people subclassing we should preserve old behaviour
             prepared_kwargs["data"] = json.dumps(data)

--- a/tests/test_resilientsession.py
+++ b/tests/test_resilientsession.py
@@ -242,3 +242,13 @@ def test_verify_is_forwarded(mocked_request_method: Mock):
     session.get(url="mocked_url", data={"some": "fake-data"})
     kwargs = mocked_request_method.call_args.kwargs
     assert kwargs["verify"] == session.verify is False
+
+
+@patch("requests.Session.request")
+def test_empty_dict_body_not_forwarded(mocked_request_method: Mock):
+    # Disable retries for this test.
+    session = jira.resilientsession.ResilientSession(max_retries=0)
+    # Empty dictionary should not be converted to JSON
+    session.get(url="mocked_url", data={})
+    kwargs = mocked_request_method.call_args.kwargs
+    assert "data" not in kwargs


### PR DESCRIPTION
Proposal to resolve https://github.com/pycontribs/jira/issues/1945 