### PR TITLE
refactor: restructure release workflow to include artifact upload and download steps with the correct token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  pypi:
-    name: Publish to PyPI registry
+  build:
+    runs-on: ubuntu-latest
     environment: release
-    runs-on: ubuntu-24.04
-    permissions:
-      id-token: write
-
     env:
       FORCE_COLOR: 1
       PY_COLORS: 1
@@ -42,7 +38,35 @@ jobs:
       - name: Build dists
         run: python3 -m tox
 
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: package
+          path: dist/
+          retention-days: 7
+          if-no-files-found: error
+
+  pypi:
+    needs: [build]
+    name:
+      Publish to PyPI registry
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment: release
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: package
+          path: dist
+
+      - name: Show tree
+        run: tree
+
       - name: Publish to pypi.org
         if: >-  # "create" workflows run separately from "push" & "pull_request"
           github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
making the release step two tasks as suggested by the github action pypa/gh-action-pypi-publish
also adding the right token 