### PR TITLE
fix: preserve SSL verification kwargs in handle_401

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -374,13 +374,15 @@ class JiraCookieAuth(AuthBase):
             LOG.info("Trying to refresh the cookie auth session...")
             self._increment_401_retry_counter()
             self.init_session()
-            response = self.process_original_request(response.request.copy())
+            response = self.process_original_request(response.request.copy(), **kwargs)
         self._reset_401_retry_counter()
         return response
 
-    def process_original_request(self, original_request: requests.PreparedRequest):
+    def process_original_request(
+        self, original_request: requests.PreparedRequest, **kwargs
+    ):
         self.update_cookies(original_request)
-        return self.send_request(original_request)
+        return self.send_request(original_request, **kwargs)
 
     def update_cookies(self, original_request: requests.PreparedRequest):
         # Cookie header needs first to be deleted for the header to be updated using the
@@ -389,8 +391,8 @@ class JiraCookieAuth(AuthBase):
             del original_request.headers["Cookie"]
         original_request.prepare_cookies(self.cookies)
 
-    def send_request(self, request: requests.PreparedRequest):
-        return self._session.send(request)
+    def send_request(self, request: requests.PreparedRequest, **kwargs):
+        return self._session.send(request, **kwargs)
 
 
 class TokenAuth(AuthBase):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -413,3 +413,101 @@ def test_experimental_non_200_not_404_405(
 
     assert ex.value.status_code == status_code
     assert isinstance(ex.value, JIRAError)
+
+
+def test_handle_401_preserves_send_kwargs():
+    """Test that handle_401 passes kwargs to process_original_request"""
+
+    auth = jira.client.JiraCookieAuth(
+        session=mock.Mock(),
+        session_api_url="https://mock",
+        auth=("user", "pass"),
+    )
+
+    prepared_request = requests.Request(
+        "GET",
+        "https://mocked.jira.invalid/rest/api/2/myself",
+    ).prepare()
+
+    response_401 = mock.Mock()
+    response_401.status_code = 401
+    response_401.request = prepared_request
+    response_401.text = "Unauthorized"
+
+    retried_response = mock.Mock()
+    retried_response.status_code = 200
+
+    auth.process_original_request = mock.Mock(return_value=retried_response)
+    auth.init_session = mock.Mock()
+
+    kwargs = {
+        "verify": "/usr/local/share/ca-certificates/root.crt",
+        "stream": True,
+        "cert": "/path/client.pem",
+    }
+
+    result = auth.handle_401(response_401, **kwargs)
+
+    auth.process_original_request.assert_called_once_with(
+        mock.ANY,
+        **kwargs,
+    )
+
+    assert result == retried_response
+
+
+def test_process_original_request_preserves_kwargs():
+    """Test that process_original_request forwards kwargs to send_request"""
+    auth = jira.client.JiraCookieAuth(
+        session=mock.Mock(),
+        session_api_url="https://mock",
+        auth=("user", "pass"),
+    )
+
+    request = requests.Request(
+        "GET",
+        "https://mocked.jira.invalid/rest/api/2/myself",
+    ).prepare()
+
+    auth.update_cookies = mock.Mock()
+    auth.send_request = mock.Mock(return_value=mock.Mock(status_code=200))
+
+    kwargs = {
+        "verify": "/usr/local/share/ca-certificates/root.crt",
+        "stream": True,
+        "cert": "/path/client.pem",
+    }
+
+    auth.process_original_request(request, **kwargs)
+
+    auth.send_request.assert_called_once_with(
+        request,
+        **kwargs,
+    )
+
+
+def test_send_request_preserves_kwargs_to_session_send():
+    """Test that send_request forwards kwargs to session.send"""
+    session = mock.Mock()
+    session.send.return_value = mock.Mock(status_code=200)
+
+    auth = jira.client.JiraCookieAuth(
+        session=session,
+        session_api_url="https://mock",
+        auth=("user", "pass"),
+    )
+
+    request = requests.Request(
+        "GET",
+        "https://mocked.jira.invalid/rest/api/2/myself",
+    ).prepare()
+
+    kwargs = {
+        "verify": "/usr/local/share/ca-certificates/root.crt",
+        "stream": True,
+        "cert": "/path/client.pem",
+    }
+
+    auth.send_request(request, **kwargs)
+
+    session.send.assert_called_once_with(request, **kwargs)


### PR DESCRIPTION
Fixes #2432

Good afternoon!

This PR preserves request kwargs when retrying requests in `handle_401`.

Previously, SSL settings derived from requests environment variables such as `REQUESTS_CA_BUNDLE` and `CURL_CA_BUNDLE` were lost during request replay, causing SSL verification failures for custom CAs.

The fix forwards the original `send()` kwargs through the retry chain and adds regression tests covering the behavior.