### PR TITLE
feat(jira-test-image): self-host the test image and run test suite on multiple jira versions

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -1,0 +1,146 @@
+name: ghcr-publish
+
+# Publishes the jira-test-image for any Jira major. Every input below
+# maps 1:1 onto a Dockerfile ARG; defaults match the Dockerfile defaults
+# (Jira 8.17.1, the version pycontribs/jira's server CI runs against).
+# Always builds AND publishes both the unwarmed and the warmed variant
+# in a single dispatch; the `tag_latest` boolean controls only whether
+# the floating `:<major>[-warm]-latest` tags are pushed alongside the
+# version-pinned ones.
+#
+# Tag composition:
+#
+#   tag_latest=false (default):
+#     :<jira_version>          (unwarmed)
+#     :<jira_version>-warm     (warmed)
+#
+#   tag_latest=true:
+#     :<jira_version>          (unwarmed)
+#     :<jira_version>-warm     (warmed)
+#     :<jira_major>-latest     (unwarmed)
+#     :<jira_major>-warm-latest (warmed)
+#
+# Different majors do not collide on `:<major>[-warm]-latest`, so this
+# is safe to enable per release. Build context is `docker/jira-test-image/`.
+
+on:
+  workflow_dispatch:
+    inputs:
+      jira_major:
+        description: "Jira major version (e.g. 8)"
+        required: true
+        type: string
+        default: "8"
+      jira_minor_patch:
+        description: "Jira minor.patch (e.g. 17.1)"
+        required: true
+        type: string
+        default: "17.1"
+      java_image:
+        description: "Java base image"
+        required: true
+        type: string
+        default: "eclipse-temurin:8-jdk-jammy"
+      amps_version:
+        description: "AMPS / jira-maven-plugin version (must resolve on both maven-external paths)"
+        required: true
+        type: string
+        default: "8.2.3"
+      spring_scanner_version:
+        description: "atlassian-spring-scanner version (2.1.x for Jira 8, 2.2.x for 9-10, 6.x for 11)"
+        required: true
+        type: string
+        default: "2.1.17"
+      testrunner_version:
+        description: "atlassian-plugins-osgi-testrunner version"
+        required: true
+        type: string
+        default: "2.0.16"
+      compile_floor:
+        description: "Java source/target compile floor (1.8 / 11 / 17)"
+        required: true
+        type: string
+        default: "1.8"
+      tag_latest:
+        description: "Also push :<major>[-warm]-latest floating tags"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/jira-test-image
+  JIRA_VERSION: ${{ inputs.jira_major }}.${{ inputs.jira_minor_patch }}
+  CONTEXT: docker/jira-test-image
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    # Per-variant rough budget on a clean cache:
+    #   unwarmed build + push  ~10min
+    #   warmer-stage boot      ~15-25min
+    #   warmed export + push   ~5min
+    # Total ~50min; 90min ceiling absorbs slow GHCR / Maven days.
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build unwarmed
+        run: |
+          docker build \
+            --target unwarmed \
+            --build-arg JAVA_IMAGE='${{ inputs.java_image }}' \
+            --build-arg AMPS_VERSION='${{ inputs.amps_version }}' \
+            --build-arg JIRA_VERSION='${{ env.JIRA_VERSION }}' \
+            --build-arg SPRING_SCANNER_VERSION='${{ inputs.spring_scanner_version }}' \
+            --build-arg TESTRUNNER_VERSION='${{ inputs.testrunner_version }}' \
+            --build-arg COMPILE_FLOOR='${{ inputs.compile_floor }}' \
+            -t '${{ env.IMAGE }}:${{ env.JIRA_VERSION }}' \
+            '${{ env.CONTEXT }}'
+
+      - name: Push unwarmed
+        run: docker push '${{ env.IMAGE }}:${{ env.JIRA_VERSION }}'
+
+      - name: Build warmed
+        # Reuses the warmed stage's underlying base layers from the
+        # previous step's local cache; only the warmer-stage atlas-run
+        # boot is genuinely new work here.
+        run: |
+          docker build \
+            --target warmed \
+            --build-arg JAVA_IMAGE='${{ inputs.java_image }}' \
+            --build-arg AMPS_VERSION='${{ inputs.amps_version }}' \
+            --build-arg JIRA_VERSION='${{ env.JIRA_VERSION }}' \
+            --build-arg SPRING_SCANNER_VERSION='${{ inputs.spring_scanner_version }}' \
+            --build-arg TESTRUNNER_VERSION='${{ inputs.testrunner_version }}' \
+            --build-arg COMPILE_FLOOR='${{ inputs.compile_floor }}' \
+            -t '${{ env.IMAGE }}:${{ env.JIRA_VERSION }}-warm' \
+            '${{ env.CONTEXT }}'
+
+      - name: Push warmed
+        run: docker push '${{ env.IMAGE }}:${{ env.JIRA_VERSION }}-warm'
+
+      - name: Push :<major>-latest tags
+        if: inputs.tag_latest
+        run: |
+          UNWARMED_SRC='${{ env.IMAGE }}:${{ env.JIRA_VERSION }}'
+          WARMED_SRC='${{ env.IMAGE }}:${{ env.JIRA_VERSION }}-warm'
+          UNWARMED_DST='${{ env.IMAGE }}:${{ inputs.jira_major }}-latest'
+          WARMED_DST='${{ env.IMAGE }}:${{ inputs.jira_major }}-warm-latest'
+          docker tag "$UNWARMED_SRC" "$UNWARMED_DST"
+          docker tag "$WARMED_SRC" "$WARMED_DST"
+          docker push "$UNWARMED_DST"
+          docker push "$WARMED_DST"

--- a/.github/workflows/jira_server_ci.yml
+++ b/.github/workflows/jira_server_ci.yml
@@ -20,6 +20,10 @@ on:
 # Concurrency is set on the calling ci.yml; defining it here too
 # would self-cancel since github.workflow returns the caller's name.
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   test:
     name: py${{ matrix.python-version }}-jira${{ matrix.jira-version }}
@@ -27,21 +31,41 @@ jobs:
     strategy:
       fail-fast: false
       # One python is enough against a real Jira; tox.yml covers
-      # the full python matrix without booting one.
+      # the full python matrix without booting one. Each Jira version
+      # below must already exist as a warmed image on GHCR; the
+      # `.github/workflows/ghcr-publish.yml` workflow_dispatch publishes
+      # them. See docker/jira-test-image/README.md for the validated
+      # version matrix.
       matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.12"]
-        jira-version: ["8.17.1"]
+        include:
+          - { os: ubuntu-latest, python-version: "3.12", jira-version: "8.17.1"  }
+          - { os: ubuntu-latest, python-version: "3.12", jira-version: "8.20.30" }
+          - { os: ubuntu-latest, python-version: "3.12", jira-version: "9.12.34" }
+          - { os: ubuntu-latest, python-version: "3.12", jira-version: "11.3.4"  }
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Build Jira test image
-        run: docker build -t pycontribs/jira-test-image:${{ matrix.jira-version }} docker/jira-test-image
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Start Jira docker instance
-        run: docker run -dit -p 2990:2990 -e JIRA_VERSION=${{ matrix.jira-version }} --name jira pycontribs/jira-test-image:${{ matrix.jira-version }}
+        # Pulls the warmed variant published by ghcr-publish.yml.
+        # Warmed images bake the Maven cache + atlas-run-unpacked webapp
+        # so cold-boot is ~1-2 min instead of ~10-20 min, and the
+        # entrypoint runs offline (-o). Do not pass -e JIRA_VERSION:
+        # the warmed target/ directory is anchored to the version baked
+        # at publish time, and overriding it would force atlas-run to
+        # reach out for a different artifact under -o.
+        run: |
+          IMAGE='ghcr.io/${{ github.repository_owner }}/jira-test-image:${{ matrix.jira-version }}-warm'
+          docker pull "$IMAGE"
+          docker run -dit -p 2990:2990 --name jira "$IMAGE"
 
       - name: Install uv and pin python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,8 @@ repos:
         entry: codespell
         language: python
         types: [text]
-        args: []
+        # false flag of spelling errors for package names.
+        exclude: ^docker/jira-test-image/plugin/pom\.xml\.template$
         require_serial: false
         additional_dependencies:
           - tomli; python_version<'3.11'

--- a/docker/jira-test-image/Dockerfile
+++ b/docker/jira-test-image/Dockerfile
@@ -1,29 +1,120 @@
-# Thin wrap of addono/jira-software-standalone for the pycontribs/jira
-# test suite.
+# Self-hosted multi-stage image for the pycontribs/jira test suite.
+# Replaces the previous thin wrapper around addono/jira-software-standalone:
+# every value that changes between Jira majors is exposed as an ARG,
+# so the same Dockerfile boots Jira 8 (this suite's historic target)
+# all the way through Jira 11 (Jakarta / Spring 6) by flipping ARGs.
 #
-# Two non-trivial things this image does on top of the addono base:
+# Defaults pin to Jira 8.17.1 - the version used by jira_server_ci.yml -
+# so the existing CI step `docker build docker/jira-test-image` produces
+# the same image without needing per-major overrides.
 #
-#   1. Pins the upstream by digest, not tag, so we are not at the mercy
-#      of `:latest` shifting under us.
-#   2. Adds `-DskipAllPrompts=true` to the AMPS invocation. Atlassian
-#      shut down the Marketplace v1 REST endpoint AMPS hardcodes for
-#      its SDK update check; without this flag, every fresh container
-#      start fails with `FileNotFoundException` on
-#      `https://marketplace.atlassian.com/rest/1.0/plugins/...`.
-#
-# JIRA_VERSION stays overridable - users can run any supported Jira
-# version via `docker run -e JIRA_VERSION=11.0.1 ...`.
+# Why the move off the addono base:
+#   1. The upstream image is anchored to its own pom, which only
+#      resolves the Jira 8.x dependency graph. Newer majors fail
+#      Maven resolution and silently fall back to 8.x at runtime.
+#   2. The companion ghcr-publish.yml workflow exposes every ARG as
+#      a workflow_dispatch input and publishes both unwarmed and
+#      warmed variants per dispatch.
 
-# https://hub.docker.com/r/addono/jira-software-standalone
-# digest captured 2026-04-29; bump when intentionally upgrading the base.
-FROM addono/jira-software-standalone@sha256:04326628dc4ac36b2bfc1d0f2ebe5ba3807c1ec9cf9b18307d3c2ad7222537e9
+# === ARGs =====================================================================
+# Java runtime image. Jira 11.x = JDK 21; 10.x = JDK 17; 9.x = JDK 11;
+# 8.x = JDK 8. https://confluence.atlassian.com/adminjiraserver/supported-platforms-938846830.html
+ARG JAVA_IMAGE=eclipse-temurin:8-jdk-jammy
 
+# AMPS (Atlassian Maven Plugin Suite). Consumed in two places:
+#   - install-sdk.sh against the atlassian-plugin-sdk tarball
+#   - plugin/pom.xml.template against jira-maven-plugin
+# The two artifacts share a release train but can drift; verify both:
+#   https://packages.atlassian.com/maven-external/com/atlassian/amps/atlassian-plugin-sdk/maven-metadata.xml
+#   https://packages.atlassian.com/maven-external/com/atlassian/maven/plugins/jira-maven-plugin/maven-metadata.xml
+# Known-good combos: 8.2.3 (Jira 8), 9.1.2 (Jira 9 + 10), 9.11.2 (Jira 11).
+ARG AMPS_VERSION=8.2.3
+
+# Jira version baked as build-time default. Same image can boot any
+# patch within the major via `docker run -e JIRA_VERSION=...`.
+# The ENV that surfaces this to atlas-run lives inside the base stage
+# (ENV is not legal before the first FROM).
 ARG JIRA_VERSION=8.17.1
+
+# atlassian-spring-scanner. Jakarta-locked to Jira's Spring major:
+#   2.1.x = Jira 8 (Spring 5 / javax.*)
+#   2.2.x = Jira 9 + 10 (Spring 5 / javax.*)
+#   6.x   = Jira 11 (Spring 6 / Jakarta EE 10)
+# Crossing the streams (2.x against jakarta.*, 6.x against javax.*) silently no-ops.
+ARG SPRING_SCANNER_VERSION=2.1.17
+
+# atlassian-plugins-osgi-testrunner. Stable across Jira 8-11 on the 2.0.x line.
+ARG TESTRUNNER_VERSION=2.0.16
+
+# Java compile floor for the plugin jar. Match the runtime JDK so the
+# resulting class files load on the target Jira's classloader.
+ARG COMPILE_FLOOR=1.8
+
+# === base =====================================================================
+# Common scaffolding shared by `unwarmed`, `warmer`, and `warmed`.
+FROM ${JAVA_IMAGE} AS base
+
+# Redeclare ARGs after FROM so they're visible in this stage.
+ARG AMPS_VERSION
+ARG JIRA_VERSION
+ARG SPRING_SCANNER_VERSION
+ARG TESTRUNNER_VERSION
+ARG COMPILE_FLOOR
+
 ENV JIRA_VERSION=${JIRA_VERSION}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV PATH=/opt/atlassian-plugin-sdk/bin:${PATH}
+
+# SDK install. Tarball is the only supported path - the apt repo at
+# packages.atlassian.com/atlassian-sdk-deb was retired Feb 2018.
+COPY scripts/install-sdk.sh /tmp/install-sdk.sh
+RUN bash /tmp/install-sdk.sh "${AMPS_VERSION}" && rm /tmp/install-sdk.sh
+
+WORKDIR /opt/jira-plugin
+COPY plugin/ ./
+COPY scripts/render-pom.sh /tmp/render-pom.sh
+RUN bash /tmp/render-pom.sh \
+        "${AMPS_VERSION}" \
+        "${SPRING_SCANNER_VERSION}" \
+        "${TESTRUNNER_VERSION}" \
+        "${COMPILE_FLOOR}" \
+        pom.xml.template \
+        pom.xml \
+    && rm /tmp/render-pom.sh pom.xml.template
 
 EXPOSE 2990
 
-# atlas-run reads JIRA_VERSION from the env (the upstream image's pom
-# uses ${env.JIRA_VERSION}). -DskipAllPrompts=true is a Maven system
-# property forwarded through to the AMPS plugin.
+# === warmer ===================================================================
+# Build-time-only stage. Runs atlas-run in the background, polls
+# /rest/api/2/serverInfo until 200, SIGTERMs the JVM, validates that
+# the warmed paths exist + are non-empty. The `warmed` stage COPY-s
+# those paths from this stage's filesystem.
+FROM base AS warmer
+COPY scripts/warm.sh /tmp/warm.sh
+RUN bash /tmp/warm.sh && rm /tmp/warm.sh
+
+# === warmed ===================================================================
+# Runtime stage with the Maven cache + unpacked Jira webapp baked in.
+# Caller picks this via `docker build --target warmed`. Cold-boot
+# becomes ~1-2min instead of ~10-20min because Maven downloads + war
+# unpack + initial DB schema are pre-populated. -o (offline) keeps
+# Maven from reaching out at runtime since the cache is fully populated.
+FROM base AS warmed
+COPY --from=warmer /root/.m2 /root/.m2
+COPY --from=warmer /opt/jira-plugin/target /opt/jira-plugin/target
+# -DskipAllPrompts=true: AMPS hardcodes a call to the shut-down
+# Atlassian Marketplace v1 endpoint at startup. This flag makes the
+# resulting 404 non-fatal so the boot proceeds.
+# Caller MUST run with -it; atlas-run exits without a TTY.
+ENTRYPOINT ["atlas-run", "-DskipAllPrompts=true", "-o"]
+
+# === unwarmed (default target) ================================================
+# Default `docker build .` target. Boots cold every container start
+# (~10-20min depending on Jira major). Use `--target warmed` to opt
+# into the pre-baked variant when the upfront ~25min build cost is
+# acceptable.
+FROM base AS unwarmed
+# -DskipAllPrompts=true: same Marketplace v1 endpoint workaround as
+# above. Caller MUST run with -it; atlas-run exits without a TTY.
 ENTRYPOINT ["atlas-run", "-DskipAllPrompts=true"]

--- a/docker/jira-test-image/README.md
+++ b/docker/jira-test-image/README.md
@@ -19,16 +19,92 @@ docker run -dit -p 2990:2990 --name jira pycontribs/jira-test-image:8.17.1
 credentials: `admin/admin`. First responsive request is typically
 within ~3-5 minutes on a cold network.
 
-### Jira version
+### Targeting a different Jira version
 
-`JIRA_VERSION` is overridable across Jira 8.x patch versions:
+The Dockerfile is parameterised; every value that changes between Jira
+majors is exposed as a `--build-arg`. `scripts/render-pom.sh` substitutes
+the matching `@TOKEN@` placeholders in `plugin/pom.xml.template` into a
+real `plugin/pom.xml` during the build, so the same source tree builds
+Jira 8 through Jira 11.
+
+```bash
+docker build \
+  --build-arg JAVA_IMAGE=eclipse-temurin:21-jdk-jammy \
+  --build-arg AMPS_VERSION=9.11.2 \
+  --build-arg JIRA_VERSION=11.3.4 \
+  --build-arg SPRING_SCANNER_VERSION=6.0.0 \
+  --build-arg COMPILE_FLOOR=17 \
+  -t pycontribs/jira-test-image:11.3.4 docker/jira-test-image
+```
+
+Within a single major, `JIRA_VERSION` is also overridable at run-time
+via `docker run -e JIRA_VERSION=...`:
 
 ```bash
 docker run -dit -p 2990:2990 -e JIRA_VERSION=8.17.0 --name jira \
   pycontribs/jira-test-image:8.17.1
 ```
 
-Jira 9+ / 11+ are **not** supported here - the upstream addono pom.xml
-is anchored to the 8.x dependency graph and fails Maven resolution
-for newer majors. A future iteration will replace this wrapper with a
-fully self-hosted multi-stage image that supports newer Jiras.
+Defaults match the Jira version pycontribs server CI runs against
+(`jira_server_ci.yml`), so a bare `docker build docker/jira-test-image`
+produces the historical Jira 8.17.1 image.
+
+#### Known-good build-arg combinations
+
+Each row has been validated against a fresh `atlas-run` boot in the
+companion `docker-jira-software-standalone` fork. Pass these as
+`--build-arg` flags when building locally, or as workflow inputs in
+`ghcr-publish.yml`.
+
+| Jira version | `JAVA_IMAGE`                  | `AMPS_VERSION` | `SPRING_SCANNER_VERSION` | `TESTRUNNER_VERSION` | `COMPILE_FLOOR` |
+|--------------|-------------------------------|----------------|--------------------------|----------------------|-----------------|
+| 8.20.30      | `eclipse-temurin:8-jdk-jammy`  | `8.2.3`        | `2.1.17`                 | `2.0.16`             | `1.8`           |
+| 9.12.34      | `eclipse-temurin:11-jdk-jammy` | `9.1.2`        | `2.2.6`                  | `2.0.16`             | `11`            |
+| 10.3.19      | `eclipse-temurin:17-jdk-jammy` | `9.1.2`        | `2.2.6`                  | `2.0.16`             | `17`            |
+| 11.3.4       | `eclipse-temurin:21-jdk-jammy` | `9.11.2`       | `6.0.0`                  | `2.0.16`             | `17`            |
+
+Notes on the `AMPS_VERSION` line:
+
+- `AMPS_VERSION` feeds two artefacts that share a release train but
+  can drift: the SDK tarball (`atlassian-plugin-sdk`, consumed by
+  `scripts/install-sdk.sh`) and the build extension
+  (`com.atlassian.maven.plugins:jira-maven-plugin`, consumed by
+  `plugin/pom.xml.template`). Both must resolve at the chosen
+  version. Verify against
+  [the SDK metadata](https://packages.atlassian.com/maven-external/com/atlassian/amps/atlassian-plugin-sdk/maven-metadata.xml)
+  and
+  [the plugin metadata](https://packages.atlassian.com/maven-external/com/atlassian/maven/plugins/jira-maven-plugin/maven-metadata.xml).
+- For Jira 8 the SDK ships through `8.2.10` but the
+  `jira-maven-plugin` 8.2.x line tops out at `8.2.3`, so `8.2.3` is
+  the highest value that resolves on both paths.
+- For Jira 9 the older 8.2.x SDK ships an `atlas-run` that calls
+  `jira-maven-plugin:8.2.3` internally, which predates Jira 9 and
+  fails to launch a 9.x instance. The 9.1.x line is the lowest AMPS
+  that handles both Jira 9 and 10 cleanly (Spring 5 / `javax.*`
+  baseline carries through; Maven 3.9 in SDK 9.1.x runs on Java 11+).
+- `SPRING_SCANNER_VERSION` is Jakarta-locked to Jira's Spring major:
+  2.1.x for Jira 8, 2.2.x for Jira 9-10, 6.x for Jira 11. Crossing
+  the streams (2.x against `jakarta.*`, 6.x against `javax.*`)
+  silently no-ops at scan time.
+
+### Warmed variant
+
+The Dockerfile is multi-stage. The default `unwarmed` target cold-boots
+on every container start (~10–20 min depending on Jira major). The
+`warmed` target bakes the result of one full `atlas-run` boot into the
+image, so subsequent containers reach `/serverInfo` in ~1–2 min, at the
+cost of ~25 min of build time:
+
+```bash
+docker build --target warmed -t pycontribs/jira-test-image:8.17.1-warm \
+  docker/jira-test-image
+```
+
+### Publishing
+
+`.github/workflows/ghcr-publish.yml` is a `workflow_dispatch` job that
+exposes every build-arg as an input and publishes both the unwarmed
+and warmed variants on every run. The optional `tag_latest` flag also
+pushes `:<major>-latest` and `:<major>-warm-latest` floating tags.
+Images are published under
+`ghcr.io/<repository_owner>/jira-test-image:<jira_version>[-warm]`.

--- a/docker/jira-test-image/plugin/.gitignore
+++ b/docker/jira-test-image/plugin/.gitignore
@@ -1,0 +1,6 @@
+target/
+
+# Rendered from pom.xml.template by scripts/render-pom.sh during
+# `docker build`. Treat the template as source of truth; the rendered
+# pom is a build artefact.
+pom.xml

--- a/docker/jira-test-image/plugin/pom.xml.template
+++ b/docker/jira-test-image/plugin/pom.xml.template
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Source-of-truth pom rendered into plugin/pom.xml at docker build time
+  by scripts/render-pom.sh. Tokens of the form @ARG_NAME@ are filled
+  from the matching Dockerfile ARG; mirror any change here in the ARG
+  block at the top of Dockerfile.
+
+  The single Jira-version-aware property left as a Maven expression is
+  ${env.JIRA_VERSION} so the same image can boot any patch within the
+  built major via `docker run -e JIRA_VERSION=...`.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>mygroup</groupId>
+    <artifactId>myartifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <organization>
+        <name>Example Company</name>
+        <url>http://www.example.com/</url>
+    </organization>
+
+    <name>myartifact</name>
+    <description>This is the mygroup:myartifact plugin for Atlassian JIRA.</description>
+    <packaging>atlassian-plugin</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.atlassian.jira</groupId>
+            <artifactId>jira-api</artifactId>
+            <version>${jira.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Add dependency on jira-core if you want access to JIRA implementation classes as well as the sanctioned API. -->
+        <!-- This is not normally recommended, but may be required eg when migrating a plugin originally developed against JIRA 4.x -->
+        <!--
+        <dependency>
+            <groupId>com.atlassian.jira</groupId>
+            <artifactId>jira-core</artifactId>
+            <version>${jira.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- atlassian-spring-scanner is a Jira platform artefact and
+             is on jira-maven-plugin's banned-dependencies list when
+             bundled (compile/runtime scope). Mark both as `provided`
+             so the annotation processor and runtime are available at
+             build time but not packaged into the plugin jar. -->
+        <dependency>
+            <groupId>com.atlassian.plugin</groupId>
+            <artifactId>atlassian-spring-scanner-annotation</artifactId>
+            <version>${atlassian.spring.scanner.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.atlassian.plugin</groupId>
+            <artifactId>atlassian-spring-scanner-runtime</artifactId>
+            <version>${atlassian.spring.scanner.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- WIRED TEST RUNNER DEPENDENCIES -->
+        <dependency>
+            <groupId>com.atlassian.plugins</groupId>
+            <artifactId>atlassian-plugins-osgi-testrunner</artifactId>
+            <version>${plugin.testrunner.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>jsr311-api</artifactId>
+            <version>1.1.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- gson is supplied by the Jira runtime (atlassian-bundled-libs);
+             omit a scope here and the default `compile` triggers the
+             banned-dependencies enforcer. `provided` keeps it on the
+             compile classpath without packaging it into the plugin jar. -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.9</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Uncomment to use TestKit in your project. Details at https://bitbucket.org/atlassian/jira-testkit -->
+        <!-- You can read more about TestKit at https://developer.atlassian.com/display/JIRADEV/Plugin+Tutorial+-+Smarter+integration+testing+with+TestKit -->
+        <!--
+        <dependency>
+            <groupId>com.atlassian.jira.tests</groupId>
+            <artifactId>jira-testkit-client</artifactId>
+            <version>${testkit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        -->
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.atlassian.maven.plugins</groupId>
+                <artifactId>jira-maven-plugin</artifactId>
+                <version>${amps.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <applications>
+                        <application>
+                            <applicationKey>jira-software</applicationKey>
+                            <version>${jira.version}</version>
+                        </application>
+                        <!-- Example of how to enable JSD -->
+                        <!--
+                        <application>
+                            <applicationKey>jira-servicedesk</applicationKey>
+                            <version>${jira.servicedesk.application.version}</version>
+                        </application>
+                        -->
+                    </applications>
+                    <productVersion>${jira.version}</productVersion>
+                    <productDataVersion>${jira.version}</productDataVersion>
+                    <!-- Uncomment to install TestKit backdoor in JIRA. -->
+                    <!--
+                    <pluginArtifacts>
+                        <pluginArtifact>
+                            <groupId>com.atlassian.jira.tests</groupId>
+                            <artifactId>jira-testkit-plugin</artifactId>
+                            <version>${testkit.version}</version>
+                        </pluginArtifact>
+                    </pluginArtifacts>
+                    -->
+                    <enableQuickReload>true</enableQuickReload>
+
+                    <!-- See here for an explanation of default instructions: -->
+                    <!-- https://developer.atlassian.com/docs/advanced-topics/configuration-of-instructions-in-atlassian-plugins -->
+                    <instructions>
+                        <Atlassian-Plugin-Key>${atlassian.plugin.key}</Atlassian-Plugin-Key>
+
+                        <!-- Add package to export here -->
+                        <Export-Package>
+                            mypackage.api,
+                        </Export-Package>
+
+                        <!-- Add package import here -->
+                        <Import-Package>
+                            org.springframework.osgi.*;resolution:="optional",
+                            org.eclipse.gemini.blueprint.*;resolution:="optional",
+                            *
+                        </Import-Package>
+
+                        <!-- Ensure plugin is spring powered -->
+                        <Spring-Context>*</Spring-Context>
+                    </instructions>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.atlassian.plugin</groupId>
+                <artifactId>atlassian-spring-scanner-maven-plugin</artifactId>
+                <version>${atlassian.spring.scanner.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>atlassian-spring-scanner</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scannedDependencies>
+                        <dependency>
+                            <groupId>com.atlassian.plugin</groupId>
+                            <artifactId>atlassian-spring-scanner-external-jar</artifactId>
+                        </dependency>
+                    </scannedDependencies>
+                    <verbose>false</verbose>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <jira.version>${env.JIRA_VERSION}</jira.version>
+        <amps.version>@AMPS_VERSION@</amps.version>
+        <plugin.testrunner.version>@TESTRUNNER_VERSION@</plugin.testrunner.version>
+        <atlassian.spring.scanner.version>@SPRING_SCANNER_VERSION@</atlassian.spring.scanner.version>
+        <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
+        <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
+        <!-- TestKit version 6.x for JIRA 6.x -->
+        <testkit.version>6.3.11</testkit.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>@COMPILE_FLOOR@</maven.compiler.source>
+        <maven.compiler.target>@COMPILE_FLOOR@</maven.compiler.target>
+    </properties>
+
+</project>

--- a/docker/jira-test-image/plugin/src/main/resources/atlassian-plugin.xml
+++ b/docker/jira-test-image/plugin/src/main/resources/atlassian-plugin.xml
@@ -1,0 +1,9 @@
+<atlassian-plugin key="${atlassian.plugin.key}" name="${project.name}" plugins-version="2">
+    <plugin-info>
+        <description>Stub plugin for the pycontribs/jira test image. Ships no
+            functionality - exists only so atlas-run has an artifactId to
+            launch Jira against.</description>
+        <version>${project.version}</version>
+        <vendor name="${project.organization.name}" url="${project.organization.url}" />
+    </plugin-info>
+</atlassian-plugin>

--- a/docker/jira-test-image/scripts/install-sdk.sh
+++ b/docker/jira-test-image/scripts/install-sdk.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Install the Atlassian Plugin SDK from the maven-external tarball.
+# Apt path was retired Feb 2018, so curl-extract is the only supported
+# install pattern. Tarball URL pattern is stable across AMPS 9.x.
+#
+# Artifact coordinates: groupId=com.atlassian.amps,
+# artifactId=atlassian-plugin-sdk. Verify a chosen version is published
+# at:
+#   https://packages.atlassian.com/maven-external/com/atlassian/amps/atlassian-plugin-sdk/maven-metadata.xml
+#
+# Args:
+#   $1  AMPS version (e.g. 9.11.2)
+set -euo pipefail
+
+AMPS_VERSION="${1:?AMPS version required}"
+
+apt-get update
+apt-get install -y --no-install-recommends ca-certificates curl
+rm -rf /var/lib/apt/lists/*
+
+mkdir -p /opt/atlassian-plugin-sdk
+
+curl -fsSL \
+    "https://packages.atlassian.com/maven-external/com/atlassian/amps/atlassian-plugin-sdk/${AMPS_VERSION}/atlassian-plugin-sdk-${AMPS_VERSION}.tar.gz" \
+  | tar -xz -C /opt/atlassian-plugin-sdk --strip-components=1
+
+chmod -R a+rx /opt/atlassian-plugin-sdk/bin

--- a/docker/jira-test-image/scripts/render-pom.sh
+++ b/docker/jira-test-image/scripts/render-pom.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Substitute the @PLACEHOLDER@ tokens in plugin/pom.xml.template with
+# build-arg values and emit plugin/pom.xml. Invoked by the Dockerfile
+# during the base stage so a single source-of-truth template can serve
+# every Jira major - the surrounding Dockerfile ARG block names every
+# version pin that must change between majors.
+#
+# Args (positional, all required):
+#   $1  AMPS version            (com.atlassian.maven.plugins:jira-maven-plugin)
+#   $2  spring-scanner version  (atlassian-spring-scanner; must match
+#                                Jira's Spring/Jakarta major)
+#   $3  testrunner version      (atlassian-plugins-osgi-testrunner)
+#   $4  compile floor           (Java source/target; matches runtime JDK)
+#   $5  template path           (default: plugin/pom.xml.template)
+#   $6  output path             (default: plugin/pom.xml)
+#
+# Adding a new placeholder is two edits: a new `-e` to the sed call,
+# and a new ARG block in the Dockerfile that surfaces the value.
+# A new placeholder NOT wired into the sed call will trip the drift
+# guard below, since it survives untouched in the rendered pom.
+set -euo pipefail
+
+AMPS_VERSION="${1:?AMPS version required}"
+SPRING_SCANNER_VERSION="${2:?spring-scanner version required}"
+TESTRUNNER_VERSION="${3:?testrunner version required}"
+COMPILE_FLOOR="${4:?compile floor required}"
+TEMPLATE="${5:-plugin/pom.xml.template}"
+OUTPUT="${6:-plugin/pom.xml}"
+
+if [ ! -f "$TEMPLATE" ]; then
+    echo "render-pom: template not found at $TEMPLATE" >&2
+    exit 1
+fi
+
+sed \
+    -e "s|@AMPS_VERSION@|${AMPS_VERSION}|g" \
+    -e "s|@SPRING_SCANNER_VERSION@|${SPRING_SCANNER_VERSION}|g" \
+    -e "s|@TESTRUNNER_VERSION@|${TESTRUNNER_VERSION}|g" \
+    -e "s|@COMPILE_FLOOR@|${COMPILE_FLOOR}|g" \
+    "$TEMPLATE" > "$OUTPUT"
+
+# Drift guard: any `@TOKEN@` sitting inside an XML element (or as the
+# value of an attribute) survived sed and is therefore a placeholder
+# the substitution block above forgot. The XML-context anchors
+# (`>@...@<`, `="@...@"`) keep this from false-positive-ing on the
+# bare `@ARG_NAME@` prose example in the template's header comment.
+if grep -nE '(>@[A-Z_]+@<|="@[A-Z_]+@")' "$OUTPUT" >&2; then
+    echo "render-pom: unsubstituted placeholder(s) remain in $OUTPUT" >&2
+    exit 1
+fi

--- a/docker/jira-test-image/scripts/smoke.sh
+++ b/docker/jira-test-image/scripts/smoke.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Smoke-test a freshly-built jira-software-standalone image: start it,
+# poll until Jira responds (cold boot 10-20min), confirm /serverInfo
+# returns the expected version, dump container logs to artifacts/
+# regardless of outcome.
+#
+# Args:
+#   $1  Image tag (e.g. ghcr.io/adehad/jira-software-standalone:11.3.4)
+#   $2  Expected Jira version (asserted against /serverInfo JSON)
+#   $3  Artifacts directory
+set -euo pipefail
+
+IMAGE="${1:?image tag required}"
+EXPECTED_VERSION="${2:?expected version required}"
+ARTIFACTS_DIR="${3:?artifacts directory required}"
+NAME=jira-smoke
+READY_URL=http://localhost:2990/jira/secure/Dashboard.jspa
+INFO_URL=http://localhost:2990/jira/rest/api/2/serverInfo
+POLL_INTERVAL=10
+MAX_POLLS=180   # 30 min ceiling
+
+mkdir -p "$ARTIFACTS_DIR"
+
+cleanup() {
+    docker logs "$NAME" > "$ARTIFACTS_DIR/container.log" 2>&1 || true
+    docker rm -f "$NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Pre-flight: drop any stale container left by a hard-killed previous
+# run (Ctrl+C, kill -9). The cleanup trap handles graceful exits, but
+# only on signals it can catch.
+docker rm -f "$NAME" 2>/dev/null || true
+
+# Tee docker run's stderr+stdout to smoke-run.log so pre-container
+# failures (image pull errors, port collisions, name conflicts) are
+# captured in artifacts even when no container exists for `docker logs`
+# to read from.
+docker run -dit -p 2990:2990 --name "$NAME" "$IMAGE" \
+    2>&1 | tee "$ARTIFACTS_DIR/smoke-run.log"
+
+ready=0
+# GET (not HEAD): Jira 11 returns 405 Method Not Allowed on HEAD for
+# secure servlets like Dashboard.jspa. GET produces a 200 once the
+# webapp is up. Output is discarded via -o /dev/null to avoid streaming
+# the rendered HTML.
+for ((i = 1; i <= MAX_POLLS; i++)); do
+    if curl --output /dev/null --silent --fail "$READY_URL"; then
+        echo "Jira responsive after $((i * POLL_INTERVAL))s"
+        ready=1
+        break
+    fi
+    sleep "$POLL_INTERVAL"
+done
+
+if [ "$ready" != "1" ]; then
+    echo "Jira not responsive after $((MAX_POLLS * POLL_INTERVAL))s" >&2
+    exit 1
+fi
+
+RESP=$(curl --silent --show-error --fail -u admin:admin "$INFO_URL")
+echo "$RESP" | tee "$ARTIFACTS_DIR/server-info.json"
+echo "$RESP" | grep -F "\"version\":\"$EXPECTED_VERSION\"" \
+    || { echo "Version mismatch: expected $EXPECTED_VERSION" >&2; exit 1; }

--- a/docker/jira-test-image/scripts/warm.sh
+++ b/docker/jira-test-image/scripts/warm.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Build-time warmer. Boots atlas-run in the background, polls
+# /rest/api/2/serverInfo until 200, SIGTERMs the JVM, waits for
+# graceful shutdown, and validates the warmed paths exist + are
+# non-empty.
+#
+# The `warmed` runtime stage COPY-s these paths from this stage:
+#   /root/.m2/repository    - Maven cache (Jira deps, plugins, etc.)
+#   /opt/jira-plugin/target - atlas-run unpacks Jira's webapp + the
+#                             local plugin jar + initial HSQLDB here
+#
+# Failure modes that abort the build (rather than baking a half-warm
+# image):
+#   - atlas-run exits before /serverInfo becomes responsive
+#   - poll ceiling hit (cold boot exceeded MAX_POLLS * POLL_INTERVAL)
+#   - either warmed path missing or empty after shutdown
+set -euo pipefail
+
+LOG=/tmp/warm.log
+WORKDIR_TARGET=/opt/jira-plugin/target
+M2_REPO=/root/.m2/repository
+READY_URL=http://localhost:2990/jira/rest/api/2/serverInfo
+POLL_INTERVAL=10
+MAX_POLLS=180  # 30 min ceiling; cold boot of Jira 11 is ~10-20min
+
+# atlas-run hardcodes a call to the shut-down Atlassian Marketplace v1
+# endpoint at startup; -DskipAllPrompts=true makes that 404 non-fatal.
+#
+# stdin is redirected from /dev/zero (not /dev/null) because the Cargo
+# Maven plugin behind `atlas-run` reads stdin after "Type Ctrl-C to
+# shutdown gracefully" and treats EOF as Ctrl-C. Docker build has no
+# TTY, so /dev/null (or inherited closed stdin) returns EOF immediately
+# and Jira shuts down within ~1s of finishing startup -- before the
+# poll loop below can confirm /serverInfo. /dev/zero blocks the read
+# forever, keeping the JVM alive until we send SIGTERM ourselves.
+atlas-run -DskipAllPrompts=true < /dev/zero > "$LOG" 2>&1 &
+ATLAS_PID=$!
+echo "[warm] atlas-run pid=$ATLAS_PID, polling $READY_URL ..."
+
+ready=0
+for ((i = 1; i <= MAX_POLLS; i++)); do
+    if curl --output /dev/null --silent --fail -u admin:admin "$READY_URL"; then
+        echo "[warm] /serverInfo responsive after $((i * POLL_INTERVAL))s"
+        ready=1
+        break
+    fi
+    if ! kill -0 "$ATLAS_PID" 2>/dev/null; then
+        echo "[warm] FAIL: atlas-run exited early (pid $ATLAS_PID gone)" >&2
+        echo "[warm] last 200 lines of warm.log:" >&2
+        tail -200 "$LOG" >&2
+        exit 1
+    fi
+    sleep "$POLL_INTERVAL"
+done
+
+if [ "$ready" != "1" ]; then
+    echo "[warm] FAIL: /serverInfo never became responsive after $((MAX_POLLS * POLL_INTERVAL))s" >&2
+    tail -200 "$LOG" >&2
+    kill -TERM "$ATLAS_PID" 2>/dev/null || true
+    exit 1
+fi
+
+# SIGTERM the JVM. atlas-run forwards to mvn which forwards to Jetty;
+# Jetty graceful shutdown takes ~30s. Wait for the process tree to
+# drain so the warmed paths are not mid-write.
+echo "[warm] shutting down atlas-run gracefully ..."
+kill -TERM "$ATLAS_PID"
+wait "$ATLAS_PID" 2>/dev/null || true
+
+# Validate the paths the warmed runtime stage will COPY. If atlas-run's
+# unpack location ever changes (e.g. AMPS major bump moves the webapp
+# from target/ to elsewhere), this loop fails fast so we do not bake
+# an image where the cache lives but the webapp does not.
+for path in "$M2_REPO" "$WORKDIR_TARGET"; do
+    if [ ! -d "$path" ]; then
+        echo "[warm] FAIL: expected warmed path $path does not exist" >&2
+        exit 1
+    fi
+    if [ -z "$(ls -A "$path" 2>/dev/null)" ]; then
+        echo "[warm] FAIL: expected warmed path $path is empty" >&2
+        exit 1
+    fi
+    size=$(du -sb "$path" 2>/dev/null | awk '{print $1}')
+    echo "[warm] OK: $path size=${size} bytes"
+done
+
+echo "[warm] done"


### PR DESCRIPTION
This proof of concept PR shows the regressions on various different versions of the self hosted Jira, we can therefore use this to test multi-version compatible changes

FYI @studioj 