### PR TITLE
chore: Adds some missing type annotations

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -732,11 +732,11 @@ class JIRA:
         except Exception as e:
             self.log.warning(e)
 
-    def __del__(self):
+    def __del__(self) -> None:
         """Destructor for JIRA instance."""
         self.close()
 
-    def close(self):
+    def close(self) -> None:
         session = getattr(self, "_session", None)
         if session is not None:
             try:

--- a/jira/resources.py
+++ b/jira/resources.py
@@ -893,7 +893,7 @@ class Issue(Resource):
         else:
             return getattr(self.fields, field_name)
 
-    def add_field_value(self, field: str, value: str):
+    def add_field_value(self, field: str, value: str) -> None:
         """Add a value to a field that supports multiple values, without resetting the existing values.
 
         This should work with: labels, multiple checkbox lists, multiple select
@@ -904,7 +904,7 @@ class Issue(Resource):
         """
         super().update(fields={"update": {field: [{"add": value}]}})
 
-    def delete(self, deleteSubtasks=False):
+    def delete(self, deleteSubtasks=False) -> None:
         """Delete this issue from the server.
 
         Args:
@@ -912,7 +912,7 @@ class Issue(Resource):
         """
         super().delete(params={"deleteSubtasks": deleteSubtasks})
 
-    def permalink(self):
+    def permalink(self) -> str:
         """Get the URL of the issue, the browsable one not the REST one.
 
         Returns:


### PR DESCRIPTION
Adds a few missing type annotations I found while working on another project. `mypy` flagged most of these with `no-untyped-call`. The others I found while updating the functions flagged by `mypy`.