### PR TITLE
fix(client): support bytes in add_attachment() (#1735)

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -25,7 +25,7 @@ import warnings
 from collections import OrderedDict
 from collections.abc import Iterable, Iterator
 from functools import cache, wraps
-from io import BufferedReader
+from io import BufferedReader, BytesIO
 from numbers import Number
 from typing import (
     Any,
@@ -1119,7 +1119,7 @@ class JIRA:
     def add_attachment(
         self,
         issue: str | int,
-        attachment: str | BufferedReader,
+        attachment: str | bytes | BufferedReader,
         filename: str | None = None,
     ) -> Attachment:
         """Attach an attachment to an issue and returns a Resource for it.
@@ -1139,6 +1139,9 @@ class JIRA:
         close_attachment = False
         if isinstance(attachment, str):
             attachment_io = open(attachment, "rb")  # type: ignore
+            close_attachment = True
+        elif isinstance(attachment, bytes):
+            attachment_io = BytesIO(attachment)
             close_attachment = True
         else:
             attachment_io = attachment

--- a/jira/client.py
+++ b/jira/client.py
@@ -1137,8 +1137,9 @@ class JIRA:
             Attachment
         """
         close_attachment = False
+        attachment_io: BytesIO | BufferedReader
         if isinstance(attachment, str):
-            attachment_io = open(attachment, "rb")  # type: ignore
+            attachment_io = open(attachment, "rb")  # type: ignore[assignment]
             close_attachment = True
         elif isinstance(attachment, bytes):
             attachment_io = BytesIO(attachment)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -413,3 +413,31 @@ def test_experimental_non_200_not_404_405(
 
     assert ex.value.status_code == status_code
     assert isinstance(ex.value, JIRAError)
+
+
+class _BareAttachmentClient(jira.client.JIRA):
+    """A client without __init__ wiring, enough for add_attachment unit tests."""
+
+    def __init__(self, session):
+        self.log = logging.getLogger("test_add_attachment")
+        self._options = dict(jira.client.JIRA.DEFAULT_OPTIONS)
+        self._options["server"] = "https://mocked.jira.invalid"
+        self._session = session
+
+
+def test_add_attachment_accepts_bytes():
+    content = b"example content"
+    mock_session = mock.Mock()
+    mock_session.post.return_value.status_code = 200
+    mock_session.post.return_value.json.return_value = [
+        {"id": "10001", "filename": "example.txt", "size": len(content)}
+    ]
+    client = _BareAttachmentClient(mock_session)
+
+    attachment = client.add_attachment("QQ-1", content, "example.txt")
+
+    assert attachment.size == len(content)
+    posted_kwargs = mock_session.post.call_args.kwargs
+    body: bytes = posted_kwargs["data"].read()
+    assert content in body
+    assert posted_kwargs["headers"]["X-Atlassian-Token"] == "no-check"


### PR DESCRIPTION
## Problem

Fixes #1735.

Passing a `bytes` object to `add_attachment()` raises `AttributeError` since v3.3.0:

```python
jira.add_attachment(issue='QQ-1', attachment=b'example content', filename='example.txt')
# AttributeError: 'bytes' object has no attribute 'seek'
```

## Root Cause

The regression was introduced in #1366. Before that PR the attachment was passed directly to `requests`. After #1366, the upload goes through a `MultipartEncoder`, and `generate_multipartencoded_request_args()` calls `attachment_io.seek(0)` to reset the stream position before encoding.

When `attachment` is `bytes`, the `else` branch sets `attachment_io = attachment` (the `bytes` object itself), and `bytes` has no `.seek()` method.

## Fix

Add an explicit `bytes` branch that wraps the content in `io.BytesIO`:

```diff
-from io import BufferedReader
+from io import BufferedReader, BytesIO

 def add_attachment(self, issue: str | int,
-                   attachment: str | BufferedReader,
+                   attachment: str | bytes | BufferedReader,
                    filename: str | None = None) -> Attachment:
     close_attachment = False
     if isinstance(attachment, str):
         attachment_io = open(attachment, 'rb')
         close_attachment = True
+    elif isinstance(attachment, bytes):
+        attachment_io = BytesIO(attachment)
+        close_attachment = True
     else:
         attachment_io = attachment
         ...
```

`BytesIO` is seekable, so `attachment_io.seek(0)` works. `close_attachment = True` ensures the `BytesIO` is closed in the `finally` block (we created it, so we're responsible for it).

## Notes

- When passing `bytes`, a `filename` argument is required: `BytesIO` has no `.name` attribute, so the auto-name fallback (`os.path.basename(attachment_io.name)`) is skipped. This was already the case for any non-`BufferedReader` file-like object.
- `BytesIO` is accepted by `MultipartEncoder` for the same reason `BufferedReader` is: both are file-like objects implementing `read()` and `seek()`.

## Verification

```python
from jira import JIRA

jira = JIRA(basic_auth=('admin', 'admin'))
att = jira.add_attachment(
    issue='QQ-1',
    attachment=b'example content',
    filename='example.txt',
)
print(att)  # Attachment: example.txt — no more AttributeError
```
