### PR TITLE
fix: don’t forward empty JSON bodies on GET (prevents Jira 403)

### DIFF
--- a/jira/resilientsession.py
+++ b/jira/resilientsession.py
@@ -180,10 +180,14 @@ class ResilientSession(Session):
         prepared_kwargs["headers"] = request_headers
 
         data = original_kwargs.get("data", None)
-        if isinstance(data, dict) and data:
-            # mypy ensures we don't do this,
-            # but for people subclassing we should preserve old behaviour
-            prepared_kwargs["data"] = json.dumps(data)
+        if isinstance(data, dict):
+            if data:
+                # mypy ensures we don't do this,
+                # but for people subclassing we should preserve old behaviour
+                prepared_kwargs["data"] = json.dumps(data)
+            else:
+                # Don't forward an empty JSON body
+                prepared_kwargs.pop("data", None)
 
         if "verify" not in prepared_kwargs:
             prepared_kwargs["verify"] = self.verify


### PR DESCRIPTION
* Non-empty dict → keep existing behavior and send json.dumps(data). 
* Empty dict → remove data from prepared_kwargs so no body is sent.

While I understand this is needed I do not understand why the tests ever passed.

* Fixes #2362