### PR TITLE
Use explicit filepath for ansible/team-devtools

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,2 +1,2 @@
 # see https://github.com/ansible/team-devtools
-_extends: ansible/team-devtools
+_extends: ansible/team-devtools:.github/release-drafter.yml


### PR DESCRIPTION
Repo-only `_extends: ansible/team-devtools`
breaks on release-drafter v7.0.0–v7.1.1
(fixed in v7.2.0 by PR #1577,
but ansible/team-devtools still pins the broken SHA).

https://github.com/ansible/team-devtools/pull/458