### PR TITLE
fix: update tag regex pattern in pyproject.toml for version matching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,7 +239,7 @@ git_describe_command = [
   "--long",
   "--tags",
   "--match",
-  "v*.*"
+  "*.*.*"
 ]
 local_scheme = "no-local-version"
 tag_regex = "^(?P<prefix>v)?(?P<version>\\d+[^\\+]*)(?P<suffix>.*)?$"


### PR DESCRIPTION
seems like the tag with a v was required for setuptools_scm but none of the jira tags are with a v