### PR TITLE
enhancement: Add enhanced_search_issues API for Jira Cloud using new search/jql endpoint

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -3615,7 +3615,6 @@ class JIRA:
         elif fields is None:
             fields = ["*all"]
 
-
         if self._is_cloud:
             if startAt == 0:
                 return self.enhanced_search_issues(
@@ -3682,7 +3681,6 @@ class JIRA:
                             iss.raw["fields"][v] = iss.raw["fields"][k]
 
         return issues
-
 
     @cloud_api
     def enhanced_search_issues(

--- a/jira/client.py
+++ b/jira/client.py
@@ -225,6 +225,7 @@ class ResultList(list, Generic[ResourceType]):
         _maxResults: int = 0,
         _total: int | None = None,
         _isLast: bool | None = None,
+        _nextPageToken: bool | None = None,
     ) -> None:
         """Results List.
 
@@ -234,6 +235,7 @@ class ResultList(list, Generic[ResourceType]):
             _maxResults (int): Max results per page. Defaults to 0.
             _total (Optional[int]): Total results from query. Defaults to 0.
             _isLast (Optional[bool]): True to mark this page is the last page? (Default: ``None``).
+            _nextPageToken (Optional[str]): Token for fetching the next page of results. Defaults to None.
              see `The official API docs <https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/#expansion:~:text=for%20all%20operations.-,isLast,-indicates%20whether%20the>`_
         """
         if iterable is not None:
@@ -249,6 +251,7 @@ class ResultList(list, Generic[ResourceType]):
 
         self.iterable: list[ResourceType] = list(iterable) if iterable else []
         self.current = self.startAt
+        self.nextPageToken = _nextPageToken
 
     def __next__(self) -> ResourceType:  # type:ignore[misc]
         self.current += 1
@@ -816,6 +819,7 @@ class JIRA:
         resource = self._get_json(
             request_path, params=page_params, base=base, use_post=use_post
         )
+
         next_items_page = self._get_items_from_page(item_type, items_key, resource)
         items = next_items_page
 
@@ -907,6 +911,70 @@ class JIRA:
             return ResultList(
                 [item_type(self._options, self._session, resource)], 0, 1, 1, True
             )
+
+    @cloud_api
+    def _fetch_pages_searchToken(
+        self,
+        item_type: type[ResourceType],
+        items_key: str | None,
+        request_path: str,
+        maxResults: int = 50,
+        params: dict[str, Any] | None = None,
+        base: str = JIRA_BASE_URL,
+        use_post: bool = False,
+    ) -> ResultList[ResourceType]:
+        """Fetch from a paginated API endpoint using `nextPageToken`.
+
+        Args:
+            item_type (Type[Resource]): Type of single item. Returns a `ResultList` of such items.
+            items_key (Optional[str]): Path to the items in JSON returned from the server.
+            request_path (str): Path in the request URL.
+            maxResults (int): Maximum number of items to return per page. (Default: 50)
+            params (Dict[str, Any]): Parameters to be sent with the request.
+            base (str): Base URL for the requests.
+            use_post (bool): Whether to use POST instead of GET.
+
+        Returns:
+            ResultList: List of fetched items.
+        """
+        def json_params() -> dict[str, Any]:
+            return json.loads(json.dumps(params.copy())) if params else {}
+
+        DEFAULT_BATCH = 100  # default page size for each request
+        # Decide if we should fetch unlimited results:
+        unlimited = False
+        if not maxResults:
+            unlimited = True
+
+        # When a limit is specified, record it for later use.
+        limit_total = None if unlimited else maxResults
+
+        # Initialize the page parameters for the first request.
+        page_params = json_params()
+        page_params["maxResults"] = DEFAULT_BATCH if unlimited else min(limit_total, DEFAULT_BATCH)
+        items = []
+        nextPageToken = None
+
+        while True:
+            if nextPageToken:
+                page_params["nextPageToken"] = nextPageToken
+
+            # For limited fetches, adjust the page size to not exceed the remaining limit.
+            if not unlimited:
+                remaining = limit_total - len(items)
+                if remaining <= 0:
+                    break
+                page_params["maxResults"] = min(remaining, DEFAULT_BATCH)
+            else:
+                page_params["maxResults"] = DEFAULT_BATCH
+            resource = self._get_json(request_path, params=page_params, base=base, use_post=use_post)
+            next_items_page = self._get_items_from_page(item_type, items_key, resource)
+            items.extend(next_items_page)
+            nextPageToken = resource.get("nextPageToken")
+            # Stop if there are no more pages.
+            if nextPageToken is None:
+                break
+        return ResultList(items, _nextPageToken=nextPageToken)
 
     def _get_items_from_page(
         self,
@@ -3547,6 +3615,21 @@ class JIRA:
         elif fields is None:
             fields = ["*all"]
 
+
+        if self._is_cloud:
+            if startAt == 0:
+                return self.enhanced_search_issues(
+                    jql_str=jql_str,
+                    maxResults=maxResults,
+                    fields=fields,
+                    expand=expand,
+                    properties=properties,
+                    json_result=json_result,
+                    use_post=use_post,
+                )
+            else:
+                raise JIRAError("The `search` API is deprecated in Jira Cloud. Use `enhanced_search_issues` instead.")
+
         # this will translate JQL field names to REST API Name
         # most people do know the JQL names so this will help them use the API easier
         untranslate = {}  # use to add friendly aliases when we get the results back
@@ -3599,6 +3682,129 @@ class JIRA:
                             iss.raw["fields"][v] = iss.raw["fields"][k]
 
         return issues
+
+
+    @cloud_api
+    def enhanced_search_issues(
+        self,
+        jql_str: str,
+        nextPageToken: str | None = None,
+        maxResults: int = 50,
+        fields: str | list[str] | None = "*all",
+        expand: str | None = None,
+        reconcileIssues: list[int] | None = None,
+        properties: str | None = None,
+        *,
+        json_result: bool = False,
+        use_post: bool = False,
+    ) -> dict[str, Any] | ResultList[Issue]:
+        """Get a :class:`~jira.client.ResultList` of issue Resources matching a JQL search string.
+
+        Args:
+            jql_str (str): The JQL search string.
+            nextPageToken (Optional[str]): Token for paginated results.
+            maxResults (int): Maximum number of issues to return.
+              Total number of results is available in the ``total`` attribute of the returned :class:`ResultList`.
+              If maxResults evaluates to False, it will try to get all issues in batches. (Default: ``50``)
+            fields (Optional[Union[str, List[str]]]): comma-separated string or list of issue fields to include in the results.
+              Default is to include all fields.
+            expand (Optional[str]): extra information to fetch inside each resource.
+            reconcileIssues (Optional[List[int]]): List of issue IDs to reconcile.
+            properties (Optional[str]): extra properties to fetch inside each result
+            json_result (bool): True to return a JSON response. When set to False a :class:`ResultList` will be returned. (Default: ``False``)
+            use_post (bool): True to use POST endpoint to fetch issues.
+
+        Returns:
+            Union[Dict, ResultList]: JSON Dict if ``json_result=True``, otherwise a `ResultList`.
+        """
+        if isinstance(fields, str):
+            fields = fields.split(",")
+        elif fields is None:
+            fields = ["*all"]
+
+        if reconcileIssues is None:
+            reconcileIssues = []
+
+        # this will translate JQL field names to REST API Name
+        # most people do know the JQL names so this will help them use the API easier
+        untranslate = {}  # use to add friendly aliases when we get the results back
+        if self._fields_cache:
+            for i, field in enumerate(fields):
+                if field in self._fields_cache:
+                    untranslate[self._fields_cache[field]] = fields[i]
+                    fields[i] = self._fields_cache[field]
+
+        search_params = {
+            "jql": jql_str,
+            "fields": fields,
+            "expand": expand,
+            "properties": properties,
+            "reconcileIssues": reconcileIssues,
+        }
+        if nextPageToken:
+            search_params["nextPageToken"] = nextPageToken
+
+        if json_result:
+            search_params["maxResults"] = maxResults
+            if not maxResults:
+                warnings.warn(
+                    "All issues cannot be fetched at once, when json_result parameter is set",
+                    Warning,
+                )
+            r_json: dict[str, Any] = self._get_json(
+                "search/jql", params=search_params, use_post=use_post
+            )
+            return r_json
+
+        issues = self._fetch_pages_searchToken(
+            item_type=Issue,
+            items_key="issues",
+            request_path="search/jql",
+            maxResults=maxResults,
+            params=search_params,
+            use_post=use_post,
+        )
+
+        if untranslate:
+            iss: Issue
+            for iss in issues:
+                for k, v in untranslate.items():
+                    if iss.raw:
+                        if k in iss.raw.get("fields", {}):
+                            iss.raw["fields"][v] = iss.raw["fields"][k]
+
+        return issues
+
+    @cloud_api
+    def approximate_issue_count(
+        self,
+        jql_str: str,
+        *,
+        json_result: bool = False,
+    ) -> int | dict[str, Any]:
+        """Get an approximate count of issues matching a JQL search string.
+
+        Args:
+            jql_str (str): The JQL search string.
+            json_result (bool): If True, returns the full JSON response. Defaults to False.
+
+        Returns:
+            int | dict[str, Any]: The issue count if json_result is False, else the raw JSON response.
+        """
+        print(self.deploymentType)
+        if not self._is_cloud:
+            raise ValueError("The 'approximate-count' API is only available for Jira Cloud.")
+
+        search_params = {"jql": jql_str}
+
+        response_json: dict[str, Any] = self._get_json(
+            "search/approximate-count", params=search_params, use_post=True
+        )
+
+        if json_result:
+            return response_json
+
+        return response_json.get("count", 0)
 
     # Security levels
     def security_level(self, id: str) -> SecurityLevel:

--- a/jira/client.py
+++ b/jira/client.py
@@ -937,6 +937,7 @@ class JIRA:
         Returns:
             ResultList: List of fetched items.
         """
+
         def json_params() -> dict[str, Any]:
             return json.loads(json.dumps(params.copy())) if params else {}
 
@@ -951,7 +952,9 @@ class JIRA:
 
         # Initialize the page parameters for the first request.
         page_params = json_params()
-        page_params["maxResults"] = DEFAULT_BATCH if unlimited else min(limit_total, DEFAULT_BATCH)
+        page_params["maxResults"] = (
+            DEFAULT_BATCH if unlimited else min(limit_total, DEFAULT_BATCH)
+        )
         items = []
         nextPageToken = None
 
@@ -967,7 +970,9 @@ class JIRA:
                 page_params["maxResults"] = min(remaining, DEFAULT_BATCH)
             else:
                 page_params["maxResults"] = DEFAULT_BATCH
-            resource = self._get_json(request_path, params=page_params, base=base, use_post=use_post)
+            resource = self._get_json(
+                request_path, params=page_params, base=base, use_post=use_post
+            )
             next_items_page = self._get_items_from_page(item_type, items_key, resource)
             items.extend(next_items_page)
             nextPageToken = resource.get("nextPageToken")
@@ -3627,7 +3632,9 @@ class JIRA:
                     use_post=use_post,
                 )
             else:
-                raise JIRAError("The `search` API is deprecated in Jira Cloud. Use `enhanced_search_issues` instead.")
+                raise JIRAError(
+                    "The `search` API is deprecated in Jira Cloud. Use `enhanced_search_issues` instead."
+                )
 
         # this will translate JQL field names to REST API Name
         # most people do know the JQL names so this will help them use the API easier
@@ -3791,7 +3798,9 @@ class JIRA:
         """
         print(self.deploymentType)
         if not self._is_cloud:
-            raise ValueError("The 'approximate-count' API is only available for Jira Cloud.")
+            raise ValueError(
+                "The 'approximate-count' API is only available for Jira Cloud."
+            )
 
         search_params = {"jql": jql_str}
 


### PR DESCRIPTION
### Overview
This PR introduces two new functions for Jira Cloud:
1. **enhanced_search_issues:**  
   This function leverages the new search/jql REST endpoint with nextPageToken-based pagination. It is designed to replace the deprecated search API endpoints (GET/POST /rest/api/3/search), which Atlassian has already deprecated and will remove support for on May 1, 2025. The function allows for either limited or complete fetching of results (when maxResults is set to false).

2. **approximate_issue_count:**  
   This new function calls the search/approximate-count API to retrieve an approximate count of issues matching a given JQL query. This endpoint is available only for Jira Cloud and is essential for users who need a quick estimation of matching issues.

### Changes
- **enhanced_search_issues:**  
  - Implements nextPageToken-based pagination.
  - Fetches all results if `maxResults` evaluates to false; otherwise, it fetches up to the specified limit.
- **approximate_issue_count:**  
  - Returns either an integer count or the full JSON response based on the `json_result` flag.
- Both functions are decorated with `@cloud_api` to ensure they are only used on Jira Cloud.
- The new implementations are intended for Jira Cloud users, while Jira Server/Data Center users will continue using the existing APIs.

### Testing & Limitations
- **Manual Testing:** I have manually validated these changes against my Jira Cloud instance.
- **Unit Tests:** Due to difficulties in configuring our testing environment for Jira Cloud (the existing tests are designed primarily for Data Center setups), I was not able to write complete unit tests for these cloud-specific endpoints. Further work is needed to establish a dedicated Jira Cloud test environment.

### Migration & Impact
- **Breaking Change:**  
  Atlassian has already deprecated the old search API endpoints, and support for these endpoints will be removed on May 1, 2025.  
  Jira Cloud users must migrate to using `enhanced_search_issues` and `approximate_issue_count` to ensure continued compatibility.
- Jira Server/Data Center users are not affected by these changes and can continue using the existing APIs.

### Additional Context
- This update aligns with Atlassian's decision to deprecate and eventually remove support for the old search endpoints, aiming for a more reliable and performant Jira Cloud experience.
- For any questions or further clarification, please refer to the discussion thread on this PR or reach out via our developer community forum.

Please review the changes and let me know if any further modifications are required.
