### PR TITLE
add ability to configure retry time limit

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -480,6 +480,7 @@ class JIRA:
         async_workers: int = 5,
         logging: bool = True,
         max_retries: int = 3,
+        max_retry_delay: int = 60,
         proxies: Any | None = None,
         timeout: None | float | tuple[float, float] | tuple[float, None] | None = None,
         auth: tuple[str, str] | None = None,
@@ -611,7 +612,7 @@ class JIRA:
         assert isinstance(self._options["headers"], dict)  # for mypy benefit
 
         # Create Session object and update with config options first
-        self._session = ResilientSession(timeout=timeout)
+        self._session = ResilientSession(timeout=timeout, max_retries=max_retries, max_retry_delay=max_retry_delay)
         # Add the client authentication certificate to the request if configured
         self._add_client_cert_to_session()
         # Add the SSL Cert to the request if configured
@@ -621,8 +622,6 @@ class JIRA:
 
         if "cookies" in self._options:
             self._session.cookies.update(self._options["cookies"])
-
-        self._session.max_retries = max_retries
 
         if proxies:
             self._session.proxies = proxies

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -407,3 +407,16 @@ def test_experimental_non_200_not_404_405(
 
     assert ex.value.status_code == status_code
     assert isinstance(ex.value, JIRAError)
+
+
+def test_client_retry_config():
+    client = jira.client.JIRA(
+        server="https://jira.example.com",
+        get_server_info=False,
+        validate=False,
+        max_retries=81,
+        max_retry_delay=111,
+    )
+
+    assert client._session.max_retries == 81
+    assert client._session.max_retry_delay == 111


### PR DESCRIPTION
Exactly what it says on the tin. Sometimes 60s is a long backoff. It would be nice to configure it.

I tried to write a test. I followed the README instructions to run tests but the JIRA server docker container failed to come up.