### PR TITLE
Fix creation of local Jira user

### DIFF
--- a/.github/workflows/jira_cloud_ci.yml
+++ b/.github/workflows/jira_cloud_ci.yml
@@ -41,7 +41,7 @@ jobs:
           python -m pip install --upgrade tox tox-gh-actions
 
       - name: Test with tox
-        run: tox -e py310 -- -m allow_on_cloud
+        run: tox run -e py310 -- -m allow_on_cloud
         env:
           CI_JIRA_TYPE: CLOUD
           CI_JIRA_CLOUD_ADMIN: ${{ secrets.CLOUD_ADMIN }}

--- a/.github/workflows/jira_server_ci.yml
+++ b/.github/workflows/jira_server_ci.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Test with tox
         run: tox
+        env:
+          CI_JIRA_TYPE: SERVER
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/make_local_jira_user.py
+++ b/make_local_jira_user.py
@@ -10,7 +10,8 @@ import requests
 
 from jira import JIRA
 
-CI_JIRA_URL = environ["CI_JIRA_URL"]
+CI_JIRA_URL = environ.get("CI_JIRA_URL")
+CI_TYPE = environ.get("CI_JIRA_TYPE")
 
 
 def add_user_to_jira():
@@ -31,7 +32,10 @@ def add_user_to_jira():
 
 
 if __name__ == "__main__":
-    if environ.get("CI_JIRA_TYPE", "Server").upper() == "CLOUD":
+    if CI_TYPE is None or CI_JIRA_URL is None:
+        print("No CI type (Server/Cloud) or Instance URL provided, quitting.")
+        sys.exit()
+    if CI_TYPE.upper() == "CLOUD":
         print("Do not need to create a user for Jira Cloud CI, quitting.")
         sys.exit()
 

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ commands_pre =
     {env_python} -m pip check
 commands =
     git clean -xdf jira tests
-    python -m pip check
+    {env_python} make_local_jira_user.py
     coverage run -m pytest {posargs: \
       -ra \
       --showlocals \


### PR DESCRIPTION
The make user file needs to be called so that the Jira instance is ready for use by the test framework.

We still call it every time, but the script now gracefully closes if the env variables are not set. 
This allows the 'unit' tests run in GHA to still run uninterrupted.