### PR TITLE
cloud: Fix project_issue_fields usage

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -3137,10 +3137,14 @@ class JIRA:
         Returns:
             ResultList[Field]
         """
-        self._check_createmeta_issuetypes()
+        if not self._is_cloud:
+            self._check_createmeta_issuetypes()
+            field_delim = "values"
+        else:
+            field_delim = "fields"
         fields = self._fetch_pages(
             Field,
-            "values",
+            field_delim,
             f"issue/createmeta/{project}/issuetypes/{issue_type}",
             startAt=startAt,
             maxResults=maxResults,

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ description =
     devel: w/ constraints, some devel dependencies
 package = editable
 deps =
-    devel: requests@ git+https://github.com/psf/requests.git
+    devel: requests @ git+https://github.com/psf/requests.git
 extras =
     cli
     opt


### PR DESCRIPTION
This is the documented REST API; it seems the code disables it when using cloud when it shouldn't. The field table definition changed in the cloud API (`values` -> `fields`), but otherwise, this is still current:

https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-createmeta-projectidorkey-issuetypes-issuetypeid-get
